### PR TITLE
fix: wrap imageUrl props with assetPath() for GitHub Pages

### DIFF
--- a/src/components/ui/BlogCard.tsx
+++ b/src/components/ui/BlogCard.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from 'react'
 import Link from 'next/link'
 import Image from 'next/image'
+import { assetPath } from '@/lib/assetPath'
 
 interface InfoCardProps {
   imageUrl?: string
@@ -29,7 +30,7 @@ const InfoCard: React.FC<InfoCardProps> = ({ imageUrl, heading, date, descriptio
       {imageUrl && (
         <div className="relative w-full aspect-[4/3] overflow-hidden">
           <Image
-            src={imageUrl}
+            src={assetPath(imageUrl)}
             alt={heading}
             fill
             className="object-cover transition-transform duration-300 group-hover:scale-105"

--- a/src/components/ui/SustainableFundingCard.tsx
+++ b/src/components/ui/SustainableFundingCard.tsx
@@ -1,5 +1,6 @@
 import Image from 'next/image'
 import React from 'react'
+import { assetPath } from '@/lib/assetPath'
 
 interface SustainableFundingCardProps {
   imageUrl: string
@@ -17,7 +18,12 @@ export const SustainableFundingCard: React.FC<SustainableFundingCardProps> = ({
       {/* Image/Icon Section */}
       <div className="flex justify-center">
         <div className="relative w-[60px] h-[60px]">
-          <Image src={imageUrl} alt={title} fill className="object-contain drop-shadow-md" />
+          <Image
+            src={assetPath(imageUrl)}
+            alt={title}
+            fill
+            className="object-contain drop-shadow-md"
+          />
         </div>
       </div>
 

--- a/src/components/ui/TeamMemberCard.tsx
+++ b/src/components/ui/TeamMemberCard.tsx
@@ -22,7 +22,7 @@ export default function TeamMemberCard({
       {/* Circular Image Container */}
       <div className="relative w-[300px] h-[300px] mb-6 rounded-full overflow-hidden ring-4 ring-white shadow-xl">
         <Image
-          src={imageUrl}
+          src={assetPath(imageUrl)}
           alt={`${name} — ${title}`}
           fill
           className="object-cover"


### PR DESCRIPTION
## Summary
- Wraps `imageUrl` props with `assetPath()` in 3 UI components that were passing raw paths directly to `<Image src>`
- **TeamMemberCard** — team member photos (`/Images/member1.webp`, etc.) were 404ing on GitHub Pages
- **BlogCard** — blog card image (`/Images/card-image.webp`)
- **SustainableFundingCard** — endowment feature SVG icons (`/Svgs/*.svg`)

On GitHub Pages the site is served from `/FFC-IN-freeforcharity.org/`, so all asset paths need the base path prefix via `assetPath()`.

## Test plan
- [x] `npm run build` — clean build
- [x] `npx jest` — 115 tests pass
- [ ] Verify team member images load on GitHub Pages after deploy
- [ ] Verify blog card image loads
- [ ] Verify endowment feature SVG icons load

🤖 Generated with [Claude Code](https://claude.com/claude-code)