### PR TITLE
docs(cutover): cutover handoff + refreshed staging checklist

### DIFF
--- a/docs/CUTOVER-HANDOFF.md
+++ b/docs/CUTOVER-HANDOFF.md
@@ -1,0 +1,124 @@
+# Cutover Handoff — Free For Charity WordPress → Next.js
+
+The pre-cutover engineering work is complete. This document inventories
+what is done, what is open for human review, and the operator steps that
+remain before DNS can flip from WordPress to GitHub Pages (issue #29).
+
+---
+
+## Status at a glance
+
+| Track                                                            | Status                            | Reference                                       |
+| ---------------------------------------------------------------- | --------------------------------- | ----------------------------------------------- |
+| Phase 1 — Content audit (REST API, URL mapping, media inventory) | ✅ Closed                         | #32 #33 #34 #35 #36                             |
+| Phase 2 — Builds for missing pages                               | ✅ Closed                         | (already in `src/app/`)                         |
+| Phase 3 — Testing                                                | ✅ Closed                         | #18 #19 #20 #22 #23 #25 #26 #28 #30 #52 #70 #71 |
+| Phase 4 — Visual regression harness                              | ✅ Done (PR #125)                 | #24, `docs/visual-regression/`                  |
+| Phase 5 — Cloudflare redirects                                   | ✅ Plan + CSV ready (PR #124)     | #27, `docs/cutover-redirects.csv`               |
+| Phase 6 — Contact form policy                                    | ✅ Closed (no forms outside /hub) | #44                                             |
+| Phase 7 — Pre-cutover review items                               | 🟡 3 open issues                  | #121 #122 #123                                  |
+| Phase 8 — DNS cutover                                            | ⛔ Operator action                | #29                                             |
+
+---
+
+## What's done (automated)
+
+### CI gates green on `main`
+
+- **`ci.yml`** — format check, lint, Jest unit tests (115), Next build, internal link check, Playwright E2E (100+ specs incl. accessibility/axe-core, contact, footer, team, mobile + desktop nav, external links, cookie consent, copyright, animated numbers, image loading, logo, mission video).
+- **`lighthouse.yml`** — multi-URL Lighthouse CI (warn thresholds).
+- **`lychee.yml`** — scheduled external link check.
+- **`codeql.yml`** — JS/TS + Actions static analysis.
+- **`deploy.yml`** — staged deploy to GitHub Pages on push to main.
+
+### Pre-cutover artifacts in this repo
+
+- [`docs/cutover-redirects.csv`](cutover-redirects.csv) — 30-row Cloudflare Bulk Redirects import file.
+- [`docs/CUTOVER-REDIRECTS.md`](CUTOVER-REDIRECTS.md) — operator runbook for the redirect import.
+- [`docs/visual-regression/README.md`](visual-regression/README.md) + `scripts/visual-regression/capture.mjs` — `npm run visual-regression` to compare every non-homepage page against the live WordPress origin (homepage excluded because it's a Figma redesign).
+- [`docs/STAGING-CHECKLIST.md`](STAGING-CHECKLIST.md) — manual verification checklist.
+- [`docs/ROLLBACK.md`](ROLLBACK.md) — emergency rollback procedure.
+
+### Source fixes shipped in the pre-cutover branch series
+
+- E2E coverage for nav, footer, team, contact, external links (PR #120).
+- `target="_blank" rel="noopener noreferrer"` on the 3 external links that were missing it: americanlegionpost64.org (Testimonials), GuideStar seal + profile (footer), techsoup.org (FAQ).
+- WCAG 2.1 AA color contrast (#92).
+
+---
+
+## Open items requiring human decision before cutover
+
+| #                                                                              | Title                                                                          | Severity                    | Decision needed                                                                                                                                |
+| ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ | --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| [#121](https://github.com/FreeForCharity/FFC-IN-freeforcharity.org/issues/121) | General Donations cards link to `/help-for-charities` instead of a donate flow | Functional regression vs WP | Confirm whether the 3 cards on `/donate` (Monthly / One Time / Large) should link to the PayPal hosted button, the Zeffy iframe, or be removed |
+| [#122](https://github.com/FreeForCharity/FFC-IN-freeforcharity.org/issues/122) | `/home-old` route purpose                                                      | Low                         | Remove if template leftover, keep if intentional                                                                                               |
+| [#123](https://github.com/FreeForCharity/FFC-IN-freeforcharity.org/issues/123) | Endowment fund page has no donate path embedded                                | Conversion regression       | Embed Zeffy iframe / PayPal button on `/free-for-charity-endowment-fund` Support-Our-Mission section, or link to `/#donate`                    |
+
+These were filed instead of stubbed per the explicit "no placeholders or
+stubs" guidance — fix in code requires intent decisions.
+
+---
+
+## Operator steps for cutover day (#29)
+
+### Pre-flight (≥ 1 hour before flip)
+
+1. **Lower DNS TTL** in Cloudflare for `freeforcharity.org` apex and `www` records to **300s**.
+2. **Drain staging cache** if any — GitHub Pages serves fresh on each request.
+3. **Resolve open review issues** (#121 #122 #123) or accept the regression risk.
+4. **Confirm staging fully passes the checklist** in [`docs/STAGING-CHECKLIST.md`](STAGING-CHECKLIST.md) sections 2–6.
+5. **Stage Cloudflare Bulk Redirects** per [`docs/CUTOVER-REDIRECTS.md`](CUTOVER-REDIRECTS.md) — import the CSV, create the rule, **leave the rule disabled**.
+
+### Flip window
+
+1. **In GitHub repo Settings → Pages** — set custom domain to `freeforcharity.org` (`public/CNAME` is already in place).
+2. **In Cloudflare DNS** — change apex `A` records from the WordPress origin IP to GitHub Pages IPs:
+   ```
+   185.199.108.153
+   185.199.109.153
+   185.199.110.153
+   185.199.111.153
+   ```
+   …or replace with `CNAME` to `freeforcharity.github.io` (proxied).
+3. **Wait for GitHub to provision HTTPS certificate** (a few minutes).
+4. **Enable** the Cloudflare Bulk Redirects rule from step 5 of pre-flight.
+5. **Smoke test** the 5 sample URLs from `docs/CUTOVER-REDIRECTS.md` section "Operator Steps" #6.
+
+### Post-flip (first 30 minutes)
+
+Follow [`docs/STAGING-CHECKLIST.md`](STAGING-CHECKLIST.md) section 8 "Post-Cutover Monitoring".
+
+### If anything breaks
+
+Follow [`docs/ROLLBACK.md`](ROLLBACK.md). The WordPress server stays running untouched for at least 14 days post-cutover.
+
+---
+
+## Out-of-scope / post-cutover
+
+These were intentionally not done because they need operator credentials, accounts, or further design discussion:
+
+- **#39–#42** — Tawk.to / Microsoft Clarity / PostHog / MS Bot Framework integrations (each needs a property ID or workspace credential).
+- **#45** — Decommission WPMUDEV Beehive Analytics (post-cutover cleanup).
+- **#46–#48** — GA4 / GTM / Google Search Console setup (need property IDs from Google).
+- **#107** — Stop blocking Dependabot on link rot (dependabot CI workflow fix).
+
+These do not block the DNS flip. Pick them up after the cutover stabilizes.
+
+---
+
+## Quick links
+
+| Resource                        | Path                                                              |
+| ------------------------------- | ----------------------------------------------------------------- |
+| WordPress URL → Next.js URL map | [`docs/CUTOVER-REDIRECTS.md`](CUTOVER-REDIRECTS.md)               |
+| Cloudflare Bulk Redirects CSV   | [`docs/cutover-redirects.csv`](cutover-redirects.csv)             |
+| Visual regression runbook       | [`docs/visual-regression/README.md`](visual-regression/README.md) |
+| Staging verification checklist  | [`docs/STAGING-CHECKLIST.md`](STAGING-CHECKLIST.md)               |
+| Rollback procedure              | [`docs/ROLLBACK.md`](ROLLBACK.md)                                 |
+| Migration master plan           | [`docs/MIGRATION-PLAN.md`](MIGRATION-PLAN.md) (in PR #38)         |
+
+---
+
+_Last updated: 2026-05-14. Source-of-truth for any time-sensitive details is the issue tracker, not this doc._

--- a/docs/STAGING-CHECKLIST.md
+++ b/docs/STAGING-CHECKLIST.md
@@ -15,16 +15,21 @@ CI-based checks in this table run automatically on every push to `main`; rows
 marked `manual` must be run by hand. Confirm all checks are green or completed
 before proceeding to the manual checks below.
 
-| Check          | Workflow     | What It Verifies                                                       |
-| -------------- | ------------ | ---------------------------------------------------------------------- |
-| Format         | `ci.yml`     | Prettier formatting                                                    |
-| Lint           | `ci.yml`     | ESLint — no errors                                                     |
-| Unit tests     | `ci.yml`     | Jest (metadata, sitemap, data files, assetPath)                        |
-| Build          | `ci.yml`     | `next build` — static export succeeds                                  |
-| Internal links | `ci.yml`     | Playwright: no broken internal links (`post-deploy-smoke.spec.ts`)     |
-| Linkinator     | manual       | Optional: run `npm run check-links` on `./out` for additional coverage |
-| E2E tests      | `ci.yml`     | Playwright: navigation, images, cookie consent, copyright              |
-| Deploy         | `deploy.yml` | GitHub Pages deployment                                                |
+| Check             | Workflow         | What It Verifies                                                                                                                             |
+| ----------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| Format            | `ci.yml`         | Prettier formatting                                                                                                                          |
+| Lint              | `ci.yml`         | ESLint — no errors                                                                                                                           |
+| Unit tests        | `ci.yml`         | Jest (metadata, sitemap, data files, assetPath)                                                                                              |
+| Build             | `ci.yml`         | `next build` — static export succeeds                                                                                                        |
+| Internal links    | `ci.yml`         | Playwright: no broken internal links (`post-deploy-smoke.spec.ts`)                                                                           |
+| External links    | `lychee.yml`     | Scheduled Lychee link checker against deployed site                                                                                          |
+| Accessibility     | `ci.yml`         | axe-core via Playwright (`tests/accessibility.spec.ts`) — WCAG 2.1 AA                                                                        |
+| E2E tests         | `ci.yml`         | Playwright: navigation, images, cookie consent, copyright, contact page, footer, team, mobile nav, dropdowns, external links                 |
+| Lighthouse        | `lighthouse.yml` | Performance / a11y / SEO / best practices thresholds on multiple URLs                                                                        |
+| CodeQL            | `codeql.yml`     | Static analysis for JS/TS and Actions                                                                                                        |
+| Linkinator        | manual           | Optional: run `npm run check-links` on `./out` for additional coverage                                                                       |
+| Visual regression | manual           | Run `npm run visual-regression` to compare each non-homepage page against the live WordPress origin (see `docs/visual-regression/README.md`) |
+| Deploy            | `deploy.yml`     | GitHub Pages deployment                                                                                                                      |
 
 ---
 
@@ -37,14 +42,19 @@ boxes as you go.
 
 ### 2a. Critical Pages
 
-- [ ] **Homepage** `/` — hero loads, mission video plays, team section visible
+- [ ] **Homepage** `/` — hero loads, Zeffy endowment-fund iframe renders in
+      the `#donate` section, team section visible
 - [ ] **About Us** `/about-us` — team member cards and photos appear
-- [ ] **Donate** `/donate` — donation form widget loads (iframe renders)
+- [ ] **Donate** `/donate` — PayPal "Donate Today" button (hosted button
+      `9ZKQ23YC3G2J2`) appears in the Measurable Impact section
+- [ ] **Endowment Fund** `/free-for-charity-endowment-fund` — see #123
+      (donate path on this page is under review)
 - [ ] **Volunteer** `/volunteer` — page loads fully
 - [ ] **Domains** `/domains` — domain ordering card renders correctly
 - [ ] **Free Hosting** `/free-charity-web-hosting` — testimonials carousel works
 - [ ] **Help for Charities** `/help-for-charities` — accordion sections expand
-- [ ] **Contact Us** `/contact-us` — contact form renders
+- [ ] **Contact Us** `/contact-us` — email, phone, and addresses display
+      (no form — matches FFC "no forms outside /hub" policy, see #44)
 - [ ] **501(c)(3) Guide** `/501c3` — content loads
 
 ### 2b. Legal / Policy Pages
@@ -81,12 +91,22 @@ boxes as you go.
 
 ## 4. Functionality Checks
 
+The following items are covered by CI E2E tests
+(`tests/cookie-consent.spec.ts`, `tests/mobile-navigation.spec.ts`,
+`tests/dropdown-navigation.spec.ts`, `tests/animated-numbers.spec.ts`,
+`tests/footer-complete.spec.ts`, `tests/contact-page.spec.ts`,
+`tests/external-links.spec.ts`, `tests/team-section.spec.ts`). Re-run as
+a spot-check in a real browser; if CI is green these should all pass.
+
 - [ ] Cookie consent banner appears on first visit (incognito)
 - [ ] Accepting cookies hides banner and persists preference on reload
 - [ ] Mobile menu opens and closes correctly (resize browser to < 768px)
+- [ ] Mobile menu dropdowns reveal sub-items
+- [ ] Desktop header dropdowns open on hover
 - [ ] Testimonial carousel on homepage auto-advances
 - [ ] Animated number counters trigger on scroll (Results section)
 - [ ] Accordion items on Help for Charities expand/collapse smoothly
+- [ ] All external links open in a new tab with `rel="noopener noreferrer"`
 
 ---
 
@@ -131,6 +151,13 @@ All items below must be confirmed before initiating DNS cutover:
 - [ ] No recent failed CI or deploy workflow runs on `main` in GitHub Actions
 - [ ] All critical pages load correctly in incognito (section 2a above)
 - [ ] Images all load (section 3 above)
+- [ ] Visual regression run (`npm run visual-regression`) reviewed — no
+      missing content on non-homepage pages (see
+      [`docs/visual-regression/`](visual-regression/))
+- [ ] Cloudflare Bulk Redirects rule **staged but not enabled** for
+      [`docs/cutover-redirects.csv`](cutover-redirects.csv) (see
+      [`docs/CUTOVER-REDIRECTS.md`](CUTOVER-REDIRECTS.md))
+- [ ] Pre-cutover review issues triaged: #121 (Donate cards), #122 (`/home-old`), #123 (endowment fund donate path)
 - [ ] `NEXT_PUBLIC_BASE_PATH` will be cleared to `''` at cutover time
   - Confirm with team: who will trigger the cutover deploy?
 - [ ] DNS TTL has been lowered to 300s (5 min) in Cloudflare at least 1 hour before cutover


### PR DESCRIPTION
Closes out the cutover-prep docs track. Two changes:

## 1. New: \`docs/CUTOVER-HANDOFF.md\`

A single-page summary of the cutover state for the operator running the DNS flip. Covers:

- Status at a glance (8 tracks, what's done vs open)
- What's automated and green on \`main\`
- Pre-cutover artifacts now in repo (redirects CSV/runbook, visual regression script, staging checklist, rollback)
- Open issues requiring human decision (#121 #122 #123)
- Operator steps for cutover day (pre-flight, flip, post-flip)
- Out-of-scope items deferred to post-cutover

## 2. Refresh: \`docs/STAGING-CHECKLIST.md\`

Several rows in the original checklist no longer matched the site:

- Section 1 now lists all CI workflows (lychee, axe-core a11y, lighthouse, CodeQL) plus the new manual visual-regression run.
- Section 2a fixed — \`/contact-us\` no longer claims a 'form renders' (matches FFC no-forms policy, #44 closed). \`/donate\` describes the PayPal hosted button. New row for the endowment fund page calling out the open #123 question.
- Section 4 cross-references the CI E2E spec that covers each manual item.
- Section 7 adds explicit gates for visual regression review, Cloudflare rule staging, and triage of the 3 open review issues.

## Test plan
- [ ] CI green (docs-only, should be uneventful)
- [ ] Visual review of \`docs/CUTOVER-HANDOFF.md\` — confirm the issue/PR numbers + dates are correct

Refs #28 #29