### PR TITLE
fix(security): drop placeholder fallbacks for analytics tracking IDs in CookieConsent

### DIFF
--- a/src/components/cookie-consent/index.tsx
+++ b/src/components/cookie-consent/index.tsx
@@ -3,10 +3,13 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import Link from 'next/link'
 
-// Environment variables for tracking IDs (replace with actual values)
-const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID || 'G-XXXXXXXXXX'
-const META_PIXEL_ID = process.env.NEXT_PUBLIC_META_PIXEL_ID || 'XXXXXXXXXXXXXXX'
-const CLARITY_PROJECT_ID = process.env.NEXT_PUBLIC_CLARITY_PROJECT_ID || 'XXXXXXXXXX'
+// Tracking IDs come from build-time env vars. No placeholder fallbacks:
+// a missing var must mean "don't load the script" — never "load with a
+// fake/dev ID" — so we don't risk shipping bogus or accidentally-real
+// hardcoded keys to production.
+const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID || ''
+const META_PIXEL_ID = process.env.NEXT_PUBLIC_META_PIXEL_ID || ''
+const CLARITY_PROJECT_ID = process.env.NEXT_PUBLIC_CLARITY_PROJECT_ID || ''
 
 // Define type for GTM dataLayer events
 interface DataLayerEvent {
@@ -44,6 +47,7 @@ export default function CookieConsent() {
   const previousFocusRef = useRef<HTMLElement | null>(null)
 
   const loadGoogleAnalytics = useCallback(() => {
+    if (!GA_MEASUREMENT_ID) return
     if (
       typeof window !== 'undefined' &&
       !document.querySelector('script[src*="googletagmanager.com/gtag"]')
@@ -70,6 +74,7 @@ export default function CookieConsent() {
   }, [])
 
   const loadMetaPixel = useCallback(() => {
+    if (!META_PIXEL_ID) return
     if (typeof window !== 'undefined' && !document.querySelector('script[src*="fbevents.js"]')) {
       const fbScript = document.createElement('script')
       fbScript.textContent = `
@@ -98,6 +103,7 @@ export default function CookieConsent() {
   }, [])
 
   const loadMicrosoftClarity = useCallback(() => {
+    if (!CLARITY_PROJECT_ID) return
     if (typeof window !== 'undefined' && !document.querySelector('script[src*="clarity.ms"]')) {
       const clarityScript = document.createElement('script')
       clarityScript.textContent = `


### PR DESCRIPTION
## Summary

`src/components/cookie-consent/index.tsx` hardcoded `'G-XXXXXXXXXX'`, `'XXXXXXXXXXXXXXX'`, and `'XXXXXXXXXX'` as fallbacks for the `NEXT_PUBLIC_GA_MEASUREMENT_ID`, `NEXT_PUBLIC_META_PIXEL_ID`, and `NEXT_PUBLIC_CLARITY_PROJECT_ID` env vars. The risk is two-fold:

1. A developer could replace the placeholder with a real key inline and ship a hardcoded secret to the public source tree.
2. When the env vars are unset (current production state), the component still injects gtag / fbevents / clarity scripts which fire requests against the placeholder ID — leaking every visitor's page-view to Google / Meta / Clarity under a bogus tenant.

**Fix:** drop the fallbacks (empty string) and add an early `if (!ID) return` at the top of each `loadGoogleAnalytics`, `loadMetaPixel`, `loadMicrosoftClarity` so the script is never injected when the ID is missing.

## Supersedes Jules PRs

This rolls up the value from two Jules PRs that conflict with current main:
- **#227** — same intent, but adds 14 unrelated `.lycheeignore` entries (several now redundant with merged #234)
- **#233** — cleanest of the two, but also conflicts with merged #232/#234

This PR is the minimal, conflict-free version.

## Test plan

- [x] `npm test` — 237/237 pass (existing tests cover the component shape; the change is opt-in early returns)
- [ ] CI: lint + build + jest + Playwright (`tests/cookie-consent.spec.ts` covers the banner flow end-to-end)
- [ ] After deploy: open DevTools Network on staging, accept all cookies — verify NO request to `googletagmanager.com/gtag/js`, `connect.facebook.net/en_US/fbevents.js`, or `clarity.ms/tag/*` when the corresponding env var is unset

## Reviews

Same 3-review protocol planned: Copilot auto-review on push, my manual line-by-line, and the `code-review` skill. Will merge on clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGJYDDsAjZ1PjdeBTVV4Qh)_