### PR TITLE
fix(donate): Large Donations card uses correct PayPal button (WP parity)

### DIFF
--- a/src/components/donate-components/General-donation/index.tsx
+++ b/src/components/donate-components/General-donation/index.tsx
@@ -28,7 +28,7 @@ const index = () => {
             title="Large Donations"
             description="For large donations we can work directly with the donor and earmark the funds for a particular project of personal significance. This can be as simple as saying that your donation should be used for the technology programs vs. the business programs or more involved such as that the funds should be used to assist one particular local charity you support"
             img="/Images/payment.gif"
-            href="https://www.paypal.com/donate/?hosted_button_id=9ZKQ23YC3G2J2"
+            href="https://www.paypal.com/donate/?hosted_button_id=243G37NHXSRY8"
           />
         </div>
       </div>


### PR DESCRIPTION
## Why

The pre-cutover audit on `wordpress-static-export-2026-02-16/donate/index.html` shows two distinct PayPal hosted buttons on the WP donate page:

| Section | Hosted button ID |
|---------|------------------|
| Standard / Donate Today CTA | `9ZKQ23YC3G2J2` |
| Large Donations | `243G37NHXSRY8` |

PR #127 wired all three General Donations cards to `9ZKQ23YC3G2J2` to match the page's "Donate Today" CTA, but didn't catch the second button used for the Large Donations section in WordPress.

## Fix

Update the Large Donations card to point at `243G37NHXSRY8` so a donor clicking that card lands on the same PayPal flow they did on the WordPress site.

## Test plan

- [x] `npm run build` succeeds
- [ ] CI green
- [ ] Manual smoke on staging: clicking 'Large Donations' card opens `paypal.com/donate/?hosted_button_id=243G37NHXSRY8` in a new tab

Refs #43 #29
EOF
)