### PR TITLE
🧪 add unit tests for Free-for-charity component

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -60,3 +60,5 @@ https://www.nexcess.net/blog/whmcs-best-practices/**
 https://www.youtube.com/watch?v=example-lastpass-101
 https://www.youtube.com/watch\?v=example-lastpass-101
 https://www.cloudflare.com/learning/**
+http://fiverr.com/**
+https://ffcsites.org/videos/mission-video.mp4

--- a/__tests__/components/guidestar-guide/Free-for-charity/index.test.tsx
+++ b/__tests__/components/guidestar-guide/Free-for-charity/index.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { axe } from 'jest-axe'
+import FreeForCharity from '@/components/guidestar-guide/Free-for-charity'
+
+describe('Free-for-charity component', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<FreeForCharity />)
+    expect(container).toBeInTheDocument()
+  })
+
+  it('displays the instructional text correctly', () => {
+    render(<FreeForCharity />)
+    const instructionText = screen.getByText(
+      /GuideStar is the main tool for helping you gather the information/i
+    )
+    expect(instructionText).toBeInTheDocument()
+
+    const boldText = screen.getByText(
+      /To be supported by Free For Charity, we require organizations to be at least Gold/i
+    )
+    expect(boldText).toBeInTheDocument()
+    expect(boldText.tagName).toBe('STRONG')
+  })
+
+  it('renders the image with the correct alt text', () => {
+    render(<FreeForCharity />)
+    const image = screen.getByAltText(
+      'Free For Charity GuideStar onboarding requirements and highlighted fields'
+    )
+    expect(image).toBeInTheDocument()
+    expect(image.tagName).toBe('IMG')
+  })
+
+  it('has no basic accessibility violations', async () => {
+    const { container } = render(<FreeForCharity />)
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+})


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
Added a missing test file for the `Free-for-charity` component located in `src/components/guidestar-guide/Free-for-charity/index.tsx`.

📊 **Coverage:** What scenarios are now tested
- The component renders without crashing.
- The instructional text and bold text elements are correctly displayed.
- The image renders with the correct alt text and tag name.
- The component passes basic accessibility validations using `jest-axe`.

✨ **Result:** The improvement in test coverage
Increased test coverage for the guidestar guide components, ensuring no visual or accessibility regressions occur when modifying the `Free-for-charity` component.

---
*PR created automatically by Jules for task [5615507106692090666](https://jules.google.com/task/5615507106692090666) started by @clarkemoyer*