### PR TITLE
feat: add SEO metadata to all pages and expand sitemap (#150)

### DIFF
--- a/src/app/501c3/page.tsx
+++ b/src/app/501c3/page.tsx
@@ -1,5 +1,13 @@
+import type { Metadata } from "next";
 import HeroSection from "@/components/ui/HeroSection";
 import HelpForCharitiesandNonprofit from "@/components/501c3-components/Help-For-Charities-and-Nonprofit";
+
+export const metadata: Metadata = {
+  title: "501(c)(3) Onboarding Guide",
+  description:
+    "Onboarding guide for verified 501(c)(3) charities. Get instant access to free domains, hosting, email, and technology tools from Free For Charity.",
+  alternates: { canonical: "/501c3" },
+};
 import ReadyToGetStartedAndFaq from "@/components/501c3-components/Ready-to-get-started-and-faqs";
 import CallSection from "@/components/help-for-charities-components/call-section";
 

--- a/src/app/about-us/page.tsx
+++ b/src/app/about-us/page.tsx
@@ -1,8 +1,16 @@
+import type { Metadata } from "next";
 import React from "react";
 import HeroSection from "@/components/ui/HeroSection";
 import Content from "@/components/about-us-components/content";
 import CardSection from "@/components/about-us-components/Card-section";
 import ParaText from "@/components/about-us-components/ParaText";
+
+export const metadata: Metadata = {
+  title: "About Us",
+  description:
+    "Learn about Free For Charity's mission to reduce costs and increase revenues for nonprofits by connecting students, professionals, and businesses with charities in need.",
+  alternates: { canonical: "/about-us" },
+};
 import CallToAction from "@/components/about-us-components/CallToAction";
 
 const index = () => {

--- a/src/app/charity-validation-guide-ensuring-mutual-benefit-through-comprehensive-validation-processes/page.tsx
+++ b/src/app/charity-validation-guide-ensuring-mutual-benefit-through-comprehensive-validation-processes/page.tsx
@@ -1,5 +1,13 @@
+import type { Metadata } from "next";
 import React from "react";
 import Hero from "@/components/charity-validation-guide-ensuring-mutual-benefit-through-comprehensive-validation-processes-components/Hero";
+
+export const metadata: Metadata = {
+  title: "Charity Validation Guide",
+  description:
+    "Comprehensive guide for validating charitable entities, ensuring credibility and mutual benefit through GuideStar verification and due diligence processes.",
+  alternates: { canonical: "/charity-validation-guide-ensuring-mutual-benefit-through-comprehensive-validation-processes" },
+};
 
 const index = () => {
   return (

--- a/src/app/contact-us/page.tsx
+++ b/src/app/contact-us/page.tsx
@@ -1,6 +1,14 @@
+import type { Metadata } from "next";
 import React from "react";
 import HeroSection from "@/components/ui/HeroSection";
 import ContactSection from "@/components/contact-us-components/Contact-Us";
+
+export const metadata: Metadata = {
+  title: "Contact Us",
+  description:
+    "Get in touch with Free For Charity. We connect students, professionals, and businesses with charities in need of support.",
+  alternates: { canonical: "/contact-us" },
+};
 
 const index = () => {
   return (

--- a/src/app/domains/page.tsx
+++ b/src/app/domains/page.tsx
@@ -1,8 +1,16 @@
+import type { Metadata } from "next";
 import React from "react";
 import Hero from "@/components/domains/Hero";
 import DearProspective from "@/components/domains/Dear-Prospective";
 import OrderYourDomain from "@/components/domains/Order-Your-Domain";
 import CardsSection from "@/components/domains/Cards-Section";
+
+export const metadata: Metadata = {
+  title: "Free Domains for Nonprofits",
+  description:
+    "Free For Charity provides free domain registration, DNS management, and email setup for verified 501(c)(3) nonprofit organizations.",
+  alternates: { canonical: "/domains" },
+};
 import VerifyYourDomain from "@/components/domains/Verify-Your-Domain";
 import Seperater from "@/components/domains/Seperater";
 import SetupEmailHosting from "@/components/domains/Setup-Email-Hosting";

--- a/src/app/donate/page.tsx
+++ b/src/app/donate/page.tsx
@@ -1,8 +1,16 @@
+import type { Metadata } from "next";
 import React from "react";
 import HeroSection from "@/components/ui/HeroSection";
 import Measurableimpact from "@/components/donate-components/measurable-impact";
 import FreeForCharityDonationOptions from "@/components/donate-components/Free-for-Charity-Donation-Options";
 import GeneralDonation from "@/components/donate-components/General-donation";
+
+export const metadata: Metadata = {
+  title: "Donate",
+  description:
+    "Support Free For Charity's mission by donating. Your tax-deductible contribution helps provide free domains, hosting, and technology services to nonprofits.",
+  alternates: { canonical: "/donate" },
+};
 
 const index = () => {
   return (

--- a/src/app/donation-policy/page.tsx
+++ b/src/app/donation-policy/page.tsx
@@ -1,3 +1,12 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Donation Policy",
+  description:
+    "Free For Charity donation policy outlining guidelines for acceptance, management, and acknowledgment of tax-deductible donations.",
+  alternates: { canonical: "/donation-policy" },
+};
+
 export default function DonationPolicy() {
   return (
     <main className="ffc-container py-16">

--- a/src/app/ffc-volunteer-proving-ground-core-competencies/page.tsx
+++ b/src/app/ffc-volunteer-proving-ground-core-competencies/page.tsx
@@ -1,5 +1,13 @@
+import type { Metadata } from "next";
 import React from "react";
 import Header from "@/components/ffc-volunteer-proving-ground-core-competencies/Header";
+
+export const metadata: Metadata = {
+  title: "Volunteer Proving Ground: Core Competencies",
+  description:
+    "Mandatory first step for FFC volunteers. Learn foundational tools for security and effective collaboration in nonprofit technology services.",
+  alternates: { canonical: "/ffc-volunteer-proving-ground-core-competencies" },
+};
 import ContentSection from "@/components/ffc-volunteer-proving-ground-core-competencies/ContentSection";
 import Modulessection from "@/components/ffc-volunteer-proving-ground-core-competencies/Modules-section";
 import Footer from "@/components/ffc-volunteer-proving-ground-core-competencies/Footer";

--- a/src/app/ffcadmin-free-for-charity-cpanel-backup-sop/layout.tsx
+++ b/src/app/ffcadmin-free-for-charity-cpanel-backup-sop/layout.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "cPanel Backup SOP",
+  description:
+    "Free For Charity internal standard operating procedure for cPanel backups.",
+  robots: { index: false, follow: false },
+};
+
+export default function CpanelBackupSopLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/src/app/ffcadmin/page.tsx
+++ b/src/app/ffcadmin/page.tsx
@@ -1,4 +1,11 @@
+import type { Metadata } from "next";
 import React from "react";
+
+export const metadata: Metadata = {
+  title: "FFC Admin",
+  description: "Free For Charity internal administration portal.",
+  robots: { index: false, follow: false },
+};
 
 const index = () => {
   return <div className="flex items-center justify-center min-h-screen text-[34px] w-full text-center">

--- a/src/app/free-charity-web-hosting/page.tsx
+++ b/src/app/free-charity-web-hosting/page.tsx
@@ -1,5 +1,13 @@
+import type { Metadata } from "next";
 import React from "react";
 import Hero from "@/components/free-charity-web-hosting/Hero";
+
+export const metadata: Metadata = {
+  title: "Free Nonprofit Web Hosting",
+  description:
+    "Free WordPress hosting, domain registration, and email setup for nonprofit organizations. Powered by Free For Charity volunteers.",
+  alternates: { canonical: "/free-charity-web-hosting" },
+};
 import Hosting from "@/components/free-charity-web-hosting/hosting";
 import AboutFFCHosting from "@/components/free-charity-web-hosting/About-FFC-Hosting";
 import ThreeCards from "@/components/free-charity-web-hosting/ThreeCards";

--- a/src/app/free-for-charity-donation-policy/page.tsx
+++ b/src/app/free-for-charity-donation-policy/page.tsx
@@ -1,4 +1,12 @@
+import type { Metadata } from "next";
 import React from "react";
+
+export const metadata: Metadata = {
+  title: "Donation Policy",
+  description:
+    "Free For Charity donation policy outlining guidelines for the acceptance, management, and acknowledgment of charitable donations.",
+  alternates: { canonical: "/free-for-charity-donation-policy" },
+};
 
 const index = () => {
   return (

--- a/src/app/free-for-charity-endowment-fund/page.tsx
+++ b/src/app/free-for-charity-endowment-fund/page.tsx
@@ -1,5 +1,13 @@
+import type { Metadata } from "next";
 import React from "react";
 import Hero from "@/components/free-for-charity-endowment-fund-components/Hero";
+
+export const metadata: Metadata = {
+  title: "Endowment Fund",
+  description:
+    "Support the Free For Charity Endowment Fund to sustain free domain and hosting services for nonprofits long-term.",
+  alternates: { canonical: "/free-for-charity-endowment-fund" },
+};
 import TextSection from "@/components/free-for-charity-endowment-fund-components/Text-Section";
 import OurMission from "@/components/free-for-charity-endowment-fund-components/Our-Mission";
 import EndowmentFeatures from "@/components/free-for-charity-endowment-fund-components/Endowment-Features";

--- a/src/app/free-for-charity-ffc-service-delivery-stages/page.tsx
+++ b/src/app/free-for-charity-ffc-service-delivery-stages/page.tsx
@@ -1,5 +1,13 @@
+import type { Metadata } from "next";
 import React from "react";
 import Hero from "@/components/free-for-charity-ffc-service-delivery-stages-components/Hero";
+
+export const metadata: Metadata = {
+  title: "Service Delivery Stages",
+  description:
+    "Free For Charity service delivery process: charity validation stages, onboarding philosophy, and how we deliver free technology services to nonprofits.",
+  alternates: { canonical: "/free-for-charity-ffc-service-delivery-stages" },
+};
 
 const index = () => {
   return (

--- a/src/app/free-for-charity-ffc-web-developer-training-guide/page.tsx
+++ b/src/app/free-for-charity-ffc-web-developer-training-guide/page.tsx
@@ -1,5 +1,13 @@
+import type { Metadata } from "next";
 import React from "react";
 import Hero from "@/components/free-for-charity-ffc-web-developer-training-guide-components/Hero";
+
+export const metadata: Metadata = {
+  title: "Web Developer Training Guide",
+  description:
+    "Comprehensive FFC training guide for setting up and managing WHMCS, Cloudflare, Microsoft 365, WordPress, and other nonprofit technology tools.",
+  alternates: { canonical: "/free-for-charity-ffc-web-developer-training-guide" },
+};
 
 const index = () => {
   return (

--- a/src/app/free-for-charitys-tools-for-success/page.tsx
+++ b/src/app/free-for-charitys-tools-for-success/page.tsx
@@ -1,6 +1,14 @@
+import type { Metadata } from "next";
 import React from "react";
 import HeroSection from "@/components/ui/HeroSection";
 import CardSection from "@/components/free-for-charitys-tools-for-success-components/Card-section";
+
+export const metadata: Metadata = {
+  title: "Tools for Success",
+  description:
+    "Free productivity, educational, and business tools curated by Free For Charity to help nonprofits and volunteers succeed.",
+  alternates: { canonical: "/free-for-charitys-tools-for-success" },
+};
 import RescueTime from "@/components/free-for-charitys-tools-for-success-components/Rescue-Time";
 import TwoCards from "@/components/free-for-charitys-tools-for-success-components/Two-Cards";
 import EducationalSites from "@/components/free-for-charitys-tools-for-success-components/Educational-Sites";

--- a/src/app/guidestar-guide/page.tsx
+++ b/src/app/guidestar-guide/page.tsx
@@ -1,8 +1,16 @@
+import type { Metadata } from "next";
 import React from "react";
 import HeroSection from "@/components/ui/HeroSection";
 import FreeForCharity from "@/components/guidestar-guide/Free-for-charity";
 import Faqs from "@/components/guidestar-guide/Faqs";
 import CallSection from "@/components/help-for-charities-components/call-section";
+
+export const metadata: Metadata = {
+  title: "GuideStar Guide",
+  description:
+    "Guide for achieving GuideStar/Candid Platinum Seal of Transparency. Enhance your charity's credibility and visibility for donors.",
+  alternates: { canonical: "/guidestar-guide" },
+};
 
 const index = () => {
   return (

--- a/src/app/help-for-charities/layout.tsx
+++ b/src/app/help-for-charities/layout.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Help for Charities",
+  description:
+    "Resources and support for charity and nonprofit directors. Get instant access to free tools, domains, hosting, and technology services from Free For Charity.",
+  alternates: { canonical: "/help-for-charities" },
+};
+
+export default function HelpForCharitiesLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/src/app/home-old/page.tsx
+++ b/src/app/home-old/page.tsx
@@ -1,5 +1,11 @@
+import type { Metadata } from "next";
 import React from "react";
 import Hero from "@/components/home/HeroSection";
+
+export const metadata: Metadata = {
+  title: "Home (Legacy)",
+  robots: { index: false, follow: false },
+};
 import Mission from "@/components/home/MissionSection";
 import SupportFreeforCharity from "@/components/home/SupportFreeforCharity";
 import Testimonials from "@/components/home/Testimonials";

--- a/src/app/online-impacts-onboarding-guide/page.tsx
+++ b/src/app/online-impacts-onboarding-guide/page.tsx
@@ -1,8 +1,16 @@
+import type { Metadata } from "next";
 import React from "react";
 import HeroSection from "@/components/ui/HeroSection";
 import CharityText from "@/components/online-impacts-onboarding-guide-components/charity-text";
 import ReadyToGetStartedNow from "@/components/online-impacts-onboarding-guide-components/Ready-To-Get-Started-Now";
 import CallSection from "@/components/help-for-charities-components/call-section";
+
+export const metadata: Metadata = {
+  title: "Online Impacts Onboarding Guide",
+  description:
+    "Onboarding guide for charities hosted and designed by Online Impacts, providing instant access to free tools and services.",
+  alternates: { canonical: "/online-impacts-onboarding-guide" },
+};
 
 const index = () => {
   return (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,14 @@
+import type { Metadata } from "next";
 import React from "react";
 // import HomePage from './Home/page'
 import FigmaHomePage from "@/app/home-page";
+
+export const metadata: Metadata = {
+  title: "Free For Charity | Reduce Costs, Increase Impact",
+  description:
+    "Free For Charity connects students, professionals, and businesses with nonprofits to reduce costs and increase revenues—putting more resources back into their missions.",
+  alternates: { canonical: "/" },
+};
 
 const page = () => {
   return (

--- a/src/app/pre501c3/page.tsx
+++ b/src/app/pre501c3/page.tsx
@@ -1,8 +1,16 @@
+import type { Metadata } from "next";
 import React from "react";
 import HeroSection from "@/components/ui/HeroSection";
 import ReadyToGetStarted from "@/components/help-for-charities-components/Ready-to-Get-Started-Now";
 import CharityNonprofitDirectorFaq from "@/components/help-for-charities-components/Charity-Nonprofit-Director-Faq";
 import CallSection from "@/components/help-for-charities-components/call-section";
+
+export const metadata: Metadata = {
+  title: "Pre-501(c)(3) Onboarding Guide",
+  description:
+    "Onboarding guide for charities pending 501(c)(3) status. Access free tools and services from Free For Charity while your application is in progress.",
+  alternates: { canonical: "/pre501c3" },
+};
 import Faqs from "@/components/pre501c3-components/Faqs";
 import Charity from "@/components/pre501c3-components/charity";
 

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -1,3 +1,12 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy",
+  description:
+    "Free For Charity privacy policy describing how we collect, use, and protect your personal information.",
+  alternates: { canonical: "/privacy-policy" },
+};
+
 export default function PrivacyPolicy() {
   return (
     <div className="pt-[140px] pb-[54px]">

--- a/src/app/security-acknowledgements/page.tsx
+++ b/src/app/security-acknowledgements/page.tsx
@@ -1,5 +1,13 @@
+import type { Metadata } from "next";
 import React from "react";
 import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Security Acknowledgements",
+  description:
+    "Acknowledging security researchers who have responsibly disclosed vulnerabilities to Free For Charity.",
+  alternates: { canonical: "/security-acknowledgements" },
+};
 
 const index = () => {
   return (

--- a/src/app/techstack/page.tsx
+++ b/src/app/techstack/page.tsx
@@ -1,5 +1,13 @@
+import type { Metadata } from "next";
 import React from "react";
 import Hero from "@/components/techstack-components/Hero";
+
+export const metadata: Metadata = {
+  title: "Tech Stack",
+  description:
+    "Understanding the Free For Charity WordPress hosting architecture, including Cloudflare, DirectAdmin, and Microsoft 365 integration layers.",
+  alternates: { canonical: "/techstack" },
+};
 
 const index = () => {
   return <Hero />;

--- a/src/app/terms-of-service/page.tsx
+++ b/src/app/terms-of-service/page.tsx
@@ -1,3 +1,12 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Terms of Service",
+  description:
+    "Free For Charity terms of service governing access to our website and nonprofit technology services.",
+  alternates: { canonical: "/terms-of-service" },
+};
+
 export default function TermsOfService() {
   return (
     <div className="pt-[130px] pb-[54px]">

--- a/src/app/volunteer/page.tsx
+++ b/src/app/volunteer/page.tsx
@@ -1,6 +1,14 @@
+import type { Metadata } from "next";
 import React from "react";
 import HeroSection from "@/components/ui/HeroSection";
 import FreeForCharity from "@/components/volunteer/Free-For-Charity";
+
+export const metadata: Metadata = {
+  title: "Volunteer",
+  description:
+    "Become a Free For Charity volunteer. Gain marketable skills in technology while helping nonprofits with domains, websites, and IT services.",
+  alternates: { canonical: "/volunteer" },
+};
 
 const index = () => {
   return (

--- a/src/app/vulnerability-disclosure-policy/page.tsx
+++ b/src/app/vulnerability-disclosure-policy/page.tsx
@@ -1,3 +1,12 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Vulnerability Disclosure Policy",
+  description:
+    "Free For Charity's responsible vulnerability disclosure policy for security researchers, including safe harbor provisions.",
+  alternates: { canonical: "/vulnerability-disclosure-policy" },
+};
+
 export default function VulnerabilityDisclosurePolicy() {
   return (
     <div className="pt-[130px] pb-[54px]">


### PR DESCRIPTION
## Summary
- Added metadata exports with title, description, and canonical URL to all 28 page routes (26 server components + 2 client component layouts)
- Expanded sitemap.ts from 1 route to 26 public routes with priorities
- Set robots noindex on internal pages (ffcadmin, cpanel-backup-sop, home-old)
- Created layout.tsx wrappers for client component pages (help-for-charities, ffcadmin-cpanel-backup-sop) to support static metadata exports
- Fixed pre-existing import casing breakage (layout.tsx, home-old, UI→ui)

## Test plan
- [ ] Run `npm run build` — passes with 0 errors
- [ ] Verify `<title>` tags render correctly on each page (check page source)
- [ ] Verify `/sitemap.xml` includes all 26 public routes
- [ ] Verify internal pages have `<meta name="robots" content="noindex">` in source
- [ ] Confirm canonical URLs match actual page paths

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)