### PR TITLE
refactor: adopt assetPath() for all static asset references

### DIFF
--- a/src/components/about-us-components/Card-section/index.tsx
+++ b/src/components/about-us-components/Card-section/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Image from 'next/image'
+import { assetPath } from '@/lib/assetPath'
 
 const Index = () => {
   return (
@@ -33,7 +34,7 @@ const Index = () => {
           {/* Right Image */}
           <div className="w-full md:w-[38.2%] flex justify-center md:justify-start">
             <Image
-              src="/Images/about-us-card-section-image.webp"
+              src={assetPath('/Images/about-us-card-section-image.webp')}
               width={500}
               height={500}
               alt="About Us Card Section Image"

--- a/src/components/domains/Cards-Section/index.tsx
+++ b/src/components/domains/Cards-Section/index.tsx
@@ -1,5 +1,6 @@
 import StepsCard from '@/components/ui/StepContentCard'
 import Image from 'next/image'
+import { assetPath } from '@/lib/assetPath'
 
 export default function CloudflareSetup() {
   return (
@@ -90,7 +91,7 @@ export default function CloudflareSetup() {
         {/* Screenshot Image – You can change the src */}
         <div className="mt-10 mb-[34px] -mx-10 md:-mx-15">
           <Image
-            src="/Images/Card-section-1.webp" // Change this path
+            src={assetPath('/Images/Card-section-1.webp')} // Change this path
             alt="User Management - Invite New User"
             width={1200}
             height={800}
@@ -102,7 +103,7 @@ export default function CloudflareSetup() {
       <StepsCard title="Change your DNS to point to Cloudflare" id="orderstep4">
         <div className="mt-10 mb-[34px] -mx-10 md:-mx-15">
           <Image
-            src="/Images/Card-section-2.webp" // Change this path
+            src={assetPath('/Images/Card-section-2.webp')} // Change this path
             alt="User Management - Invite New User"
             width={1200}
             height={800}
@@ -111,7 +112,7 @@ export default function CloudflareSetup() {
         </div>
         <div className="mt-10 mb-[34px] -mx-10 md:-mx-15">
           <Image
-            src="/Images/Card-section-3.webp" // Change this path
+            src={assetPath('/Images/Card-section-3.webp')} // Change this path
             alt="User Management - Invite New User"
             width={1200}
             height={800}
@@ -120,7 +121,7 @@ export default function CloudflareSetup() {
         </div>
         <div className="mt-10 mb-[34px] -mx-10 md:-mx-15">
           <Image
-            src="/Images/Card-section-4.webp" // Change this path
+            src={assetPath('/Images/Card-section-4.webp')} // Change this path
             alt="User Management - Invite New User"
             width={1200}
             height={800}
@@ -129,7 +130,7 @@ export default function CloudflareSetup() {
         </div>
         <div className="mt-10 mb-[34px] -mx-10 md:-mx-15">
           <Image
-            src="/Images/Card-section-5.webp" // Change this path
+            src={assetPath('/Images/Card-section-5.webp')} // Change this path
             alt="User Management - Invite New User"
             width={1200}
             height={800}

--- a/src/components/domains/Curved-Black-Section/index.tsx
+++ b/src/components/domains/Curved-Black-Section/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Image from 'next/image'
+import { assetPath } from '@/lib/assetPath'
 
 const Index = () => {
   return (
@@ -11,7 +12,7 @@ const Index = () => {
           {/* Image Section */}
           <div className="relative w-full md:w-[48.5%] h-[350px] mb-[25px] md:mb-0 md:mr-[32px]">
             <Image
-              src="/Images/domains-black-section.webp"
+              src={assetPath('/Images/domains-black-section.webp')}
               alt="domains-blue-section"
               fill
               className="object-contain rounded-[10px]"

--- a/src/components/domains/Curved-Blue-Section/index.tsx
+++ b/src/components/domains/Curved-Blue-Section/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Image from 'next/image'
+import { assetPath } from '@/lib/assetPath'
 
 const Index = () => {
   return (
@@ -51,7 +52,7 @@ const Index = () => {
 
         <div className="col-span-2 relative w-full md:w-[48.5%] h-[350px] ">
           <Image
-            src="/Images/domains-blue-section.webp"
+            src={assetPath('/Images/domains-blue-section.webp')}
             alt="domains-blue-section"
             fill
             className="object-contain rounded-[10px]"

--- a/src/components/domains/Hero/index.tsx
+++ b/src/components/domains/Hero/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Image from 'next/image'
+import { assetPath } from '@/lib/assetPath'
 
 const Index = () => {
   return (
@@ -29,7 +30,7 @@ const Index = () => {
         {/* Right Section */}
         <div className="w-full md:w-[38.2%] flex justify-center md:justify-end">
           <Image
-            src="/Images/Domains-hero.webp"
+            src={assetPath('/Images/Domains-hero.webp')}
             alt="hero image"
             width={500}
             height={400}

--- a/src/components/domains/Setup-Email-Hosting/index.tsx
+++ b/src/components/domains/Setup-Email-Hosting/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Image from 'next/image'
+import { assetPath } from '@/lib/assetPath'
 
 const index = () => {
   return (
@@ -61,7 +62,7 @@ const index = () => {
           {/* Circle Image */}
           <div className="mx-auto flex-shrink-0 w-[100px] h-[100px] overflow-hidden mb-[30px]">
             <Image
-              src="/Images/1.webp"
+              src={assetPath('/Images/1.webp')}
               alt="Step Illustration"
               width={56}
               height={56}
@@ -93,7 +94,7 @@ const index = () => {
           {/* Circle Image */}
           <div className="mx-auto flex-shrink-0 w-[100px] h-[100px] overflow-hidden mb-[30px]">
             <Image
-              src="/Images/2.webp"
+              src={assetPath('/Images/2.webp')}
               alt="Step Illustration"
               width={56}
               height={56}

--- a/src/components/domains/Verify-Your-Domain/index.tsx
+++ b/src/components/domains/Verify-Your-Domain/index.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image'
 import DomainCard from '@/components/ui/Domain-Card'
 import { IoCall } from 'react-icons/io5'
 import { IoMdMail } from 'react-icons/io'
+import { assetPath } from '@/lib/assetPath'
 
 const index = () => {
   return (
@@ -38,7 +39,7 @@ const index = () => {
             <div className="mb-4 md:mb-0 md:mr-4">
               <div className="relative h-[100px] w-[100px]">
                 <Image
-                  src="/Images/1.webp"
+                  src={assetPath('/Images/1.webp')}
                   fill
                   alt="domain verification email"
                   className="object-contain"
@@ -90,7 +91,7 @@ const index = () => {
             <div className="mb-4 md:mb-0 md:mr-4">
               <div className="relative h-[100px] w-[100px]">
                 <Image
-                  src="/Images/2.webp"
+                  src={assetPath('/Images/2.webp')}
                   fill
                   alt="domain verification email"
                   className="object-contain"

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -6,6 +6,7 @@ import { Mail, Phone, MapPin, ArrowRight } from 'lucide-react'
 
 import { FaFacebookF, FaLinkedinIn, FaGithub } from 'react-icons/fa'
 import { FaXTwitter } from 'react-icons/fa6'
+import { assetPath } from '@/lib/assetPath'
 
 const Footer: React.FC = () => {
   const currentYear = React.useMemo(() => new Date().getFullYear(), [])
@@ -33,7 +34,7 @@ const Footer: React.FC = () => {
           <div className="space-y-4">
             <a href="https://www.guidestar.org/profile/46-2471893">
               <img
-                src="/Svgs/footerImage.svg"
+                src={assetPath('/Svgs/footerImage.svg')}
                 alt="GuideStar Platinum Seal of Transparency"
                 aria-label="GuideStar Platinum Seal of Transparency"
               />

--- a/src/components/free-charity-web-hosting/About-FFC-Hosting/index.tsx
+++ b/src/components/free-charity-web-hosting/About-FFC-Hosting/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Image from 'next/image'
+import { assetPath } from '@/lib/assetPath'
 
 const index = () => {
   return (
@@ -8,7 +9,7 @@ const index = () => {
         <div className="w-full md:w-[38.2%] mr-[32px]">
           <div className="rounded-[15px] overflow-hidden shadow-[0px_2px_18px_0px_rgba(0,0,0,0.3)] w-full">
             <img
-              src="/Images/About-FFC-Hosting.webp"
+              src={assetPath('/Images/About-FFC-Hosting.webp')}
               alt="Example"
               className="w-full h-auto object-cover"
             />

--- a/src/components/free-charity-web-hosting/ClientTestimonials/index.tsx
+++ b/src/components/free-charity-web-hosting/ClientTestimonials/index.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect } from 'react'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { testimonials } from '@/data/testimonials'
+import { assetPath } from '@/lib/assetPath'
 
 export default function TestimonialSlider() {
   const [currentIndex, setCurrentIndex] = useState(0)
@@ -51,7 +52,7 @@ export default function TestimonialSlider() {
           <div
             className="absolute inset-0 bg-cover bg-bottom"
             style={{
-              backgroundImage: `url('/Images/client-section-bg-image.webp')`,
+              backgroundImage: `url('${assetPath('/Images/client-section-bg-image.webp')}')`,
             }}
           ></div>
 

--- a/src/components/free-charity-web-hosting/Hero/index.tsx
+++ b/src/components/free-charity-web-hosting/Hero/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Image from 'next/image'
+import { assetPath } from '@/lib/assetPath'
 
 const Index = () => {
   return (
@@ -30,7 +31,7 @@ const Index = () => {
         {/* Right Section */}
         <div className="w-full md:w-[58%] relative h-[400px] md:h-[500px]">
           <Image
-            src="/Images/hero-charity.webp"
+            src={assetPath('/Images/hero-charity.webp')}
             alt="hero image"
             fill
             className="object-cover w-full h-full"

--- a/src/components/free-charity-web-hosting/ThreeCards/index.tsx
+++ b/src/components/free-charity-web-hosting/ThreeCards/index.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react'
 import Image from 'next/image'
+import { assetPath } from '@/lib/assetPath'
 
 const DonateSection: React.FC = () => {
   return (
@@ -11,7 +12,7 @@ const DonateSection: React.FC = () => {
         <div className="w-full bg-[#0d7ff8] rounded-[10px] overflow-hidden pt-[30px] pr-[20px] pb-[30px] pl-[20px] shadow-[0px_2px_18px_0px_rgba(0,0,0,0.3)] flex flex-col items-center">
           <div className="mb-[30px] w-full relative h-[128px]">
             <Image
-              src="/Images/donate-now.webp"
+              src={assetPath('/Images/donate-now.webp')}
               alt="Donate Now"
               fill
               className="object-contain"
@@ -44,7 +45,7 @@ const DonateSection: React.FC = () => {
         <div className="w-full bg-[#0d7ff8] rounded-[10px] overflow-hidden pt-[30px] pr-[20px] pb-[30px] pl-[20px] shadow-[0px_2px_18px_0px_rgba(0,0,0,0.3)] flex flex-col items-center">
           <div className="mb-[30px] w-full relative h-[128px]">
             <Image
-              src="/Images/Be-a-volunteer.webp"
+              src={assetPath('/Images/Be-a-volunteer.webp')}
               alt="Be a Volunteer"
               fill
               className="object-contain"

--- a/src/components/free-charity-web-hosting/hosting/index.tsx
+++ b/src/components/free-charity-web-hosting/hosting/index.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react'
 import Image from 'next/image'
+import { assetPath } from '@/lib/assetPath'
 
 const HeroSection = () => {
   return (
@@ -26,7 +27,7 @@ const HeroSection = () => {
         <div className="w-full md:w-[47%] mx-auto">
           <div className="w-full md:w-[80%] mx-auto relative h-[400px] md:h-[272px] rounded-[15px] overflow-hidden shadow-[0px_2px_18px_0px_rgba(0,0,0,0.3)]">
             <Image
-              src="/Images/heart-in-hands.webp"
+              src={assetPath('/Images/heart-in-hands.webp')}
               alt="hero image"
               fill
               className="object-cover"

--- a/src/components/free-for-charity-endowment-fund-components/Empowering-Charities/index.tsx
+++ b/src/components/free-for-charity-endowment-fund-components/Empowering-Charities/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import Image from 'next/image'
 import ProgressBar from '@/components/ui/ProgressBar'
+import { assetPath } from '@/lib/assetPath'
 
 const Index = () => {
   return (
@@ -18,7 +19,7 @@ const Index = () => {
           <div className="w-full md:w-[36.7%] md:mr-[60px] h-auto">
             <div className="relative w-full h-[280px] sm:h-[350px] md:h-[400px]">
               <Image
-                src="/Images/Empowering-Charities.webp"
+                src={assetPath('/Images/Empowering-Charities.webp')}
                 alt="Empowering Charities"
                 fill
                 className="object-cover rounded-[6px]"

--- a/src/components/free-for-charity-endowment-fund-components/Endowment-Features/index.tsx
+++ b/src/components/free-for-charity-endowment-fund-components/Endowment-Features/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import Image from 'next/image'
 import { FaInfoCircle, FaChartPie, FaCreditCard } from 'react-icons/fa'
+import { assetPath } from '@/lib/assetPath'
 
 const Index = () => {
   return (
@@ -11,7 +12,7 @@ const Index = () => {
           <div className="w-full md:w-[47.25%] md:mr-[60px]">
             <div className="relative w-full h-[350px] sm:h-[500px] md:h-[685px]">
               <Image
-                src="/Images/Endowment-Features.webp"
+                src={assetPath('/Images/Endowment-Features.webp')}
                 alt="Endowment Features"
                 fill
                 className="object-cover rounded-[6px] shadow-[0px_40px_112px_-24px_rgba(0,0,0,0.12)]"

--- a/src/components/free-for-charity-endowment-fund-components/Hero/index.tsx
+++ b/src/components/free-for-charity-endowment-fund-components/Hero/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Link from 'next/link'
+import { assetPath } from '@/lib/assetPath'
 
 const Index = () => {
   return (
@@ -32,7 +33,7 @@ const Index = () => {
         {/* Image Section */}
         <div className="flex justify-center md:justify-start pt-[50px] md:pt-[64px]">
           <img
-            src="/Images/hero-img.webp"
+            src={assetPath('/Images/hero-img.webp')}
             alt="Person signing donation agreement"
             className="w-full max-w-[512px] rounded-[6px] shadow-2xl object-cover"
           />

--- a/src/components/free-for-charity-endowment-fund-components/Our-Mission/index.tsx
+++ b/src/components/free-for-charity-endowment-fund-components/Our-Mission/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Image from 'next/image'
+import { assetPath } from '@/lib/assetPath'
 
 const Index = () => {
   return (
@@ -32,7 +33,7 @@ const Index = () => {
           <div className="w-full md:w-[47.25%] h-[300px] sm:h-[400px] md:h-[500px]">
             <div className="relative w-full h-full">
               <Image
-                src="/Images/our-mission.webp"
+                src={assetPath('/Images/our-mission.webp')}
                 alt="Our Mission"
                 fill
                 className="object-cover rounded-[6px]"

--- a/src/components/free-for-charity-endowment-fund-components/Support-Our-Mission/index.tsx
+++ b/src/components/free-for-charity-endowment-fund-components/Support-Our-Mission/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { assetPath } from '@/lib/assetPath'
 
 interface SupportMissionSectionProps {
   title?: string
@@ -18,7 +19,7 @@ const SupportMissionSection: React.FC<SupportMissionSectionProps> = ({
       style={{
         backgroundImage: `
           linear-gradient(90deg, #003566 40%, rgba(0, 0, 0, 0.5) 100%),
-          url('/Images/people-donating.webp')
+          url('${assetPath('/Images/people-donating.webp')}')
         `,
         backgroundSize: 'cover',
         backgroundPosition: 'center',

--- a/src/components/free-for-charitys-tools-for-success-components/Educational-Sites/index.tsx
+++ b/src/components/free-for-charitys-tools-for-success-components/Educational-Sites/index.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import Image from 'next/image'
 import { IoIosArrowForward } from 'react-icons/io'
 import { motion, Variants } from 'framer-motion'
+import { assetPath } from '@/lib/assetPath'
 
 const cardVariants: Variants = {
   offscreen: { opacity: 0, scale: 0.8 },
@@ -19,17 +20,22 @@ const EducationalSitesSection = () => {
     {
       title: 'iwillteachyoutoberich.com Best for automation and earning more',
       link: 'https://www.iwillteachyoutoberich.com/blog/',
-      image: '/Images/googleLogo.webp',
+      image: assetPath('/Images/googleLogo.webp'),
     },
     {
       title: 'fourhourworkweek.com Another prime automation book and website',
       link: 'https://tim.blog/overview/',
-      image: '/Images/googleLogo.webp',
+      image: assetPath('/Images/googleLogo.webp'),
     },
   ]
 
   return (
-    <div className="py-[91px] bg-[linear-gradient(180deg,#0068b7_0%,rgba(44,96,118,0.75)_100%),url('/Images/pexels-cottonbro-4064840.webp')] bg-[#0f82af] bg-cover bg-center bg-no-repeat">
+    <div
+      className="py-[91px] bg-[#0f82af] bg-cover bg-center bg-no-repeat"
+      style={{
+        backgroundImage: `linear-gradient(180deg,#0068b7 0%,rgba(44,96,118,0.75) 100%),url('${assetPath('/Images/pexels-cottonbro-4064840.webp')}')`,
+      }}
+    >
       <div className="w-[80%] mx-auto flex flex-col items-center">
         {/* Heading */}
         <h2

--- a/src/components/free-for-charitys-tools-for-success-components/Five-Cards-Grid-Section/index.tsx
+++ b/src/components/free-for-charitys-tools-for-success-components/Five-Cards-Grid-Section/index.tsx
@@ -3,6 +3,7 @@
 import React from 'react'
 import EducationalSitesCard from '@/components/ui/EducationalSitesCard'
 import { motion, Variants } from 'framer-motion'
+import { assetPath } from '@/lib/assetPath'
 
 const cardVariants: Variants = {
   offscreen: { opacity: 0, scale: 0.8 },
@@ -16,17 +17,17 @@ const cardVariants: Variants = {
 const index = () => {
   const firstGrid = [
     {
-      imageSrc: '/Images/upwork.webp',
+      imageSrc: assetPath('/Images/upwork.webp'),
       title: 'ittybiz.com Great site for ultra small business info',
       link: 'http://ittybiz.com/about/',
     },
     {
-      imageSrc: '/Images/upwork.webp',
+      imageSrc: assetPath('/Images/upwork.webp'),
       title: 'earn1k.com Program for earning your for $1000 on the side by Ramit',
       link: 'https://www.iwillteachyoutoberich.com/',
     },
     {
-      imageSrc: '/Images/upwork.webp',
+      imageSrc: assetPath('/Images/upwork.webp'),
       title: 'appsumo.com Another program for earning your first money online',
       link: 'https://appsumo.com/courses-learning/',
     },
@@ -34,19 +35,24 @@ const index = () => {
 
   const secondGrid = [
     {
-      imageSrc: '/Images/upwork.webp',
+      imageSrc: assetPath('/Images/upwork.webp'),
       title: '100startup.com First book on starting a business',
       link: 'https://100startup.com/',
     },
     {
-      imageSrc: '/Images/upwork.webp',
+      imageSrc: assetPath('/Images/upwork.webp'),
       title: 'theleanstartup.com The next step up book on starting a business',
       link: 'http://theleanstartup.com/',
     },
   ]
 
   return (
-    <div className="bg-[linear-gradient(180deg,rgba(232,141,51,0.5)_0%,rgba(44,96,118,0.89)_100%),url('/Images/pexels-serpstat-572056.webp')] bg-cover bg-center pt-[67px] pb-[67px]">
+    <div
+      className="bg-cover bg-center pt-[67px] pb-[67px]"
+      style={{
+        backgroundImage: `linear-gradient(180deg,rgba(232,141,51,0.5) 0%,rgba(44,96,118,0.89) 100%),url('${assetPath('/Images/pexels-serpstat-572056.webp')}')`,
+      }}
+    >
       <div className="py-[27px] w-[80%] mx-auto">
         <h1 className="text-center pb-[10px] tracking-[1px] mb-[11px] text-[30px] md:text-[40px] text-[#333] font-[700] leading-[44px]">
           Educational Sites for Starting a Business

--- a/src/components/free-for-charitys-tools-for-success-components/Rescue-Time/index.tsx
+++ b/src/components/free-for-charitys-tools-for-success-components/Rescue-Time/index.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import Image from 'next/image'
 import { IoIosArrowForward } from 'react-icons/io'
 import { motion, Variants } from 'framer-motion'
+import { assetPath } from '@/lib/assetPath'
 
 const sectionVariants: Variants = {
   offscreen: { opacity: 0, scale: 0.8 },
@@ -29,7 +30,7 @@ const Index = () => {
           {/* Image */}
           <div className="relative w-full aspect-[16/9] mb-[30px]">
             <Image
-              src="/Images/credit-karma-logo.webp"
+              src={assetPath('/Images/credit-karma-logo.webp')}
               alt="Placeholder Image"
               fill
               className="object-contain"
@@ -97,7 +98,7 @@ const Index = () => {
           {/* Image */}
           <div className="relative w-full aspect-[16/9] mb-[30px]">
             <Image
-              src="/Images/rescuetime.webp"
+              src={assetPath('/Images/rescuetime.webp')}
               alt="Placeholder Image"
               fill
               className="object-contain"

--- a/src/components/free-for-charitys-tools-for-success-components/Two-Flex-Cards/index.tsx
+++ b/src/components/free-for-charitys-tools-for-success-components/Two-Flex-Cards/index.tsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useRef } from 'react'
 import Image from 'next/image'
 import { IoIosArrowForward } from 'react-icons/io'
+import { assetPath } from '@/lib/assetPath'
 
 const Index = () => {
   const sectionRef = useRef<HTMLDivElement | null>(null)
@@ -34,7 +35,7 @@ const Index = () => {
           {/* Image */}
           <div className="relative w-full h-[260px] mb-[30px]">
             <Image
-              src="/Images/Volunteer-Card.webp"
+              src={assetPath('/Images/Volunteer-Card.webp')}
               alt="Placeholder Image"
               fill
               className="object-cover"
@@ -77,7 +78,7 @@ const Index = () => {
         <div className="w-[100%] lg:w-[47.25%] rounded-[15px] shadow-[0px_2px_70px_-15px_rgba(0,0,0,0.3)] py-[40px] px-[20px] flex flex-col items-start">
           <div className="relative w-full h-[260px] mb-[30px]">
             <Image
-              src="/Images/Free-For-Charity-card.webp"
+              src={assetPath('/Images/Free-For-Charity-card.webp')}
               alt="Placeholder Image"
               fill
               className="object-cover"

--- a/src/components/guidestar-guide/Faqs/index.tsx
+++ b/src/components/guidestar-guide/Faqs/index.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import AccordianBold from '@/components/ui/AccordianBold'
 import Image from 'next/image'
 import Transparentbtn from '@/components/ui/Transparentbtn'
+import { assetPath } from '@/lib/assetPath'
 
 const index = () => {
   return (
@@ -230,7 +231,7 @@ const index = () => {
             as well as some option for posting this badge to your website that we will need later.
           </p>
           <Image
-            src="/Images/preparing-to-share.webp"
+            src={assetPath('/Images/preparing-to-share.webp')}
             alt="Free For Charity GuideStar onboarding requirements and highlighted fields"
             width={780}
             height={100}

--- a/src/components/guidestar-guide/Free-for-charity/index.tsx
+++ b/src/components/guidestar-guide/Free-for-charity/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Image from 'next/image'
+import { assetPath } from '@/lib/assetPath'
 
 const Index = () => {
   return (
@@ -29,7 +30,7 @@ const Index = () => {
         {/* Responsive Image with Proper Dimensions */}
         <div className="relative w-full h-auto">
           <Image
-            src="/Images/free-for-charity.webp"
+            src={assetPath('/Images/free-for-charity.webp')}
             alt="Free For Charity GuideStar onboarding requirements and highlighted fields"
             width={780}
             height={100}

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -7,6 +7,7 @@ import { FiMenu, FiChevronDown } from 'react-icons/fi'
 import { LiaSearchSolid } from 'react-icons/lia'
 import { RxCross2 } from 'react-icons/rx'
 import { motion, AnimatePresence } from 'framer-motion'
+import { assetPath } from '@/lib/assetPath'
 
 interface DropdownItem {
   label: string
@@ -149,7 +150,7 @@ const Header: React.FC = () => {
             >
               <Link href="/" onClick={handleLinkClick} className="block">
                 <img
-                  src="/Images/ffc-logo-banner.webp"
+                  src={assetPath('/Images/ffc-logo-banner.webp')}
                   alt="Free For Charity"
                   className={`transition-all duration-300 ${isScrolled ? 'h-7' : 'h-11'}`}
                 />

--- a/src/components/home-page/Hero/index.tsx
+++ b/src/components/home-page/Hero/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Image from 'next/image'
+import { assetPath } from '@/lib/assetPath'
 
 const CharityHeroBackground = () => {
   return (
@@ -65,7 +66,7 @@ const CharityHeroBackground = () => {
         <div className="relative w-full max-w-[445px] aspect-square bg-white rounded-full p-12 flex items-center justify-center">
           <div className="relative w-full h-full">
             <Image
-              src="/Images/figma-hero-img.webp"
+              src={assetPath('/Images/figma-hero-img.webp')}
               alt="Hero image"
               fill
               className="object-contain"

--- a/src/components/home-page/Mission/index.tsx
+++ b/src/components/home-page/Mission/index.tsx
@@ -32,7 +32,7 @@ const index = () => {
             controls
             playsInline
             preload="metadata"
-            poster="/videos/mission-video-poster.png"
+            poster={assetPath('/videos/mission-video-poster.png')}
             aria-label="Free For Charity mission video"
             title="Learn about Free For Charity's mission to help nonprofits reduce costs"
           >

--- a/src/components/home-page/Our-Programs/index.tsx
+++ b/src/components/home-page/Our-Programs/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import Image from 'next/image'
 import OrangeFaqItem from '@/components/ui/OrangeFaqItem'
+import { assetPath } from '@/lib/assetPath'
 
 const index = () => {
   return (
@@ -17,7 +18,7 @@ const index = () => {
           <div className="mb-[40px]  flex items-center gap-[20px]">
             <div className="w-[100px] flex items-center justify-center p-2 h-[100px] bg-[#2A6682] rounded-full">
               <div className="relative w-[56px] h-[56px]">
-                <Image src="/Svgs/FFC-Domains.svg" alt="FFC-Domains" fill></Image>
+                <Image src={assetPath('/Svgs/FFC-Domains.svg')} alt="FFC-Domains" fill></Image>
               </div>
             </div>
             <h1 className="text-[36px] font-[400] " id="lato-font">
@@ -73,7 +74,7 @@ const index = () => {
           <div className="lg:pl-[50px] mb-[40px]  flex items-center gap-[20px]">
             <div className="w-[100px] flex items-center justify-center p-2 h-[100px] bg-[#2A6682] rounded-full">
               <div className="relative w-[56px] h-[56px]">
-                <Image src="/Svgs/FFC-Hosting.svg" alt="FFC-Domains" fill></Image>
+                <Image src={assetPath('/Svgs/FFC-Hosting.svg')} alt="FFC-Domains" fill></Image>
               </div>
             </div>
             <h1 className="text-[36px] font-[400]  " id="lato-font">
@@ -139,7 +140,7 @@ const index = () => {
           <div className="lg:pl-[50px] mb-[40px]  flex items-center gap-[20px]">
             <div className="w-[100px] flex items-center justify-center p-2 h-[100px] bg-[#2A6682] rounded-full">
               <div className="relative w-[56px] h-[56px]">
-                <Image src="/Svgs/FFC-Consulting.svg" alt="FFC-Domains" fill></Image>
+                <Image src={assetPath('/Svgs/FFC-Consulting.svg')} alt="FFC-Domains" fill></Image>
               </div>
             </div>
             <h1 className="text-[36px] font-[400]  " id="lato-font">

--- a/src/components/home-page/SupportFreeForCharity/index.tsx
+++ b/src/components/home-page/SupportFreeForCharity/index.tsx
@@ -1,5 +1,6 @@
 import React, { CSSProperties, IframeHTMLAttributes } from 'react'
 import Image from 'next/image'
+import { assetPath } from '@/lib/assetPath'
 
 interface ExtendedIframeProps extends IframeHTMLAttributes<HTMLIFrameElement> {
   allowpaymentrequest?: string
@@ -50,7 +51,7 @@ const Index = () => {
             <div className="w-full flex justify-center lg:justify-end">
               <div className="relative w-full max-w-[400px] aspect-[578/386]">
                 <Image
-                  src="/Images/support-free-for-charity.webp"
+                  src={assetPath('/Images/support-free-for-charity.webp')}
                   alt="support free for charity image"
                   fill
                   className="object-contain scale-x-[-1]"

--- a/src/components/home-page/VoicesofGratitude/index.tsx
+++ b/src/components/home-page/VoicesofGratitude/index.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect } from 'react'
 import Image from 'next/image'
 import { testimonials } from '@/data/testimonials'
+import { assetPath } from '@/lib/assetPath'
 
 export default function TestimonialSlider() {
   const [currentIndex, setCurrentIndex] = useState(0)
@@ -60,7 +61,7 @@ export default function TestimonialSlider() {
                           {[...Array(5)].map((_, i) => (
                             <Image
                               key={i}
-                              src="/Svgs/start-icon.svg"
+                              src={assetPath('/Svgs/start-icon.svg')}
                               width={29}
                               height={29}
                               alt="star icon"

--- a/src/components/home-page/Volunteer-with-Us/index.tsx
+++ b/src/components/home-page/Volunteer-with-Us/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Image from 'next/image'
+import { assetPath } from '@/lib/assetPath'
 
 const index = () => {
   return (
@@ -32,7 +33,7 @@ const index = () => {
         </a>
 
         <Image
-          src="/Images/Volunteer-with-Us.webp"
+          src={assetPath('/Images/Volunteer-with-Us.webp')}
           alt="Volunteer-with-Us"
           width={1083}
           height={607}

--- a/src/components/home/HeroSection/index.tsx
+++ b/src/components/home/HeroSection/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Image from 'next/image'
+import { assetPath } from '@/lib/assetPath'
 
 const Hero: React.FC = () => {
   return (
@@ -21,7 +22,7 @@ const Hero: React.FC = () => {
         {/* Right Image Section */}
         <div className="w-full md:w-[60%] flex items-center justify-center md:justify-end pt-[50px] md:pt-[50px]">
           <Image
-            src="/Images/hero-image.webp"
+            src={assetPath('/Images/hero-image.webp')}
             alt="Hero"
             width={800}
             height={540}

--- a/src/components/home/SupportFreeforCharity/index.tsx
+++ b/src/components/home/SupportFreeforCharity/index.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import TrainingCard from '../../ui/trainingcard'
 import BlueBtn from '../../ui/Bluebtn'
 import Transparentbtn from '@/components/ui/Transparentbtn'
+import { assetPath } from '@/lib/assetPath'
 
 const SupportFreeForCharity: React.FC = () => {
   return (
@@ -40,7 +41,7 @@ const SupportFreeForCharity: React.FC = () => {
               TRAINING PROGRAM.
             </h1>
             <TrainingCard
-              src="/Svgs/tickmark.svg"
+              src={assetPath('/Svgs/tickmark.svg')}
               heading="FREE TRAINING PROGRAMS"
               text="Are you looking to gain marketable skills in technology and business services? Are you looking to start building a portfolio showing real world support to small, medium, and large organizations? If so, this is the place for you."
             />
@@ -57,7 +58,7 @@ const SupportFreeForCharity: React.FC = () => {
               PROJECTS.
             </h1>
             <TrainingCard
-              src="/Svgs/home.svg"
+              src={assetPath('/Svgs/home.svg')}
               heading="HELP FOR CHARITIES"
               text="If you are representing a charity or you currently work for a charity and want to improve your own skills start here to get help for your organization. You get instant access to many of our free tools and products right away!"
             />
@@ -73,7 +74,7 @@ const SupportFreeForCharity: React.FC = () => {
               ARE YOU A BUSINESS OR INDIVIDUAL LOOKING TO DONATE OR PARTNER WITH FREE FOR CHARITY?
             </h1>
             <TrainingCard
-              src="/Svgs/heart.svg"
+              src={assetPath('/Svgs/heart.svg')}
               heading="VOLUNTEER AND/OR DONATE"
               text="We are always looking for individuals and business to support our training programs. Both donations as well as performing volunteer work for our training programs are critical to the success of Free For Charity and it’s mission."
             />

--- a/src/components/ui/Frequently-Asked-Questions.tsx
+++ b/src/components/ui/Frequently-Asked-Questions.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useRef, useEffect } from 'react'
 import Image from 'next/image'
+import { assetPath } from '@/lib/assetPath'
 
 interface AccordionItemProps {
   title: string
@@ -37,9 +38,19 @@ const FrequentlyAskedQuestions: React.FC<AccordionItemProps> = ({ title, childre
         {/* Icon container with fixed width */}
         <span className="flex-shrink-0 w-8 h-8 flex items-center justify-center">
           {isOpen ? (
-            <Image src="/Svgs/up-arrow.svg" alt="up arrow" width={40} height={13}></Image>
+            <Image
+              src={assetPath('/Svgs/up-arrow.svg')}
+              alt="up arrow"
+              width={40}
+              height={13}
+            ></Image>
           ) : (
-            <Image src="/Svgs/down-arrow.svg" alt="down arrow" width={40} height={16}></Image>
+            <Image
+              src={assetPath('/Svgs/down-arrow.svg')}
+              alt="down arrow"
+              width={40}
+              height={16}
+            ></Image>
           )}
         </span>
       </button>

--- a/src/components/ui/OrangeFaqItem.tsx
+++ b/src/components/ui/OrangeFaqItem.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useRef, useEffect } from 'react'
 import Image from 'next/image'
+import { assetPath } from '@/lib/assetPath'
 
 interface AccordionItemProps {
   title: string
@@ -42,9 +43,9 @@ const AccordionItem: React.FC<AccordionItemProps> = ({ title, children }) => {
 
         <span className="flex-shrink-0 w-8 h-8 flex items-center justify-center">
           {isOpen ? (
-            <Image width={51} height={51} src="/Svgs/minus.svg" alt="Minus" />
+            <Image width={51} height={51} src={assetPath('/Svgs/minus.svg')} alt="Minus" />
           ) : (
-            <Image width={51} height={51} src="/Svgs/plus.svg" alt="Plus" />
+            <Image width={51} height={51} src={assetPath('/Svgs/plus.svg')} alt="Plus" />
           )}
         </span>
       </button>

--- a/src/components/ui/TeamMemberCard.tsx
+++ b/src/components/ui/TeamMemberCard.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react'
 import Image from 'next/image'
+import { assetPath } from '@/lib/assetPath'
 
 interface TeamMemberCardProps {
   imageUrl: string
@@ -47,7 +48,7 @@ export default function TeamMemberCard({
         className="mt-6"
         aria-label={`${name} on LinkedIn`}
       >
-        <Image src="/Svgs/linkedin-icon.svg" width={63} height={63} alt="LinkedIn" />
+        <Image src={assetPath('/Svgs/linkedin-icon.svg')} width={63} height={63} alt="LinkedIn" />
       </a>
     </div>
   )


### PR DESCRIPTION
## Summary
- Migrate all hardcoded `/Images/`, `/Svgs/`, and `/videos/` paths to use `assetPath()` helper
- 36 component files updated for GitHub Pages basePath compatibility
- Covers `<img>` src, `<Image>` src, `poster` attributes, and CSS `url()` patterns
- Tailwind `url()` background-images moved to inline styles for dynamic path resolution

## Test plan
- [x] `npm run build` - all 40 pages generate successfully
- [x] Zero remaining hardcoded asset paths (verified via grep)
- [ ] Manual: verify images load correctly on localhost
- [ ] Manual: verify images load on GitHub Pages with basePath

Closes #9

Generated with [Claude Code](https://claude.com/claude-code)