### PR TITLE
chore(cookie-consent): drop debug console.warn from localStorage catch blocks

### DIFF
--- a/src/components/cookie-consent/index.tsx
+++ b/src/components/cookie-consent/index.tsx
@@ -290,9 +290,10 @@ export default function CookieConsent() {
     setPreferences(allAccepted)
     try {
       localStorage.setItem('cookie-consent', JSON.stringify(allAccepted))
-    } catch (e) {
-      // If localStorage is unavailable, continue anyway
-      console.warn('Unable to save preferences to localStorage:', e)
+    } catch {
+      // If localStorage is unavailable (Safari private mode, quota
+      // exceeded, disabled storage), continue anyway — the consent
+      // cookie set by applyConsent() is the source of truth.
     }
     applyConsent(allAccepted, savedPreferencesBackup)
     setSavedPreferencesBackup(allAccepted)
@@ -309,9 +310,10 @@ export default function CookieConsent() {
     setPreferences(onlyNecessary)
     try {
       localStorage.setItem('cookie-consent', JSON.stringify(onlyNecessary))
-    } catch (e) {
-      // If localStorage is unavailable, continue anyway
-      console.warn('Unable to save preferences to localStorage:', e)
+    } catch {
+      // If localStorage is unavailable (Safari private mode, quota
+      // exceeded, disabled storage), continue anyway — the consent
+      // cookie set by applyConsent() is the source of truth.
     }
 
     // Delete third-party cookies when consent is withdrawn
@@ -325,9 +327,10 @@ export default function CookieConsent() {
   const handleSavePreferences = () => {
     try {
       localStorage.setItem('cookie-consent', JSON.stringify(preferences))
-    } catch (e) {
-      // If localStorage is unavailable, continue anyway
-      console.warn('Unable to save preferences to localStorage:', e)
+    } catch {
+      // If localStorage is unavailable (Safari private mode, quota
+      // exceeded, disabled storage), continue anyway — the consent
+      // cookie set by applyConsent() is the source of truth.
     }
     applyConsent(preferences, savedPreferencesBackup)
     setSavedPreferencesBackup(preferences)


### PR DESCRIPTION
## Summary

The three `try/catch` blocks around `localStorage.setItem('cookie-consent', ...)` in `handleAcceptAll`, `handleDeclineAll`, and `handleSavePreferences` (lines 291–296, 310–315, 326–331) logged a `console.warn` on failure. The catch was correctly silently-recovering — the consent cookie set in `applyConsent()` is the source of truth, so a missing localStorage write is a no-op for the visitor's session — but the warn was noisy in normal Safari private-mode and `QuotaExceededError` paths, and the bound `e` parameter would trigger `@typescript-eslint/no-unused-vars` once the warn was removed.

This PR drops the warn, drops the unused param (`catch {}`), and expands the comment to explain WHY silent recovery is correct.

## Supersedes Jules PRs

This rolls up the value from **four** Jules PRs that all touch the same 3 catch blocks. All four conflict with current main on `.lycheeignore` (their auxiliary defense-in-depth additions are now redundant with already-merged #234):
- #187 — `catch {}` variant + 3 unrelated lycheeignore lines
- #218 — keeps `catch (e)` (unused param triggers lint warning) + 4 lycheeignore lines, all redundant
- #222 — `catch {}` variant + 3 fiverr lycheeignore lines, all redundant
- #231 — keeps `catch (e)` (unused param) + 4 lycheeignore lines, all redundant

This PR keeps only the cleanest component delta (`catch {}` + better comment) with no `.lycheeignore` noise.

## Test plan

- [x] `npm test` — 237/237 pass
- [ ] CI: lint + build + jest + Playwright + Check external links

## Reviews

Same 3-review protocol: Copilot auto-review on push, manual line-by-line, and `code-review` skill. Will merge on clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGJYDDsAjZ1PjdeBTVV4Qh)_