### PR TITLE
chore(cutover): redirect plan, .gitattributes, ci.yml permissions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto eol=lf
+*.{cmd,[cC][mM][dD]} text eol=crlf
+*.{bat,[bB][aA][tT]} text eol=crlf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test-and-build:
     name: Test and Build

--- a/docs/CUTOVER-REDIRECTS.md
+++ b/docs/CUTOVER-REDIRECTS.md
@@ -31,9 +31,9 @@ action:
 
 ### Slug changes (301)
 
-| WordPress | Next.js |
-|-----------|---------|
-| `/free-for-charity-terms-of-service/` | `/terms-of-service/` |
+| WordPress                                                                | Next.js                                |
+| ------------------------------------------------------------------------ | -------------------------------------- |
+| `/free-for-charity-terms-of-service/`                                    | `/terms-of-service/`                   |
 | `/charity-and-nonprofit-case-studies-to-help-your-organization-succeed/` | `/charity-and-nonprofit-case-studies/` |
 
 ### PayPal callback URLs (302, preserve query string)
@@ -41,30 +41,30 @@ action:
 PayPal hosted button `9ZKQ23YC3G2J2` (see `src/components/donate-components/measurable-impact/index.tsx`)
 returns donors to these paths after payment. They must not 404 on cutover day.
 
-| WordPress | Next.js | Reason |
-|-----------|---------|--------|
+| WordPress                 | Next.js    | Reason                                  |
+| ------------------------- | ---------- | --------------------------------------- |
 | `/donation-confirmation/` | `/donate/` | Preserve `?tx=...&st=...` PayPal params |
-| `/donation-failed/` | `/donate/` | Preserve PayPal cancel params |
+| `/donation-failed/`       | `/donate/` | Preserve PayPal cancel params           |
 
 > **Follow-up:** the WP versions had dedicated "Thank You" / "Try Again"
 > pages. Filed as a separate issue for design review before cutover.
 
 ### Content consolidation (301)
 
-| WordPress | Next.js | Reason |
-|-----------|---------|--------|
-| `/free-for-charity-just-earned-the-platinum-seal-of-transparency/` | `/blog/` | Legacy blog post |
-| `/our-organization-earned-a-2021-platinum-seal-of-transparency/` | `/blog/` | Legacy blog post |
-| `/we-just-updated-for-the-2022-guidestar-platinum-seal/` | `/blog/` | Legacy blog post |
-| `/using-a-registered-agent-service-northwest-registered-agent/` | `/blog/` | Legacy blog post |
-| `/podio-sponsorship-program/` | `/help-for-charities/` | Closest content match |
-| `/what-is-the-cost/` | `/help-for-charities/` | Pricing FAQ rolled into help page |
-| `/testimonial/american-legion-ahwatukee-post-64/` | `/#testimonials` | Inlined on homepage |
-| `/testimonial/keith-ray/` | `/#testimonials` | Inlined on homepage |
-| `/testimonial/pardhasaradhi-namburi/` | `/#testimonials` | Inlined on homepage |
-| `/testimonial/tashonda-payne/` | `/#testimonials` | Inlined on homepage |
-| `/donor-dashboard/` | `/donate/` | WP-only logged-in dashboard removed |
-| `/submit-information/` | `/contact-us/` | WP "Coming Soon" Forminator page dropped |
+| WordPress                                                          | Next.js                | Reason                                   |
+| ------------------------------------------------------------------ | ---------------------- | ---------------------------------------- |
+| `/free-for-charity-just-earned-the-platinum-seal-of-transparency/` | `/blog/`               | Legacy blog post                         |
+| `/our-organization-earned-a-2021-platinum-seal-of-transparency/`   | `/blog/`               | Legacy blog post                         |
+| `/we-just-updated-for-the-2022-guidestar-platinum-seal/`           | `/blog/`               | Legacy blog post                         |
+| `/using-a-registered-agent-service-northwest-registered-agent/`    | `/blog/`               | Legacy blog post                         |
+| `/podio-sponsorship-program/`                                      | `/help-for-charities/` | Closest content match                    |
+| `/what-is-the-cost/`                                               | `/help-for-charities/` | Pricing FAQ rolled into help page        |
+| `/testimonial/american-legion-ahwatukee-post-64/`                  | `/#testimonials`       | Inlined on homepage                      |
+| `/testimonial/keith-ray/`                                          | `/#testimonials`       | Inlined on homepage                      |
+| `/testimonial/pardhasaradhi-namburi/`                              | `/#testimonials`       | Inlined on homepage                      |
+| `/testimonial/tashonda-payne/`                                     | `/#testimonials`       | Inlined on homepage                      |
+| `/donor-dashboard/`                                                | `/donate/`             | WP-only logged-in dashboard removed      |
+| `/submit-information/`                                             | `/contact-us/`         | WP "Coming Soon" Forminator page dropped |
 
 ### Dropped archives / WP plumbing (301 → home)
 

