### PR TITLE
fix: add assetPath() to all remaining image components

### DIFF
--- a/src/components/ui/Domain-Card.tsx
+++ b/src/components/ui/Domain-Card.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Image from 'next/image'
+import { assetPath } from '@/lib/assetPath'
 
 type StepCardProps = {
   imageSrc: string
@@ -26,7 +27,7 @@ export default function StepCard({
       {/* Circle Image */}
       <div className="mx-auto flex-shrink-0 w-[50px] h-[50px] bg-white rounded-full overflow-hidden shadow-lg mb-[30px]">
         <Image
-          src={imageSrc}
+          src={assetPath(imageSrc)}
           alt={imageAlt}
           width={56}
           height={56}

--- a/src/components/ui/General-Donation-Card.tsx
+++ b/src/components/ui/General-Donation-Card.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Link from 'next/link'
+import { assetPath } from '@/lib/assetPath'
 
 interface GeneralDonationCardProps {
   title: string
@@ -30,7 +31,7 @@ const GeneralDonationCard: React.FC<GeneralDonationCardProps> = ({
 
       {/* Image */}
       <div className="flex justify-center">
-        <img src={img} alt="Donation image" className="h-12 w-auto object-contain" />
+        <img src={assetPath(img)} alt="Donation image" className="h-12 w-auto object-contain" />
       </div>
     </Link>
   )

--- a/src/components/ui/HeroSection.tsx
+++ b/src/components/ui/HeroSection.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react'
 import Image from 'next/image'
+import { assetPath } from '@/lib/assetPath'
 
 interface HeroSectionProps {
   heading: string
@@ -49,7 +50,7 @@ const HeroSection: React.FC<HeroSectionProps> = ({
           <div className="w-full lg:w-[60%] md:pr-[50px] md:pl-[80px]">
             <div className={`relative ${imageContainerWidth} mx-auto`}>
               <Image
-                src={heroImg}
+                src={assetPath(heroImg)}
                 alt="Hero Image"
                 width={1200}
                 height={600}

--- a/src/components/ui/SlidingCard.tsx
+++ b/src/components/ui/SlidingCard.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useRef } from 'react'
 import Image, { StaticImageData } from 'next/image'
 import { IoIosArrowForward } from 'react-icons/io'
+import { assetPath } from '@/lib/assetPath'
 
 type SlidingCardProps = {
   direction?: 'left' | 'right' // Image on left or right
@@ -60,7 +61,7 @@ export default function SlidingCard({
         <div ref={imageRef} className="flex-1 flex justify-start overflow-hidden">
           <div className="relative w-full">
             <Image
-              src={imageSrc}
+              src={typeof imageSrc === 'string' ? assetPath(imageSrc) : imageSrc}
               alt={subtitle}
               width={400}
               height={120}

--- a/src/components/ui/StepCard.tsx
+++ b/src/components/ui/StepCard.tsx
@@ -1,6 +1,7 @@
 'use client'
 import React, { useEffect, useRef, useState } from 'react'
 import Image from 'next/image'
+import { assetPath } from '@/lib/assetPath'
 
 interface Step {
   number: number
@@ -45,7 +46,7 @@ const StepCard: React.FC<{ step: Step }> = ({ step }) => {
         <div className="flex justify-center mb-[30px]">
           <div className="relative w-[100px] h-[100px]">
             <Image
-              src={`/Images/${step.number}.webp`}
+              src={assetPath(`/Images/${step.number}.webp`)}
               alt={`Step ${step.number}`}
               fill
               className={`object-contain drop-shadow-lg transition-all duration-700 ${

--- a/src/components/ui/ToolCard.tsx
+++ b/src/components/ui/ToolCard.tsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useRef } from 'react'
 import Image, { StaticImageData } from 'next/image'
 import { IoIosArrowForward } from 'react-icons/io' // Import arrow
+import { assetPath } from '@/lib/assetPath'
 
 type ToolCardProps = {
   logo?: string | StaticImageData
@@ -41,7 +42,12 @@ export default function ToolCard({ logo, title, description, link }: ToolCardPro
       <div className="flex items-center mb-[15px]">
         {logo && (
           <div className="relative w-full mx-auto h-[200px]">
-            <Image src={logo} alt={`${title} logo`} fill className="object-cover" />
+            <Image
+              src={typeof logo === 'string' ? assetPath(logo) : logo}
+              alt={`${title} logo`}
+              fill
+              className="object-cover"
+            />
           </div>
         )}
       </div>

--- a/tests/post-deploy-smoke.spec.ts
+++ b/tests/post-deploy-smoke.spec.ts
@@ -1,0 +1,170 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Post-Deploy Smoke Tests
+ *
+ * Crawls every page in the sitemap and verifies:
+ * 1. All pages return 200
+ * 2. No images are broken (natural width/height > 0 for visible images)
+ * 3. No internal links are dead (404)
+ *
+ * These tests run against the static build served locally, catching
+ * broken assets before they reach production.
+ */
+
+// All routes from sitemap.ts — the single source of truth for the site
+const sitemapRoutes = [
+  '/',
+  '/about-us',
+  '/contact-us',
+  '/donate',
+  '/volunteer',
+  '/domains',
+  '/free-charity-web-hosting',
+  '/help-for-charities',
+  '/blog',
+  '/consulting',
+  '/free-training-programs',
+  '/workforce-development',
+  '/charity-and-nonprofit-service-and-consultant-directory',
+  '/charity-and-nonprofit-technology-directory',
+  '/charity-and-nonprofit-case-studies',
+  '/501c3',
+  '/pre501c3',
+  '/free-for-charity-endowment-fund',
+  '/guidestar-guide',
+  '/free-for-charitys-tools-for-success',
+  '/free-for-charity-ffc-service-delivery-stages',
+  '/free-for-charity-ffc-web-developer-training-guide',
+  '/ffc-volunteer-proving-ground-core-competencies',
+  '/charity-validation-guide-ensuring-mutual-benefit-through-comprehensive-validation-processes',
+  '/online-impacts-onboarding-guide',
+  '/techstack',
+  '/donation-policy',
+  '/free-for-charity-donation-policy',
+  '/privacy-policy',
+  '/terms-of-service',
+  '/cookie-policy',
+  '/vulnerability-disclosure-policy',
+  '/security-acknowledgements',
+]
+
+test.describe('Post-Deploy Smoke Tests', () => {
+  test.describe('All pages load successfully', () => {
+    for (const route of sitemapRoutes) {
+      test(`${route} returns 200`, async ({ page }) => {
+        const response = await page.goto(route)
+        expect(response?.status()).toBe(200)
+      })
+    }
+  })
+
+  test.describe('No broken images', () => {
+    // Test critical pages that have the most images
+    const pagesWithImages = [
+      '/',
+      '/about-us',
+      '/donate',
+      '/domains',
+      '/free-charity-web-hosting',
+      '/free-for-charity-endowment-fund',
+      '/free-for-charitys-tools-for-success',
+      '/501c3',
+      '/volunteer',
+      '/consulting',
+      '/guidestar-guide',
+      '/contact-us',
+      '/blog',
+    ]
+
+    for (const route of pagesWithImages) {
+      test(`${route} has no broken images`, async ({ page }) => {
+        // Track failed image requests
+        const failedImages: string[] = []
+
+        page.on('response', (response) => {
+          const url = response.url()
+          const status = response.status()
+          // Check for image requests that return non-200
+          if (
+            (url.match(/\.(webp|png|jpg|jpeg|gif|svg|ico)(\?|$)/i) ||
+              response.request().resourceType() === 'image') &&
+            status >= 400
+          ) {
+            failedImages.push(`${status} ${url}`)
+          }
+        })
+
+        await page.goto(route, { waitUntil: 'networkidle' })
+
+        // Check all <img> elements have loaded (naturalWidth > 0)
+        const brokenImgs = await page.evaluate(() => {
+          const imgs = document.querySelectorAll('img')
+          const broken: string[] = []
+          imgs.forEach((img) => {
+            // Skip invisible images (display:none, etc.)
+            if (img.offsetParent === null && !img.closest('header')) return
+            // Skip external images (different origin)
+            if (img.src && !img.src.startsWith(window.location.origin)) return
+            // Check if image actually loaded
+            if (img.src && img.naturalWidth === 0 && img.complete) {
+              broken.push(`${img.alt || '(no alt)'}: ${img.src}`)
+            }
+          })
+          return broken
+        })
+
+        // Report all failures together
+        const allFailures = [...failedImages, ...brokenImgs]
+        expect(allFailures, `Broken images on ${route}:\n${allFailures.join('\n')}`).toHaveLength(0)
+      })
+    }
+  })
+
+  test.describe('No broken internal links', () => {
+    test('homepage internal links resolve', async ({ page }) => {
+      await page.goto('/')
+
+      // Collect all internal href values
+      const internalLinks = await page.evaluate(() => {
+        const anchors = document.querySelectorAll('a[href]')
+        const links: string[] = []
+        const seen = new Set<string>()
+
+        anchors.forEach((a) => {
+          const href = a.getAttribute('href')
+          if (!href) return
+          // Only test internal links (relative or same-origin)
+          if (href.startsWith('http') && !href.includes('localhost')) return
+          if (href.startsWith('mailto:') || href.startsWith('tel:')) return
+          if (href.startsWith('#')) return
+          // Normalize
+          const path = href.split('#')[0].split('?')[0]
+          if (path && !seen.has(path)) {
+            seen.add(path)
+            links.push(path)
+          }
+        })
+        return links
+      })
+
+      // Check each internal link returns 200
+      const brokenLinks: string[] = []
+      for (const link of internalLinks) {
+        try {
+          const response = await page.goto(link)
+          if (response && response.status() >= 400) {
+            brokenLinks.push(`${response.status()} ${link}`)
+          }
+        } catch {
+          brokenLinks.push(`ERROR ${link}`)
+        }
+      }
+
+      expect(
+        brokenLinks,
+        `Broken internal links from homepage:\n${brokenLinks.join('\n')}`
+      ).toHaveLength(0)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Wraps image props with `assetPath()` in **6 more UI components** that were broken on GitHub Pages
- Adds a comprehensive **post-deploy smoke test** that catches broken images and dead links

### Components fixed
| Component | Prop | Pages affected |
|-----------|------|----------------|
| HeroSection | `heroImg` | **17 pages** (501c3, about-us, consulting, donate, etc.) |
| ToolCard | `logo` | 6 tool logos on tools-for-success |
| SlidingCard | `imageSrc` | 11 tool images on tools-for-success |
| General-Donation-Card | `img` | 3 payment images on donate |
| Domain-Card | `imageSrc` | 3 step images on domains |
| StepCard | template literal | Step number images on domains |

### New test: `tests/post-deploy-smoke.spec.ts`
- Verifies all **33 sitemap routes** return HTTP 200
- Checks for **broken images** on 13 key pages (monitors network 4xx + checks `naturalWidth`)
- Validates **internal links** from homepage all resolve

Refs #9

## Test plan
- [x] `npm run build` — clean build
- [x] `npx jest` — 115 unit tests pass
- [ ] CI passes (format, lint, unit, E2E)
- [ ] Verify images load on GitHub Pages after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)