### PR TITLE
fix(htaccess): serve clean URLs around Next.js RSC sidecar dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ next-env.d.ts
 
 # cPanel backup tarballs from scripts/cpanel-backup.sh — huge, sensitive
 /cpanel-backups/
+
+# Claude Code on the web — subagent worktree checkouts
+/.claude/worktrees/

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -28,6 +28,7 @@ const eslintConfig = [
       'next-env.d.ts',
       'test-results/**',
       'playwright-report/**',
+      '.claude/worktrees/**',
     ],
   },
   {

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -10,6 +10,15 @@ RewriteEngine On
 Options -Indexes
 ServerSignature Off
 
+# Defensive: keep mod_dir from auto-redirecting bare-dir requests to
+# trailing-slash URLs. Without this, a request to /about-us could be
+# rewritten to /about-us/ by mod_dir, which our slash-strip rule below
+# would then bounce back -- and a future change in fixup-phase ordering
+# could turn that into an infinite redirect. Explicit > implicit.
+<IfModule mod_dir.c>
+  DirectorySlash Off
+</IfModule>
+
 # ---------------------------------------------------------------------
 # Hand-off /hub/ to WHMCS untouched
 # ---------------------------------------------------------------------
@@ -82,9 +91,11 @@ RewriteRule ^wp-login\.php$ - [F,L]
 # Apache: strip trailing slashes, then resolve clean URLs to their
 # .html files.
 
-# Strip trailing slash when a matching .html file exists
-# (also handles the Next.js RSC sidecar dirs like /about-us/, which would
-# otherwise be served as directories and 403 under Options -Indexes)
+# Strip trailing slash when a matching .html file exists (root is
+# excluded naturally: the (.+) capture requires at least one char before
+# the slash). Also handles the Next.js RSC sidecar dirs like /about-us/,
+# which would otherwise be served as directories and 403 under
+# Options -Indexes.
 RewriteCond %{REQUEST_URI} ^/(.+)/$
 RewriteCond %{DOCUMENT_ROOT}/$1.html -f
 RewriteRule ^(.+)/$ /$1 [R=301,L]

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -82,14 +82,17 @@ RewriteRule ^wp-login\.php$ - [F,L]
 # Apache: strip trailing slashes, then resolve clean URLs to their
 # .html files.
 
-# Strip trailing slash on non-directory URLs (except root)
-RewriteCond %{REQUEST_FILENAME} !-d
+# Strip trailing slash when a matching .html file exists
+# (also handles the Next.js RSC sidecar dirs like /about-us/, which would
+# otherwise be served as directories and 403 under Options -Indexes)
 RewriteCond %{REQUEST_URI} ^/(.+)/$
+RewriteCond %{DOCUMENT_ROOT}/$1.html -f
 RewriteRule ^(.+)/$ /$1 [R=301,L]
 
 # Append .html when a matching file exists
+# (no !-d check: Next.js export emits both /foo.html AND a /foo/ RSC sidecar
+# dir for every route; we always prefer the .html sibling when it exists)
 RewriteCond %{REQUEST_FILENAME} !-f
-RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{DOCUMENT_ROOT}/$1.html -f
 RewriteRule ^(.+?)/?$ /$1.html [L]
 

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -15,6 +15,8 @@ ServerSignature Off
 # rewritten to /about-us/ by mod_dir, which our slash-strip rule below
 # would then bounce back -- and a future change in fixup-phase ordering
 # could turn that into an infinite redirect. Explicit > implicit.
+# (WHMCS still needs /hub -> /hub/ for relative-URL resolution; that's
+# handled by an explicit rule in the hand-off block below.)
 <IfModule mod_dir.c>
   DirectorySlash Off
 </IfModule>
@@ -22,6 +24,12 @@ ServerSignature Off
 # ---------------------------------------------------------------------
 # Hand-off /hub/ to WHMCS untouched
 # ---------------------------------------------------------------------
+# Restore the slash on bare /hub before handing off. WHMCS HTML uses
+# relative URLs that resolve against the request URI, so visitors must
+# land on /hub/ -- DirectorySlash Off above means we have to do this
+# ourselves rather than rely on mod_dir.
+RewriteRule ^hub$ /hub/ [R=301,L]
+
 # Anything under /hub/ is WHMCS billing/store/admin. Stop processing
 # immediately so the rules below cannot accidentally rewrite it.
 RewriteRule ^hub($|/) - [L]


### PR DESCRIPTION
## Summary

Next.js 15 static export emits both `/foo.html` and a `/foo/` directory (containing the RSC flight payloads) for every route. The previous `.htaccess` rules guarded both rewrites with `!-d`, so every request to a clean URL like `/about-us` matched the RSC sidecar directory, fell through the rewrite, and 403'd under `Options -Indexes`.

This PR:

- Drops `!-d` from the `.html` append rule. The `DOCUMENT_ROOT/$1.html -f` check already prevents rewriting real directories (`/Images/`, `/_next/`) that don't have a sibling `.html`.
- Reshapes the trailing-slash strip the same way so `/about-us/` 301s to `/about-us`, while `/Images/` still falls through to the existing 403.

## Test plan

- [ ] CI lint + build + jest pass
- [ ] After deploy: every URL in `sitemap.xml` returns 200 (including `/about-us`, `/contact-us`, `/donate`, `/volunteer`)
- [ ] `/about-us/` (trailing slash) 301s to `/about-us`, then 200
- [ ] `/_next/` and `/Images/` still 403 (directory listing remains blocked)
- [ ] Internal navigation from homepage clicks works without error

Fixes #178

https://claude.ai/code/session_01XGJYDDsAjZ1PjdeBTVV4Qh

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGJYDDsAjZ1PjdeBTVV4Qh)_