### PR TITLE
fix: upgrade fiverr.com button link to https and ignore in lychee

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -65,3 +65,4 @@ https://www.cloudflare.com/learning/**
 https://www.fiverr.com/**
 https://fiverr.com/**
 http://fiverr.com/**
+http://www.fiverr.com/**

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -60,3 +60,8 @@ https://www.nexcess.net/blog/whmcs-best-practices/**
 https://www.youtube.com/watch?v=example-lastpass-101
 https://www.youtube.com/watch\?v=example-lastpass-101
 https://www.cloudflare.com/learning/**
+
+# Fiverr blocks CI crawlers (returns 403)
+https://www.fiverr.com/**
+https://fiverr.com/**
+http://fiverr.com/**

--- a/src/components/free-for-charitys-tools-for-success-components/Tools-For-Businesses/index.tsx
+++ b/src/components/free-for-charitys-tools-for-success-components/Tools-For-Businesses/index.tsx
@@ -79,7 +79,7 @@ const index = () => {
               </>
             }
             buttonText="Available Here"
-            buttonLink="http://fiverr.com/"
+            buttonLink="https://www.fiverr.com/"
             imageSrc="/Images/fiverr.webp" // 👈 image passed as prop
           />
 


### PR DESCRIPTION
## Summary

The Tools-For-Businesses page had a `buttonLink="http://fiverr.com/"` SlidingCard. The plain-HTTP link 301-redirects to `https://www.fiverr.com/`, so every visitor click eats an extra round-trip. Worse, the link is what the weekly Lychee link-checker has been failing on (Fiverr's CDN returns `403` to bots), which has been blocking unrelated PRs (e.g. #228) on the **Check external links** CI job.

This PR:

- Updates `src/components/free-for-charitys-tools-for-success-components/Tools-For-Businesses/index.tsx` to use the canonical `https://www.fiverr.com/`, removing the 301 hop for visitors.
- Adds `fiverr.com` glob patterns to `.lycheeignore` as defense-in-depth (Fiverr blocks CI crawlers on every variant of the URL, so the only correct CI behavior is to skip it).

## Why this also helps Jules PRs

Several open Jules PRs (#187 family, #189, etc.) have tried to land the same `.lycheeignore` defense alongside their own changes. Consolidating the fix here unblocks the **Check external links** job for every PR that touches `src/**`.

## Test plan

- [x] `npm run lint` — 0 errors
- [ ] CI: lint + build + jest + Playwright + **Check external links** all green
- [ ] After deploy: clicking "Available Here" on the Tools-For-Businesses page goes straight to `https://www.fiverr.com/` (no 301 hop)

Refs #93

https://claude.ai/code/session_01XGJYDDsAjZ1PjdeBTVV4Qh

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGJYDDsAjZ1PjdeBTVV4Qh)_