--- a/docs/CUTOVER-REDIRECTS.md
+++ b/docs/CUTOVER-REDIRECTS.md
@@ -1,0 +1,115 @@
+# Cutover Redirect Plan
+
+URL changes between the WordPress site (`wordpress-static-export-2026-02-16` tag,
+60 pages) and the Next.js redesign (~36 routes). Source for Cloudflare
+[Bulk Redirects](https://developers.cloudflare.com/rules/url-forwarding/bulk-redirects/).
+
+**Status:** Source data prepared (`docs/cutover-redirects.csv`). Cloudflare
+upload requires a human with zone access — see Operator Steps below.
+
+---
+
+## URL inventory deltas
+
+### Matches (no redirect needed)
+
+These 28 WordPress slugs are preserved verbatim in Next.js and require no
+action:
+
+`/`, `/501c3/`, `/about-us/`, `/blog/`, `/charity-and-nonprofit-service-and-consultant-directory/`,
+`/charity-and-nonprofit-technology-directory/`, `/charity-validation-guide-…-validation-processes/`,
+`/consulting/`, `/contact-us/`, `/domains/`, `/donate/`,
+`/ffc-volunteer-proving-ground-core-competencies/`, `/ffcadmin/`,
+`/free-charity-web-hosting/`, `/free-for-charity-donation-policy/`,
+`/free-for-charity-endowment-fund/`, `/free-for-charity-ffc-service-delivery-stages/`,
+`/free-for-charity-ffc-web-developer-training-guide/`,
+`/free-for-charitys-tools-for-success/`, `/free-training-programs/`,
+`/guidestar-guide/`, `/help-for-charities/`, `/online-impacts-onboarding-guide/`,
+`/pre501c3/`, `/privacy-policy/`, `/security-acknowledgements/`,
+`/techstack/`, `/volunteer/`, `/vulnerability-disclosure-policy/`,
+`/workforce-development/`.
+
+### Slug changes (301)
+
+| WordPress | Next.js |
+|-----------|---------|
+| `/free-for-charity-terms-of-service/` | `/terms-of-service/` |
+| `/charity-and-nonprofit-case-studies-to-help-your-organization-succeed/` | `/charity-and-nonprofit-case-studies/` |
+
+### PayPal callback URLs (302, preserve query string)
+
+PayPal hosted button `9ZKQ23YC3G2J2` (see `src/components/donate-components/measurable-impact/index.tsx`)
+returns donors to these paths after payment. They must not 404 on cutover day.
+
+| WordPress | Next.js | Reason |
+|-----------|---------|--------|
+| `/donation-confirmation/` | `/donate/` | Preserve `?tx=...&st=...` PayPal params |
+| `/donation-failed/` | `/donate/` | Preserve PayPal cancel params |
+
+> **Follow-up:** the WP versions had dedicated "Thank You" / "Try Again"
+> pages. Filed as a separate issue for design review before cutover.
+
+### Content consolidation (301)
+
+| WordPress | Next.js | Reason |
+|-----------|---------|--------|
+| `/free-for-charity-just-earned-the-platinum-seal-of-transparency/` | `/blog/` | Legacy blog post |
+| `/our-organization-earned-a-2021-platinum-seal-of-transparency/` | `/blog/` | Legacy blog post |
+| `/we-just-updated-for-the-2022-guidestar-platinum-seal/` | `/blog/` | Legacy blog post |
+| `/using-a-registered-agent-service-northwest-registered-agent/` | `/blog/` | Legacy blog post |
+| `/podio-sponsorship-program/` | `/help-for-charities/` | Closest content match |
+| `/what-is-the-cost/` | `/help-for-charities/` | Pricing FAQ rolled into help page |
+| `/testimonial/american-legion-ahwatukee-post-64/` | `/#testimonials` | Inlined on homepage |
+| `/testimonial/keith-ray/` | `/#testimonials` | Inlined on homepage |
+| `/testimonial/pardhasaradhi-namburi/` | `/#testimonials` | Inlined on homepage |
+| `/testimonial/tashonda-payne/` | `/#testimonials` | Inlined on homepage |
+| `/donor-dashboard/` | `/donate/` | WP-only logged-in dashboard removed |
+| `/submit-information/` | `/contact-us/` | WP "Coming Soon" Forminator page dropped |
+
+### Dropped archives / WP plumbing (301 → home)
+
+WordPress generates author, category, and Divi-builder taxonomy archives that
+have no Next.js equivalent. Redirect to home to avoid 404s on stray external
+inbound links.
+
+`/author/{adagraves,admin,clarkemoyer,globaladmin,joel,tempmigrationadmin}/`,
+`/category/uncategorized/`, `/layout_type/{row,section}/`,
+`/module_width/regular/`, `/scope/not_global/`, `/sample-page/`,
+`/codetest/`, `/__qs/`.
+
+---
+
+## Operator Steps (Cloudflare Bulk Redirects)
+
+1. Sign in to [dash.cloudflare.com](https://dash.cloudflare.com) → account
+   level (not zone) → **Bulk Redirects**.
+2. Create a new **Bulk Redirect List** named `ffc-wp-to-next-cutover`.
+3. **Import URLs** → upload `docs/cutover-redirects.csv`.
+   - Verify "Status code" maps to the third column (301 for slug/content,
+     302 for the two PayPal return URLs).
+   - For the two PayPal rows, ensure **Preserve query string = enabled** so
+     `?tx=...&st=...` reach `/donate/`.
+4. Create a **Bulk Redirect Rule** that references the list. Scope: HTTP
+   requests to `freeforcharity.org` and `www.freeforcharity.org`.
+5. **Do NOT enable** the rule yet — keep it staged until DNS is flipped.
+   When the cutover deploy goes live, enable the rule in the same maintenance
+   window.
+6. After enabling, smoke-test 5 sample URLs from each category in an
+   incognito browser:
+   - `/free-for-charity-terms-of-service/` → `/terms-of-service/`
+   - `/charity-and-nonprofit-case-studies-…-succeed/` → `/charity-and-nonprofit-case-studies/`
+   - `/testimonial/keith-ray/` → `/#testimonials`
+   - `/donation-confirmation/?tx=ABC123` → `/donate/?tx=ABC123`
+   - `/sample-page/` → `/`
+
+---
+
+## Rollback
+
+If a redirect misroutes high-traffic content, disable the Bulk Redirect rule
+in Cloudflare (single toggle). The list can stay imported — only the rule
+attachment determines whether redirects fire.
+
+---
+
+_Last updated: 2026-05-12_

--- a/docs/cutover-redirects.csv
+++ b/docs/cutover-redirects.csv
@@ -1,0 +1,31 @@
+Source URL,Target URL,Status Code,Preserve Query String,Subpath Matching,Notes
+https://freeforcharity.org/free-for-charity-terms-of-service/,https://freeforcharity.org/terms-of-service/,301,disabled,disabled,Slug shortened in Next.js redesign
+https://freeforcharity.org/charity-and-nonprofit-case-studies-to-help-your-organization-succeed/,https://freeforcharity.org/charity-and-nonprofit-case-studies/,301,disabled,disabled,Slug shortened in Next.js redesign
+https://freeforcharity.org/donation-confirmation/,https://freeforcharity.org/donate/,302,enabled,disabled,PayPal return URL for completed donation; preserve query for PayPal txn params
+https://freeforcharity.org/donation-failed/,https://freeforcharity.org/donate/,302,enabled,disabled,PayPal cancel/return URL for failed donation
+https://freeforcharity.org/free-for-charity-just-earned-the-platinum-seal-of-transparency/,https://freeforcharity.org/blog/,301,disabled,disabled,Legacy blog post; consolidates to /blog index
+https://freeforcharity.org/our-organization-earned-a-2021-platinum-seal-of-transparency/,https://freeforcharity.org/blog/,301,disabled,disabled,Legacy blog post
+https://freeforcharity.org/we-just-updated-for-the-2022-guidestar-platinum-seal/,https://freeforcharity.org/blog/,301,disabled,disabled,Legacy blog post
+https://freeforcharity.org/using-a-registered-agent-service-northwest-registered-agent/,https://freeforcharity.org/blog/,301,disabled,disabled,Legacy blog post
+https://freeforcharity.org/podio-sponsorship-program/,https://freeforcharity.org/help-for-charities/,301,disabled,disabled,Legacy program page; closest content match
+https://freeforcharity.org/what-is-the-cost/,https://freeforcharity.org/help-for-charities/,301,disabled,disabled,Pricing FAQ rolled into help page
+https://freeforcharity.org/testimonial/american-legion-ahwatukee-post-64/,https://freeforcharity.org/#testimonials,301,disabled,disabled,Testimonials now inlined on homepage carousel
+https://freeforcharity.org/testimonial/keith-ray/,https://freeforcharity.org/#testimonials,301,disabled,disabled,Testimonials now inlined on homepage carousel
+https://freeforcharity.org/testimonial/pardhasaradhi-namburi/,https://freeforcharity.org/#testimonials,301,disabled,disabled,Testimonials now inlined on homepage carousel
+https://freeforcharity.org/testimonial/tashonda-payne/,https://freeforcharity.org/#testimonials,301,disabled,disabled,Testimonials now inlined on homepage carousel
+https://freeforcharity.org/author/clarkemoyer/,https://freeforcharity.org/about-us/,301,disabled,disabled,Author archive dropped; closest content
+https://freeforcharity.org/author/joel/,https://freeforcharity.org/about-us/,301,disabled,disabled,Author archive dropped
+https://freeforcharity.org/author/adagraves/,https://freeforcharity.org/about-us/,301,disabled,disabled,Author archive dropped
+https://freeforcharity.org/author/admin/,https://freeforcharity.org/about-us/,301,disabled,disabled,Author archive dropped
+https://freeforcharity.org/author/globaladmin/,https://freeforcharity.org/about-us/,301,disabled,disabled,Author archive dropped
+https://freeforcharity.org/author/tempmigrationadmin/,https://freeforcharity.org/about-us/,301,disabled,disabled,Author archive dropped
+https://freeforcharity.org/category/uncategorized/,https://freeforcharity.org/blog/,301,disabled,disabled,Category archive dropped
+https://freeforcharity.org/sample-page/,https://freeforcharity.org/,301,disabled,disabled,WordPress default sample page; redirect to home
+https://freeforcharity.org/codetest/,https://freeforcharity.org/,301,disabled,disabled,Test page; redirect to home
+https://freeforcharity.org/submit-information/,https://freeforcharity.org/contact-us/,301,disabled,disabled,Was Coming Soon Forminator page; contact-us is the closest replacement
+https://freeforcharity.org/donor-dashboard/,https://freeforcharity.org/donate/,301,disabled,disabled,WP-only logged-in dashboard removed; redirect to donate
+https://freeforcharity.org/__qs/,https://freeforcharity.org/,301,disabled,disabled,WP Query Strings utility page
+https://freeforcharity.org/layout_type/row/,https://freeforcharity.org/,301,disabled,disabled,Divi taxonomy archive
+https://freeforcharity.org/layout_type/section/,https://freeforcharity.org/,301,disabled,disabled,Divi taxonomy archive
+https://freeforcharity.org/module_width/regular/,https://freeforcharity.org/,301,disabled,disabled,Divi taxonomy archive
+https://freeforcharity.org/scope/not_global/,https://freeforcharity.org/,301,disabled,disabled,Divi taxonomy archive


### PR DESCRIPTION
Pre-cutover infrastructure bundle. Three small, independent changes that all need to land before the DNS flip.

## Summary

### 1. Cloudflare Bulk Redirects plan (#27)
- [`docs/cutover-redirects.csv`](docs/cutover-redirects.csv) — 30 redirect entries derived from `wordpress-static-export-2026-02-16` (60 URLs) vs `src/app/` (36 routes).
- [`docs/CUTOVER-REDIRECTS.md`](docs/CUTOVER-REDIRECTS.md) — operator runbook for Cloudflare upload.

**Highlights:**
- 28 slugs match verbatim → no redirect.
- 2 real slug changes (incl. the known `/free-for-charity-terms-of-service/` → `/terms-of-service/`).
- 2 PayPal callback URLs (`/donation-confirmation/`, `/donation-failed/`) configured as **302 with query-string preservation** so PayPal transaction params reach `/donate/`.
- 12 content-consolidation 301s (legacy blog posts → `/blog/`, testimonial pages → `/#testimonials`, etc.).
- 14 dropped WP archives (author/, category/, layout_type/, etc.) → `/`.

### 2. `.gitattributes` LF normalization
One-line `.gitattributes` matching the pattern in `technologyadoptionbarriers.org`. Stops the husky pre-commit hook from failing on Windows checkouts. **Mass `git add --renormalize .` deliberately deferred** to a separate operator run so this PR stays reviewable.

### 3. `ci.yml` `permissions: contents: read`
Clears the pre-existing CodeQL alert `actions/missing-workflow-permissions` (medium severity) that's been red on every PR since CodeQL was wired up.

## Test plan
- [ ] CI checks green (incl. CodeQL — should drop from red to green now)
- [ ] Manually verify `docs/cutover-redirects.csv` row count: 30 rows + 1 header = 31 lines
- [ ] Spot-check redirect map against `wordpress-static-export-2026-02-16` URL list
- [ ] Confirm `.gitattributes` doesn't trigger an immediate diff in CI (it shouldn't — files in the index were already LF)

## What this does NOT do
- Does **not** upload anything to Cloudflare. Requires zone access — see `docs/CUTOVER-REDIRECTS.md` Operator Steps.
- Does **not** renormalize existing files. Add `git add --renormalize . && git commit` as a separate operator action after this merges.

Refs #27 #29