### PR TITLE
fix(ffcadmin): replace misleading "No Results Found" cPanel SOP page content

### DIFF
--- a/src/app/ffcadmin-free-for-charity-cpanel-backup-sop/page.tsx
+++ b/src/app/ffcadmin-free-for-charity-cpanel-backup-sop/page.tsx
@@ -1,89 +1,40 @@
-'use client'
-
 import React from 'react'
-// import { Search } from "lucide-react";
+import Link from 'next/link'
 
-const NotFoundSection = () => {
+export default function CpanelBackupSop() {
   return (
-    <div className="lg:min-h-screen w-[90%] md:w-[80%] max-w-[1080px] mx-auto " id="aria-font">
-      <div className="flex flex-col lg:flex-row">
-        <div className="w-full lg:w-[79%] float-start pb-[23px] pr-[53px] pt-[138px]">
-          <div className="mb-[60px] ">
-            <h1 className="pb-[7px] text-[30px] leading-[30px] font-[500] text-[#333]">
-              No Results Found
-            </h1>
-            <p className="text-[14px] leading-[24px] font-[500] text-[#666]">
-              The page you requested could not be found. Try refining your search, or use the
-              navigation above to locate the post.
-            </p>
-          </div>
-        </div>
-
-        <div className="lg:border-l border-[#DDDDDD] h-full lg:pl-[30px] pb-[28px] w-full lg:w-[20%] float-end lg:pt-[138px]">
-          <div className="mb-[30px] flex items-center rounded-[3px] overflow-hidden">
-            <input
-              type="text"
-              className="focus:outline-none w-full p-[0.7em] h-[40px] m-0 text-[14px] leading-normal border border-[#ddd] text-[#666]"
-            />
-            <input
-              type="submit"
-              value="Search"
-              className="cursor-pointer h-[40px] px-2 bg-[#DDDDDD] text-[#666] text-[14px] font-[400] border border-transparent"
-            />
-          </div>
-          <p className="mb-[10px] text-[18px] leading-[18px] font-[500] text-[#333]">
-            Recent Posts
-          </p>
-          <ul>
-            <li className="mb-[7px]">
-              <a
-                href="https://freeforcharity.org/we-just-updated-for-the-2022-guidestar-platinum-seal/"
-                className="text-[14px] text-[#666] leading-[24px] font-[500] hover:text-[#82c0c7]"
-              >
-                We just updated for the 2022 GuideStar Platinum Seal
-              </a>
-            </li>
-            <li className="mb-[7px]">
-              <a
-                href="https://freeforcharity.org/our-organization-earned-a-2021-platinum-seal-of-transparency/"
-                className="text-[14px] text-[#666] leading-[24px] font-[500] hover:text-[#82c0c7]"
-              >
-                Our organization earned a 2021 Platinum Seal of Transparency!
-              </a>
-            </li>
-            <li className="mb-[7px]">
-              <a
-                href="https://freeforcharity.org/what-is-the-cost/"
-                className="text-[14px] text-[#666] leading-[24px] font-[500] hover:text-[#82c0c7]"
-              >
-                What is the cost?
-              </a>
-            </li>
-            <li className="mb-[7px]">
-              <a
-                href="https://freeforcharity.org/free-for-charity-just-earned-the-platinum-seal-of-transparency/"
-                className="text-[14px] text-[#666] leading-[24px] font-[500] hover:text-[#82c0c7]"
-              >
-                Free For Charity Just Earned the Platinum Seal of Transparency
-              </a>
-            </li>
-            <li className="mb-[7px]">
-              <a
-                href="https://freeforcharity.org/using-a-registered-agent-service-northwest-registered-agent/"
-                className="text-[14px] text-[#666] leading-[24px] font-[500] hover:text-[#82c0c7]"
-              >
-                Using a Registered Agent Service (Northwest Registered Agent)
-              </a>
-            </li>
-          </ul>
-
-          <p className="my-[30px] text-[18px] leading-[18px] font-[500] text-[#333]">
-            Recent Comments
-          </p>
-        </div>
+    <div className="lg:min-h-screen w-[90%] md:w-[80%] max-w-[1080px] mx-auto" id="aria-font">
+      <div className="pt-[138px] pb-[60px]">
+        <p className="text-[14px] font-[500] text-[#666] uppercase tracking-wider mb-[10px]">
+          Internal SOP &mdash; FFC Admin
+        </p>
+        <h1 className="text-[36px] leading-[40px] font-[600] text-[#333] mb-[24px]">
+          cPanel Backup SOP
+        </h1>
+        <p className="text-[16px] leading-[26px] font-[500] text-[#333] mb-[20px]">
+          The full text of this standard operating procedure is maintained off-site and is
+          restricted to FFC administrators. This page exists as a stable URL that the admin handbook
+          and other internal docs can link to; it is intentionally not indexed by search engines.
+        </p>
+        <p className="text-[16px] leading-[26px] font-[500] text-[#333] mb-[20px]">
+          See the runbook in{' '}
+          <code className="px-1 py-0.5 bg-[#f4f4f4] rounded">docs/CUTOVER-HANDOFF.md</code> and the
+          helper script{' '}
+          <code className="px-1 py-0.5 bg-[#f4f4f4] rounded">scripts/cpanel-backup.sh</code> in the
+          FFC-IN-freeforcharity.org repository for the operational steps.
+        </p>
+        <p className="text-[14px] leading-[24px] font-[500] text-[#666] mb-[20px]">
+          If you arrived here looking for public content, head back to the{' '}
+          <Link href="/" className="text-[#0567B1] underline">
+            Free For Charity homepage
+          </Link>{' '}
+          or the{' '}
+          <Link href="/about-us/" className="text-[#0567B1] underline">
+            About Us page
+          </Link>
+          .
+        </p>
       </div>
     </div>
   )
 }
-
-export default NotFoundSection

--- a/src/app/ffcadmin-free-for-charity-cpanel-backup-sop/page.tsx
+++ b/src/app/ffcadmin-free-for-charity-cpanel-backup-sop/page.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import Link from 'next/link'
 
 export default function CpanelBackupSop() {
@@ -29,7 +28,7 @@ export default function CpanelBackupSop() {
             Free For Charity homepage
           </Link>{' '}
           or the{' '}
-          <Link href="/about-us/" className="text-[#0567B1] underline">
+          <Link href="/about-us" className="text-[#0567B1] underline">
             About Us page
           </Link>
           .


### PR DESCRIPTION
## Summary

The `cPanel Backup SOP` page (`/ffcadmin-free-for-charity-cpanel-backup-sop/`) is linked from the global header's FFCAdmin nav so every visitor on the site can reach it. Its rendered body was a **"No Results Found" placeholder** with a bogus "Recent Posts" sidebar listing legacy WordPress URLs — so a non-admin who clicks through lands on what looks like a broken 404 inside the FFC site.

The layout already declares `robots: { index: false, follow: false }`, so search engines aren't crawling the page; the fix is purely the visible content.

This PR:

- Replaces the misleading "No Results Found" body with an honest "Internal SOP" notice that explains the page is an intentional stable URL for the admin handbook to link to.
- Points readers at the in-repo runbook (`docs/CUTOVER-HANDOFF.md` + `scripts/cpanel-backup.sh`).
- Gives a visitor who landed there by accident clean links back to `/` and `/about-us/`.
- Drops the fake "Recent Posts" sidebar (it was hardcoded to legacy WP slugs anyway and would have 301-hopped to `/blog/`).

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npm test` — 115/115 jest tests pass
- [x] `npm run build` — succeeds
- [ ] CI lint + build + jest + Playwright
- [ ] After deploy: hard-refresh `https://staging.freeforcharity.org/ffcadmin-free-for-charity-cpanel-backup-sop/` — page shows the new "Internal SOP" content, no "No Results Found", no bogus sidebar
- [ ] `robots:` is still `noindex, nofollow` (set in `layout.tsx` — unchanged)

https://claude.ai/code/session_01XGJYDDsAjZ1PjdeBTVV4Qh

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGJYDDsAjZ1PjdeBTVV4Qh)_