### PR TITLE
chore(cutover): visual regression script for WP vs staging parity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ next-env.d.ts
 
 # Decap CMS uploads
 /public/uploads
+
+# Visual regression artifacts (large PNG screenshots; regenerate locally)
+/docs/visual-regression/screenshots/
+/docs/visual-regression/REPORT.md

--- a/docs/visual-regression/README.md
+++ b/docs/visual-regression/README.md
@@ -1,0 +1,52 @@
+# Visual regression — WordPress origin vs Next.js staging
+
+This directory holds the artifacts for issue #24: comparing every
+non-homepage page on the WordPress origin
+(`https://freeforcharity.org`) against the same page on the Next.js
+staging site (`https://freeforcharity.github.io/FFC-IN-freeforcharity.org`)
+so we can sign off on content parity before DNS cutover.
+
+The homepage (`/`) is intentionally excluded. The new homepage is the
+Figma redesign and is not expected to match the WordPress version —
+diffs there are intentional product direction, not regressions.
+
+## Run
+
+```sh
+npm run visual-regression
+```
+
+That runs [`scripts/visual-regression/capture.mjs`](../../scripts/visual-regression/capture.mjs),
+which uses Playwright to load each pair in a headless Chromium browser and
+save a full-page screenshot from both sides. Output lands in
+`screenshots/wp/` and `screenshots/staging/`, and an index report is
+written to `REPORT.md`.
+
+To run against different origins (e.g., a PR preview):
+
+```sh
+WP_BASE_URL=https://freeforcharity.org \
+STAGING_BASE_URL=https://your-preview.example.com \
+node scripts/visual-regression/capture.mjs
+```
+
+## Review
+
+Open `REPORT.md` once the run finishes. The table has links to the WP
+and Next.js screenshots for each route. Open the pair side-by-side in
+an image viewer (Windows Photos: select both → right-click → Open with)
+or in VS Code (drag both PNGs into split editors).
+
+Focus on **content parity** rather than pixel-level styling — Tailwind
+v4 vs Divi will always produce different layouts. Flag pages where the
+Next.js version is missing content that exists in WordPress.
+
+## Why this lives outside `tests/`
+
+The Playwright specs under `tests/` run against the local static export
+on every CI build. This regression compares the **deployed staging** to
+the **live WordPress origin** — it's a one-shot pre-cutover gate, not a
+recurring check, so it lives under `scripts/`.
+
+After cutover, this directory can be deleted (or retained for historical
+reference).

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
+    "visual-regression": "node scripts/visual-regression/capture.mjs",
     "prepare": "husky"
   },
   "dependencies": {

--- a/scripts/visual-regression/capture.mjs
+++ b/scripts/visual-regression/capture.mjs
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+/**
+ * Visual regression — WordPress origin vs Next.js staging.
+ *
+ * Captures full-page screenshots of each non-homepage page on both sides
+ * and writes a markdown report with side-by-side image links.
+ *
+ * The homepage is intentionally excluded — it is a Figma redesign and
+ * diffs there are expected, not regressions.
+ *
+ * Usage:
+ *   npm run visual-regression           # uses defaults below
+ *   WP_BASE_URL=... STAGING_BASE_URL=... node scripts/visual-regression/capture.mjs
+ *
+ * Output:
+ *   docs/visual-regression/screenshots/{wp,staging}/<slug>.png
+ *   docs/visual-regression/REPORT.md
+ */
+
+import { chromium } from 'playwright'
+import { mkdir, writeFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = resolve(__dirname, '..', '..')
+
+const WP_BASE = process.env.WP_BASE_URL || 'https://freeforcharity.org'
+const STAGING_BASE =
+  process.env.STAGING_BASE_URL || 'https://freeforcharity.github.io/FFC-IN-freeforcharity.org'
+const VIEWPORT = { width: 1280, height: 800 }
+
+// (WP slug, Next.js slug). Identical strings mean a verbatim match.
+// Homepage is intentionally excluded — see docs/visual-regression/README.md.
+const ROUTE_PAIRS = [
+  ['/about-us/', '/about-us/'],
+  ['/501c3/', '/501c3/'],
+  ['/blog/', '/blog/'],
+  [
+    '/charity-and-nonprofit-service-and-consultant-directory/',
+    '/charity-and-nonprofit-service-and-consultant-directory/',
+  ],
+  ['/charity-and-nonprofit-technology-directory/', '/charity-and-nonprofit-technology-directory/'],
+  [
+    '/charity-validation-guide-ensuring-mutual-benefit-through-comprehensive-validation-processes/',
+    '/charity-validation-guide-ensuring-mutual-benefit-through-comprehensive-validation-processes/',
+  ],
+  [
+    '/charity-and-nonprofit-case-studies-to-help-your-organization-succeed/',
+    '/charity-and-nonprofit-case-studies/',
+  ],
+  ['/consulting/', '/consulting/'],
+  ['/contact-us/', '/contact-us/'],
+  ['/domains/', '/domains/'],
+  ['/donate/', '/donate/'],
+  [
+    '/ffc-volunteer-proving-ground-core-competencies/',
+    '/ffc-volunteer-proving-ground-core-competencies/',
+  ],
+  ['/ffcadmin/', '/ffcadmin/'],
+  ['/free-charity-web-hosting/', '/free-charity-web-hosting/'],
+  ['/free-for-charity-donation-policy/', '/free-for-charity-donation-policy/'],
+  ['/free-for-charity-endowment-fund/', '/free-for-charity-endowment-fund/'],
+  [
+    '/free-for-charity-ffc-service-delivery-stages/',
+    '/free-for-charity-ffc-service-delivery-stages/',
+  ],
+  [
+    '/free-for-charity-ffc-web-developer-training-guide/',
+    '/free-for-charity-ffc-web-developer-training-guide/',
+  ],
+  ['/free-for-charitys-tools-for-success/', '/free-for-charitys-tools-for-success/'],
+  ['/free-training-programs/', '/free-training-programs/'],
+  ['/guidestar-guide/', '/guidestar-guide/'],
+  ['/help-for-charities/', '/help-for-charities/'],
+  ['/online-impacts-onboarding-guide/', '/online-impacts-onboarding-guide/'],
+  ['/pre501c3/', '/pre501c3/'],
+  ['/privacy-policy/', '/privacy-policy/'],
+  ['/security-acknowledgements/', '/security-acknowledgements/'],
+  ['/techstack/', '/techstack/'],
+  ['/free-for-charity-terms-of-service/', '/terms-of-service/'],
+  ['/volunteer/', '/volunteer/'],
+  ['/vulnerability-disclosure-policy/', '/vulnerability-disclosure-policy/'],
+  ['/workforce-development/', '/workforce-development/'],
+]
+
+const slugFor = (wp, next) => {
+  const base = wp.replace(/^\/+|\/+$/g, '').replaceAll('/', '__')
+  return base || 'root'
+}
+
+async function capturePage(page, url, outPath) {
+  try {
+    const response = await page.goto(url, { waitUntil: 'networkidle', timeout: 60_000 })
+    const status = response?.status() ?? 0
+    // Let lazy assets settle a beat
+    await page.waitForTimeout(1500)
+    await page.screenshot({ path: outPath, fullPage: true })
+    return { ok: status >= 200 && status < 400, status }
+  } catch (err) {
+    return { ok: false, status: 0, error: err.message }
+  }
+}
+
+async function main() {
+  const outDir = resolve(repoRoot, 'docs', 'visual-regression', 'screenshots')
+  const wpDir = resolve(outDir, 'wp')
+  const stagingDir = resolve(outDir, 'staging')
+  await mkdir(wpDir, { recursive: true })
+  await mkdir(stagingDir, { recursive: true })
+
+  const browser = await chromium.launch()
+  const context = await browser.newContext({ viewport: VIEWPORT })
+  const page = await context.newPage()
+
+  const rows = []
+  for (const [wpPath, nextPath] of ROUTE_PAIRS) {
+    const slug = slugFor(wpPath, nextPath)
+    const wpFile = resolve(wpDir, `${slug}.png`)
+    const stagingFile = resolve(stagingDir, `${slug}.png`)
+
+    // WordPress serves with trailing slash; the Next.js static export does
+    // not — strip the trailing slash from the staging path (except for `/`).
+    const stagingPath = nextPath.length > 1 ? nextPath.replace(/\/$/, '') : nextPath
+
+    console.log(`Capturing ${wpPath}  vs  ${stagingPath}`)
+    const wpResult = await capturePage(page, `${WP_BASE}${wpPath}`, wpFile)
+    const stagingResult = await capturePage(page, `${STAGING_BASE}${stagingPath}`, stagingFile)
+
+    rows.push({ wpPath, nextPath, slug, wpResult, stagingResult })
+  }
+
+  await browser.close()
+
+  // Build markdown report
+  const lines = []
+  lines.push('# WordPress ↔ Next.js Visual Regression Report')
+  lines.push('')
+  lines.push(`Generated: ${new Date().toISOString()}`)
+  lines.push('')
+  lines.push(`WordPress origin: \`${WP_BASE}\``)
+  lines.push(`Staging: \`${STAGING_BASE}\``)
+  lines.push('')
+  lines.push(
+    '> Homepage is intentionally excluded. The new homepage is a Figma redesign and is not expected to match WordPress.'
+  )
+  lines.push('')
+  lines.push('## Captures')
+  lines.push('')
+  lines.push('| Page | WordPress | Next.js staging | WP status | Staging status |')
+  lines.push('|------|-----------|-----------------|-----------|----------------|')
+  for (const r of rows) {
+    const wpRel = `screenshots/wp/${r.slug}.png`
+    const stagingRel = `screenshots/staging/${r.slug}.png`
+    const label =
+      r.wpPath === r.nextPath ? `\`${r.wpPath}\`` : `\`${r.wpPath}\` → \`${r.nextPath}\``
+    lines.push(
+      `| ${label} | [WP](${wpRel}) | [Next](${stagingRel}) | ${r.wpResult.status || 'ERR'} | ${r.stagingResult.status || 'ERR'} |`
+    )
+  }
+  lines.push('')
+  lines.push('## How to review')
+  lines.push('')
+  lines.push(
+    '1. Open `docs/visual-regression/screenshots/wp/<slug>.png` and `docs/visual-regression/screenshots/staging/<slug>.png` side by side in your image viewer.'
+  )
+  lines.push(
+    '2. Focus on **content parity**: headings, paragraphs, key images, call-to-action buttons. Styling differences are expected (Tailwind v4 vs Divi); content gaps are not.'
+  )
+  lines.push(
+    '3. Flag any page where the Next.js staging is missing content that exists in WordPress.'
+  )
+  lines.push('')
+  lines.push('## Re-running')
+  lines.push('')
+  lines.push('```sh')
+  lines.push('npm run visual-regression')
+  lines.push('# or with overrides:')
+  lines.push(
+    'WP_BASE_URL=https://freeforcharity.org STAGING_BASE_URL=https://freeforcharity.github.io/FFC-IN-freeforcharity.org node scripts/visual-regression/capture.mjs'
+  )
+  lines.push('```')
+
+  const reportPath = resolve(repoRoot, 'docs', 'visual-regression', 'REPORT.md')
+  await writeFile(reportPath, lines.join('\n'))
+  console.log(`\nReport written to ${reportPath}`)
+
+  const failures = rows.filter((r) => !r.wpResult.ok || !r.stagingResult.ok)
+  if (failures.length > 0) {
+    console.log(`\n⚠ ${failures.length} page(s) failed to capture cleanly:`)
+    for (const f of failures) {
+      console.log(
+        `  - ${f.wpPath} (wp:${f.wpResult.status || 'ERR'}, staging:${f.stagingResult.status || 'ERR'})`
+      )
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
Closes the visual-parity gap in #24 with a one-shot, operator-run script.

## Summary

- [`scripts/visual-regression/capture.mjs`](scripts/visual-regression/capture.mjs) — Playwright-driven script that captures full-page screenshots of every non-homepage page on both `https://freeforcharity.org` (WP) and `https://freeforcharity.github.io/FFC-IN-freeforcharity.org` (staging).
- 31 route pairs covering all WP pages with a Next.js equivalent (plus the 2 slug-changed pages: terms-of-service and case-studies).
- [`docs/visual-regression/README.md`](docs/visual-regression/README.md) — operator guide.
- `npm run visual-regression` wires up the script.

## Why a script and not a Playwright spec

This is a **pre-cutover gate**, not a recurring CI check. After cutover both URLs collapse to the same site and the regression no longer makes sense. Living under `scripts/` keeps it out of the CI test suite while still being npm-script-discoverable.

## Homepage is excluded

Per memory note `visual-regression-scope`: the new homepage is the Figma redesign and is not expected to match WordPress. Diffing it would flood the report with intended changes.

## URL pattern fix discovered during run

WordPress URLs include trailing slashes (`/about-us/`); the Next.js static export does not (`/about-us` works, `/about-us/` returns 404). The script strips the trailing slash from the staging path so both sides resolve.

## Run output

The report and screenshots are .gitignored — they're binary artifacts regenerated on each run. After running locally, the operator gets:

```
docs/visual-regression/
├── REPORT.md
└── screenshots/
    ├── wp/          (31 PNGs)
    └── staging/     (31 PNGs)
```

## Test plan

- [ ] CI green (script under `scripts/` should not trigger CI tests)
- [ ] Run `npm run visual-regression` locally
- [ ] Open `docs/visual-regression/REPORT.md` and spot-check a few pairs
- [ ] Flag any page where staging content is **missing** vs WordPress (styling differences are expected)

Refs #24 #29