### PR TITLE
revert: remove duplicate Zeffy iframe on Support-Our-Mission

### DIFF
--- a/src/components/free-for-charity-endowment-fund-components/Support-Our-Mission/index.tsx
+++ b/src/components/free-for-charity-endowment-fund-components/Support-Our-Mission/index.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, IframeHTMLAttributes } from 'react'
+import React from 'react'
 import { assetPath } from '@/lib/assetPath'
 
 interface SupportMissionSectionProps {
@@ -7,38 +7,13 @@ interface SupportMissionSectionProps {
   description2?: string
 }
 
-interface ExtendedIframeProps extends IframeHTMLAttributes<HTMLIFrameElement> {
-  allowpaymentrequest?: string
-  allowtransparency?: string
-}
-
 const SupportMissionSection: React.FC<SupportMissionSectionProps> = ({
   title = 'Support Our Mission',
   description1 = 'Join us in reaching our $1,000,000 Endowment goal to ensure sustainable support for our US based 501c3 charities.',
   description2 = 'Your contribution will help provide free domain names and essential email services to nonprofits, enabling them to focus on their missions without the burden of digital costs. Every donation brings us closer to empowering more charities with the tools they need to succeed.',
 }) => {
-  const donationFormStyle: CSSProperties = {
-    position: 'absolute',
-    border: '0',
-    top: 0,
-    left: 0,
-    bottom: 0,
-    right: 0,
-    width: '100%',
-    height: '100%',
-  }
-
-  const donationFormProps: ExtendedIframeProps = {
-    title: 'Donation form powered by Zeffy',
-    style: donationFormStyle,
-    src: 'https://www.zeffy.com/embed/donation-form/free-for-charity-endowment-fund',
-    allowpaymentrequest: '',
-    allowtransparency: 'true',
-  }
-
   return (
     <section
-      id="donate"
       className="pt-[90px] pb-[90px] bg-[#003566] md:min-h-screen flex items-center justify-center p-6
       sm:pt-[60px] sm:pb-[60px] sm:p-4"
       style={{
@@ -51,43 +26,31 @@ const SupportMissionSection: React.FC<SupportMissionSectionProps> = ({
         backgroundRepeat: 'no-repeat',
       }}
     >
-      <div className="w-full max-w-[1200px] flex flex-col lg:flex-row gap-[40px] items-center">
-        <div
-          className="bg-white rounded-[6px] shadow-[0px_24px_72px_-12px_rgba(0,0,0,0.12)] p-[40px] max-w-[540px] text-center
-        sm:p-[24px] sm:max-w-[540px] w-[100%]"
+      <div
+        className="bg-white rounded-[6px] shadow-[0px_24px_72px_-12px_rgba(0,0,0,0.12)] p-[40px] max-w-[540px] text-center
+      sm:p-[24px] sm:max-w-[540px] w-[100%]"
+      >
+        <h1
+          className="text-[32px] font-[500] text-gray-900 mb-[10px] pb-[10px] sm:leading-[60px]
+          sm:text-[50px] leading-[40px]"
+          id="cinzel"
         >
-          <h1
-            className="text-[32px] font-[500] text-gray-900 mb-[10px] pb-[10px] sm:leading-[60px]
-            sm:text-[50px] leading-[40px]"
-            id="cinzel"
-          >
-            {title}
-          </h1>
-          <p
-            className="sm:text-[16px] font-[500] text-[#000000a3] mb-6 sm:leading-[28px]
-            text-[14px] leading-[24px]"
-            id="fauna-font"
-          >
-            {description1}
-          </p>
-          <p
-            className="sm:text-[16px] font-[500] text-[#000000a3] mb-6 sm:leading-[28px]
-            text-[14px] leading-[24px]"
-            id="fauna-font"
-          >
-            {description2}
-          </p>
-        </div>
-
-        <div className="w-full lg:w-[50%] flex justify-center">
-          <div
-            className="relative w-full max-w-[500px] h-[600px] bg-white rounded-lg shadow-lg overflow-hidden"
-            role="region"
-            aria-label="Endowment fund donation form"
-          >
-            <iframe {...donationFormProps}></iframe>
-          </div>
-        </div>
+          {title}
+        </h1>
+        <p
+          className="sm:text-[16px] font-[500] text-[#000000a3] mb-6 sm:leading-[28px]
+          text-[14px] leading-[24px]"
+          id="fauna-font"
+        >
+          {description1}
+        </p>
+        <p
+          className="sm:text-[16px] font-[500] text-[#000000a3] mb-6 sm:leading-[28px]
+          text-[14px] leading-[24px]"
+          id="fauna-font"
+        >
+          {description2}
+        </p>
       </div>
     </section>
   )


### PR DESCRIPTION
## Why

PR #127 added a Zeffy donation iframe to the endowment fund page's `Support-Our-Mission` section to resolve #123 ("endowment fund page has no donate path"). On closer review against deployed staging, **the same iframe was already present in the page's `Empower-Charities` section** (along with a Zeffy thermometer embed).

Two donation forms on one page is duplicate content and a worse UX than one. The page's established donate moment is `Empower-Charities`.

## Fix

Revert `Support-Our-Mission/index.tsx` to its pre-#127 text-only state. Verified with `curl` against staging that `/free-for-charity-endowment-fund` still surfaces the Zeffy donation-form iframe via `Empower-Charities` — donate path is preserved.

## Test plan

- [x] `npm run build` succeeds
- [x] grep confirms `zeffy.com/embed/donation-form/free-for-charity-endowment-fund` still appears in `src/components/free-for-charity-endowment-fund-components/Empower-Charities/index.tsx`
- [ ] CI green
- [ ] Manual smoke on staging: endowment fund page has exactly one donation-form iframe

Refs #123 #29