### PR TITLE
fix: address Team section issues (#147)

### DIFF
--- a/src/components/home-page/TheFreeForCharityTeam/index.tsx
+++ b/src/components/home-page/TheFreeForCharityTeam/index.tsx
@@ -2,18 +2,18 @@ import React from "react";
 import TeamMemberCard from "@/components/ui/TeamMemberCard";
 import { team } from "@/data/team";
 
-const index = () => {
+const TheFreeForCharityTeam = () => {
   return (
-    <div className="py-[50px]">
-      <h1
-        className="font-[400] text-[40px] lg:text-[48px]  tracking-[0] text-center mx-auto mb-[50px]"
+    <section id="team" className="py-[50px]">
+      <h2
+        className="font-[400] text-[40px] lg:text-[48px] tracking-[0] text-center mx-auto mb-[50px]"
         id="faustina-font"
       >
         The Free For Charity Team
-      </h1>
+      </h2>
 
       <div className="w-[90%] mx-auto py-[40px]">
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3  items-stretch justify-center mb-[50px] gap-[30px]">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 items-stretch justify-center mb-[50px] gap-[30px]">
           {team.slice(0, 3).map((member) => (
             <TeamMemberCard
               key={member.name}
@@ -36,8 +36,8 @@ const index = () => {
           ))}
         </div>
       </div>
-    </div>
+    </section>
   );
 };
 
-export default index;
+export default TheFreeForCharityTeam;

--- a/src/components/ui/TeamMemberCard.tsx
+++ b/src/components/ui/TeamMemberCard.tsx
@@ -17,52 +17,43 @@ export default function TeamMemberCard({
   linkedinUrl,
 }: TeamMemberCardProps) {
   return (
-    <>
-      <div className="flex flex-col items-center max-w-[388px] w-full mx-auto">
-        {/* Circular Image Container */}
-        <div className="relative w-[300px] h-[300px] mb-6 rounded-full overflow-hidden ring-4 ring-white shadow-xl">
-          <Image
-            src={imageUrl}
-            alt={name}
-            fill
-            className="object-cover"
-            sizes="(max-width: 768px) 100vw, 192px"
-            priority
-          />
-        </div>
-
-        {/* Text Content */}
-        <div className="text-center space-y-2">
-          <h3 className="text-[32px] font-[400]" id="lato-font">
-            {name}
-          </h3>
-          <p className="text-[25px] font-[400]" id="lato-font">
-            {title}
-          </p>
-        </div>
-
-        {/* LinkedIn Button */}
-        <a
-          href={linkedinUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="mt-6"
-        >
-          <Image
-            src="/Svgs/linkedin-icon.svg"
-            width={63}
-            height={63}
-            alt="linkedin icon"
-          ></Image>
-        </a>
+    <div className="flex flex-col items-center max-w-[388px] w-full mx-auto">
+      {/* Circular Image Container */}
+      <div className="relative w-[300px] h-[300px] mb-6 rounded-full overflow-hidden ring-4 ring-white shadow-xl">
+        <Image
+          src={imageUrl}
+          alt={`${name} — ${title}`}
+          fill
+          className="object-cover"
+          sizes="300px"
+        />
       </div>
 
-      {/* Optional: Add global styles if needed */}
-      <style jsx global>{`
-        .ring-4 {
-          box-shadow: 0 0 0 4px white;
-        }
-      `}</style>
-    </>
+      {/* Text Content */}
+      <div className="text-center space-y-2">
+        <h3 className="text-[32px] font-[400]" id="lato-font">
+          {name}
+        </h3>
+        <p className="text-[25px] font-[400]" id="lato-font">
+          {title}
+        </p>
+      </div>
+
+      {/* LinkedIn Button */}
+      <a
+        href={linkedinUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="mt-6"
+        aria-label={`${name} on LinkedIn`}
+      >
+        <Image
+          src="/Svgs/linkedin-icon.svg"
+          width={63}
+          height={63}
+          alt="LinkedIn"
+        />
+      </a>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- Converted 5 team member images from PNG to WebP (~90% size reduction: 1.09MB → 97KB total)
- Added `id="team"` anchor to Team section for deep-linking
- Renamed component export to PascalCase (`TheFreeForCharityTeam`)
- Changed section heading from `h1` to `h2` for proper semantic HTML
- Removed inline `<style jsx global>` hack from TeamMemberCard
- Added descriptive alt text (`{name} — {title}`) and `aria-label` on LinkedIn links
- Removed `priority` flag from below-fold team images
- Fixed `sizes` attribute to match actual 300px render size
- Fixed pre-existing import casing breakage (layout.tsx, home-old, `UI/` → `ui/`)

## Test plan
- [ ] Verify team member images render correctly as WebP
- [ ] Verify `#team` anchor scrolls to team section
- [ ] Verify LinkedIn links open in new tabs with correct profiles
- [ ] Run `npm run build` — passes with 0 errors
- [ ] Check accessibility: alt text, aria-labels present

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)