### PR TITLE
fix: correct FAQ typo and allow require() in CJS configs

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -37,6 +37,13 @@ const eslintConfig = [
       'react-hooks/immutability': 'warn',
     },
   },
+  {
+    // Allow require() in CJS config files (Jest, commitlint)
+    files: ['*.config.js', '*.config.cjs'],
+    rules: {
+      '@typescript-eslint/no-require-imports': 'off',
+    },
+  },
 ]
 
 export default eslintConfig

--- a/src/components/home-page/FrequentlyAskedQuestions/index.tsx
+++ b/src/components/home-page/FrequentlyAskedQuestions/index.tsx
@@ -238,7 +238,7 @@ const index = () => {
               We are a registered reseller of eNom domain names. eNom has graciously provided us
               with a Platinum account to support other non profits providing the lowest cost domain
               names for a charity of our size. As we get more and more charities into the domain
-              system we expect the costs to freeforchariy.org to drop even further.
+              system we expect the costs to freeforcharity.org to drop even further.
             </p>
           </FrequentlyAskedQuestions>
 


### PR DESCRIPTION
## Summary
- Fix "freeforchariy.org" typo in FAQ section → "freeforcharity.org"
- Add ESLint override to allow `require()` in CJS config files (`jest.config.js`, `commitlint.config.js`)

Supersedes #56 — analysis found that all other fixes from PR #56 were already applied through PRs #57–#61. Only this typo remained.

Fixes #55

## Test plan
- [ ] Verify FAQ section displays correct "freeforcharity.org" text
- [ ] Verify `npm run lint` passes with 0 errors
- [ ] Verify build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)