### PR TITLE
fix(visual-regression): use 'load' wait so pages with live iframes capture

### DIFF
--- a/scripts/visual-regression/capture.mjs
+++ b/scripts/visual-regression/capture.mjs
@@ -92,10 +92,14 @@ const slugFor = (wp, next) => {
 
 async function capturePage(page, url, outPath) {
   try {
-    const response = await page.goto(url, { waitUntil: 'networkidle', timeout: 60_000 })
+    // Use 'load' (not 'networkidle') because pages with live third-party
+    // iframes (Zeffy donation forms) keep polling and never reach
+    // networkidle within a reasonable timeout.
+    const response = await page.goto(url, { waitUntil: 'load', timeout: 45_000 })
     const status = response?.status() ?? 0
-    // Let lazy assets settle a beat
-    await page.waitForTimeout(1500)
+    // Let lazy assets and animations settle. Longer than strictly
+    // necessary for static pages but safe across the board.
+    await page.waitForTimeout(3000)
     await page.screenshot({ path: outPath, fullPage: true })
     return { ok: status >= 200 && status < 400, status }
   } catch (err) {


### PR DESCRIPTION
## Why

The Zeffy donation iframes on the endowment fund page keep polling, so the page never reaches Playwright's `networkidle` state. Every visual-regression run timed out on `/free-for-charity-endowment-fund/` (both WP origin and Next.js staging marked ERR in the report) despite both URLs returning HTTP 200 in a normal browser.

## Fix

Switch `page.goto(..., { waitUntil: 'load', timeout: 45_000 })` and bump the post-load settle from 1.5s to 3s. Captures complete reliably across all 31 page pairs, including those with third-party widgets.

## Test plan

- [x] Local re-run captures the endowment fund page successfully (verified after fix)
- [ ] CI green

Refs #24 #29