### PR TITLE
test(playwright): un-skip image-loading naturalWidth assertion with onload await

### DIFF
--- a/tests/image-loading.spec.ts
+++ b/tests/image-loading.spec.ts
@@ -62,10 +62,7 @@ test.describe('Image Loading', () => {
     }
   })
 
-  // Temporarily disabled: This test checks natural dimensions which don't work reliably in CI
-  // The test passes locally but fails on GitHub Actions
-  // TODO: Investigate why naturalWidth/naturalHeight return 0 in CI despite image being visible
-  test.skip('images have natural dimensions indicating successful load', async ({ page }) => {
+  test('images have natural dimensions indicating successful load', async ({ page }) => {
     // Navigate to the homepage
     await page.goto('/')
 
@@ -74,6 +71,18 @@ test.describe('Image Loading', () => {
 
     // Wait for the image to be visible
     await expect(heroImage).toBeVisible()
+
+    // In CI, the element becoming "visible" can fire before the bitmap
+    // decode completes, so naturalWidth/naturalHeight read back as 0.
+    // Wait for the browser's own load event (or error) on the underlying
+    // <img> before reading natural dimensions.
+    await heroImage.evaluate((img: HTMLImageElement) => {
+      if (img.complete) return
+      return new Promise<void>((resolve) => {
+        img.onload = () => resolve()
+        img.onerror = () => resolve()
+      })
+    })
 
     // Verify the image has loaded by checking it has natural dimensions
     const naturalWidth = await heroImage.evaluate((img: HTMLImageElement) => img.naturalWidth)


### PR DESCRIPTION
## Summary

`tests/image-loading.spec.ts` had its `images have natural dimensions indicating successful load` assertion `.skip`-ped with a TODO since the original spec (#102) — the assertion fails in CI even though it passes locally, because Playwright's `.toBeVisible()` resolves the moment the `<img>` element is rendered in the viewport, which can happen before the browser finishes decoding the bitmap. In that window `naturalWidth`/`naturalHeight` read back as `0`.

This PR fixes the underlying race by waiting for the native `img.onload`/`img.onerror` event (or `img.complete === true`) inside `heroImage.evaluate()` before reading the dimensions, then un-skips the test.

## Supersedes Jules PR

**#219** contains this same 11-line fix to `image-loading.spec.ts` but also 21 unrelated file changes that come from rebasing onto an older `main`. Merging #219 as-is would revert:
- merged staging fixes #181 (`.htaccess` clean-URL handling + mission-video same-origin migration + admin SOP page)
- merged perf #189 (`STAR_INDICES` constant)
- merged tests #214 (About-FFC-Hosting test)
- merged fix #228 (FFCAdmin SOP page replacement)
- merged CI fix #232 (fiverr https + lychee ignore)

This PR isolates only the legitimate flaky-test fix.

## Test plan

- [ ] CI: Playwright `image-loading.spec.ts` passes on the un-skipped assertion
- [ ] All other CI checks remain green

## Reviews

Same 3-review protocol: Copilot auto-review on push, manual line-by-line, and `code-review` skill. Will merge on clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGJYDDsAjZ1PjdeBTVV4Qh)_