### PR TITLE
fix(ci): ignore third-party domains that 403/503 lychee crawlers

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -66,3 +66,19 @@ https://www.fiverr.com/**
 https://fiverr.com/**
 http://fiverr.com/**
 http://www.fiverr.com/**
+
+# GuideStar/Candid returns 403 to bots — visible profile URL still reachable in browser
+https://www.guidestar.org/**
+
+# Microsoft privacy statement 403s on bots; the canonical /en-us/ variant is what users get redirected to
+https://privacy.microsoft.com/privacystatement
+https://privacy.microsoft.com/**
+
+# Third-party knowledge bases / search pages that return non-2xx to crawlers
+https://www.cloudwards.net/**
+https://www.inmotionhosting.com/**
+https://www.siteground.com/**
+https://www.youtube.com/results**
+https://www.microsoft.com/en-us/nonprofits/**
+https://mailchimp.com/**
+https://www.mailchimp.com/**


### PR DESCRIPTION
## Summary

The weekly Lychee link checker has been failing in PR CI on every PR that touches `src/**` because several external URLs in the codebase return non-2xx to bots even though they are reachable in a normal browser. This was blocking unrelated PRs (e.g. #228) from merging on the **Check external links** job.

Verified locally with `lychee 0.21.0` against current `src/` after this change: **0 errors** (down from 10).

## Domains added to `.lycheeignore`

| Domain | Status | Used in |
|---|---|---|
| `guidestar.org` | 403 to bots | footer, GuideStar guide FAQs, Ourblogs |
| `privacy.microsoft.com` | 403 to bots | cookie-policy |
| `cloudwards.net`, `inmotionhosting.com`, `siteground.com` | 403/503/202 | web-developer-training Hero |
| `youtube.com/results` | 500 to bots (search URLs) | web-developer-training Hero |
| `microsoft.com/en-us/nonprofits` | 403 to bots | web-developer-training Hero |
| `mailchimp.com` | 403 to bots | Six-Grid-Cards |

All of these are reachable in a normal browser; only the bot-detection layer at the destination is returning the non-2xx. None of these links are actually broken from a visitor's perspective.

## Test plan

- [x] `lychee` against `src/**`, `*.md` → 0 errors locally
- [ ] CI: **Check external links** passes
- [ ] Other CI checks (lint, build, jest, Playwright) remain green

Refs #93

https://claude.ai/code/session_01XGJYDDsAjZ1PjdeBTVV4Qh

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGJYDDsAjZ1PjdeBTVV4Qh)_