### PR TITLE
fix(home): use same-origin mission video source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ next-env.d.ts
 
 # cPanel backup tarballs from scripts/cpanel-backup.sh — huge, sensitive
 /cpanel-backups/
+
+# Claude Code on the web — subagent worktree checkouts
+/.claude/worktrees/

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -28,6 +28,7 @@ const eslintConfig = [
       'next-env.d.ts',
       'test-results/**',
       'playwright-report/**',
+      '.claude/worktrees/**',
     ],
   },
   {

--- a/src/components/home-page/Mission/index.tsx
+++ b/src/components/home-page/Mission/index.tsx
@@ -36,7 +36,7 @@ const index = () => {
             aria-label="Free For Charity mission video"
             title="Learn about Free For Charity's mission to help nonprofits reduce costs"
           >
-            <source src="https://ffcsites.org/videos/mission-video.mp4" type="video/mp4" />
+            <source src={assetPath('/videos/mission-video.mp4')} type="video/mp4" />
             Your browser does not support the video tag.
           </video>
         </div>

--- a/tests/README.md
+++ b/tests/README.md
@@ -79,7 +79,7 @@ Tests the Results 2023 section with animated statistics.
    - Accessibility for users with motion sensitivity
    - Animation disabled when prefers-reduced-motion is set
 
-### `mission-video.spec.ts` - Video Functionality (2 tests)
+### `mission-video.spec.ts` - Video Functionality (3 tests)
 
 Tests the video element in the mission section.
 
@@ -94,6 +94,12 @@ Tests the video element in the mission section.
 2. **`should have video source configured correctly`**
    - Validates video source configuration
    - Ensures video src attribute is set correctly
+
+3. **`video source URL should resolve to a 200 (no dead off-domain redirect)`**
+   - Asserts the `<source>` URL is same-origin (no `ffcsites.org` /
+     `ffcadmin.org` / other off-domain hosts)
+   - Fetches the resolved URL and verifies it returns 200 or 206
+     (catches dead redirect chains before deploy)
 
 ### `cookie-consent.spec.ts` - Cookie Consent (14 tests)
 

--- a/tests/mission-video.spec.ts
+++ b/tests/mission-video.spec.ts
@@ -53,9 +53,9 @@ test.describe('Mission Video', () => {
       .getAttribute('src')
 
     expect(src, 'video <source> must have a src attribute').toBeTruthy()
-    expect(src, 'video <source> must be served from this origin').not.toMatch(
-      /^https?:\/\/(www\.)?ffcsites\.org/
-    )
+    // Same-origin only: no absolute http(s) URL. Catches any future
+    // regression to ffcsites.org, ffcadmin.org, a CDN host, etc.
+    expect(src, 'video <source> must be served from this origin').not.toMatch(/^https?:\/\//)
 
     const resolved = new URL(src!, page.url()).toString()
     const response = await page.request.get(resolved, {

--- a/tests/mission-video.spec.ts
+++ b/tests/mission-video.spec.ts
@@ -42,4 +42,28 @@ test.describe('Mission Video', () => {
     // Verify the source has the correct type
     await expect(videoSource).toHaveAttribute('type', 'video/mp4')
   })
+
+  test('video source URL should resolve to a 200 (no dead off-domain redirect)', async ({
+    page,
+  }) => {
+    await page.goto('/')
+
+    const src = await page
+      .locator('video[aria-label="Free For Charity mission video"] source')
+      .getAttribute('src')
+
+    expect(src, 'video <source> must have a src attribute').toBeTruthy()
+    expect(src, 'video <source> must be served from this origin').not.toMatch(
+      /^https?:\/\/(www\.)?ffcsites\.org/
+    )
+
+    const resolved = new URL(src!, page.url()).toString()
+    const response = await page.request.get(resolved, {
+      headers: { Range: 'bytes=0-0' },
+    })
+    expect(
+      [200, 206].includes(response.status()),
+      `video src ${resolved} returned ${response.status()}`
+    ).toBe(true)
+  })
 })


### PR DESCRIPTION
## Summary

The mission `<video>` `<source>` was hardcoded to `https://ffcsites.org/videos/mission-video.mp4`, which now redirects to `https://ffcadmin.org/videos/mission-video.mp4` — and that 404s on GitHub Pages. The actual file ships with the repo at `public/videos/mission-video.mp4` and serves correctly from the same origin.

- Route the `<source src>` through `assetPath('/videos/mission-video.mp4')` to match the poster.
- Add a Playwright regression: fetch the resolved `<source src>` and assert a 200/206 (also assert it's not on `ffcsites.org`), so the same off-domain mistake can't slip back in unnoticed.

## Test plan

- [ ] CI lint + build + jest pass
- [ ] CI Playwright `tests/mission-video.spec.ts` includes the new "video source URL should resolve to a 200" assertion and passes
- [ ] After deploy: mission video plays on `https://staging.freeforcharity.org/` (hard refresh, no cache)
- [ ] `view-source:` shows ``&lt;source src="/videos/mission-video.mp4"&gt;``

Fixes #179

https://claude.ai/code/session_01XGJYDDsAjZ1PjdeBTVV4Qh

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGJYDDsAjZ1PjdeBTVV4Qh)_