### PR TITLE
test: rollup 2 — add 6 unit tests for hero/donate/charity components

### DIFF
--- a/__tests__/components/charity-validation-guide-ensuring-mutual-benefit-through-comprehensive-validation-processes-components/Hero/index.test.tsx
+++ b/__tests__/components/charity-validation-guide-ensuring-mutual-benefit-through-comprehensive-validation-processes-components/Hero/index.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import CharityValidationGuide from '@/components/charity-validation-guide-ensuring-mutual-benefit-through-comprehensive-validation-processes-components/Hero'
+
+describe('CharityValidationGuide Hero Component', () => {
+  it('renders without crashing', () => {
+    render(<CharityValidationGuide />)
+    expect(
+      screen.getByRole('heading', {
+        name: /Charity Validation Guide: Ensuring Mutual Benefit Through Comprehensive Validation Processes/i,
+      })
+    ).toBeInTheDocument()
+  })
+
+  it('renders the Introduction section', () => {
+    render(<CharityValidationGuide />)
+    expect(screen.getByRole('heading', { name: /Introduction/i })).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        /Effective validation of charitable entities is not only pivotal for the credibility/i
+      )
+    ).toBeInTheDocument()
+  })
+
+  it('renders external and internal validation subheadings', () => {
+    render(<CharityValidationGuide />)
+    expect(
+      screen.getByRole('heading', { name: /External Trusted Validation Sources/i })
+    ).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /Internal Validation Steps/i })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /Conclusion/i })).toBeInTheDocument()
+  })
+})

--- a/__tests__/components/donate-components/General-donation.test.tsx
+++ b/__tests__/components/donate-components/General-donation.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import GeneralDonation from '@/components/donate-components/General-donation/index'
+
+describe('GeneralDonation Component', () => {
+  it('renders the main heading', () => {
+    render(<GeneralDonation />)
+    expect(
+      screen.getByRole('heading', { name: /General Donations/i, level: 1 })
+    ).toBeInTheDocument()
+  })
+
+  it('renders the three donation cards with correct titles and descriptions', () => {
+    render(<GeneralDonation />)
+
+    expect(screen.getByRole('heading', { name: 'Monthly Donations', level: 1 })).toBeInTheDocument()
+    expect(
+      screen.getByText(/Monthly donations help by providing a predictable cash flow/)
+    ).toBeInTheDocument()
+
+    expect(
+      screen.getByRole('heading', { name: 'One Time Donations', level: 1 })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/On time donations of any amount are placed in the general fund/)
+    ).toBeInTheDocument()
+
+    expect(screen.getByRole('heading', { name: 'Large Donations', level: 1 })).toBeInTheDocument()
+    expect(
+      screen.getByText(/For large donations we can work directly with the donor/)
+    ).toBeInTheDocument()
+  })
+
+  it('provides correct links with external target attributes', () => {
+    render(<GeneralDonation />)
+    const links = screen.getAllByRole('link')
+    expect(links).toHaveLength(3)
+
+    expect(links[0]).toHaveAttribute(
+      'href',
+      'https://www.paypal.com/donate/?hosted_button_id=9ZKQ23YC3G2J2'
+    )
+    expect(links[0]).toHaveAttribute('target', '_blank')
+    expect(links[0]).toHaveAttribute('rel', 'noopener noreferrer')
+
+    expect(links[1]).toHaveAttribute(
+      'href',
+      'https://www.paypal.com/donate/?hosted_button_id=9ZKQ23YC3G2J2'
+    )
+    expect(links[1]).toHaveAttribute('target', '_blank')
+    expect(links[1]).toHaveAttribute('rel', 'noopener noreferrer')
+
+    expect(links[2]).toHaveAttribute(
+      'href',
+      'https://www.paypal.com/donate/?hosted_button_id=243G37NHXSRY8'
+    )
+    expect(links[2]).toHaveAttribute('target', '_blank')
+    expect(links[2]).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+
+  it('renders images for each donation card', () => {
+    render(<GeneralDonation />)
+    const images = screen.getAllByAltText('Donation image')
+    expect(images).toHaveLength(3)
+  })
+})

--- a/__tests__/components/free-charity-web-hosting/BecomePartOfOurMission/BecomePartOfOurMission.test.tsx
+++ b/__tests__/components/free-charity-web-hosting/BecomePartOfOurMission/BecomePartOfOurMission.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import BecomePartOfOurMission from '@/components/free-charity-web-hosting/BecomePartOfOurMission'
+
+// Mock the BecomePartOfOurMissionCard component to make testing simpler
+// and isolate the test to just the BecomePartOfOurMission component's rendering
+jest.mock('@/components/ui/BecomePartOfOurMissionCard', () => {
+  return function DummyBecomePartOfOurMissionCard(props: {
+    heading: string
+    description1: string
+    description2: string
+    buttonLink: string
+    buttonText: string
+  }) {
+    return (
+      <div data-testid="mission-card">
+        <span data-testid="card-heading">{props.heading}</span>
+        <span data-testid="card-desc1">{props.description1}</span>
+        <span data-testid="card-desc2">{props.description2}</span>
+        <a href={props.buttonLink} data-testid="card-link">
+          {props.buttonText}
+        </a>
+      </div>
+    )
+  }
+})
+
+describe('BecomePartOfOurMission', () => {
+  it('renders the main heading', () => {
+    render(<BecomePartOfOurMission />)
+    expect(screen.getByText('Become a part of our Mission')).toBeInTheDocument()
+  })
+
+  it('renders the HELP US card with correct props', () => {
+    render(<BecomePartOfOurMission />)
+
+    const cards = screen.getAllByTestId('mission-card')
+    expect(cards).toHaveLength(2)
+
+    expect(screen.getByText('HELP US')).toBeInTheDocument()
+    expect(screen.getByText('INDIVIDUALS OR BUSINESSES LOOKING')).toBeInTheDocument()
+    expect(screen.getByText('FOR A DOMAIN NAME PACKAGE')).toBeInTheDocument()
+
+    const getStartedLinks = screen.getAllByText('Get Started')
+    expect(getStartedLinks[0]).toHaveAttribute(
+      'href',
+      'https://freeforcharity.org/hub/store/free-for-charity-individual-supporter-package'
+    )
+  })
+
+  it('renders the HELP THEM card with correct props', () => {
+    render(<BecomePartOfOurMission />)
+
+    expect(screen.getByText('HELP THEM')).toBeInTheDocument()
+    expect(screen.getByText('FREE FOR CHARITY DOMAIN PACKAGE')).toBeInTheDocument()
+    expect(screen.getByText('(NOT-FOR-PROFIT, PRE-501(C)3, FULL 501(C)3)')).toBeInTheDocument()
+
+    const getStartedLinks = screen.getAllByText('Get Started')
+    expect(getStartedLinks[1]).toHaveAttribute('href', '/help-for-charities')
+  })
+})

--- a/__tests__/components/free-for-charity-ffc-service-delivery-stages-components/Hero/index.test.tsx
+++ b/__tests__/components/free-for-charity-ffc-service-delivery-stages-components/Hero/index.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import Hero from '@/components/free-for-charity-ffc-service-delivery-stages-components/Hero'
+
+describe('Free For Charity Service Delivery Stages - Hero Component', () => {
+  it('renders without crashing', () => {
+    render(<Hero />)
+  })
+
+  it('renders key headings', () => {
+    render(<Hero />)
+    expect(
+      screen.getByRole('heading', { name: /Free For Charity \(FFC\)/i, level: 1 })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: /Service Delivery Stages/i, level: 2 })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: /Onboarding Philosophy/i, level: 2 })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', {
+        name: /Supported Organization Establishment: Order of Operations/i,
+        level: 2,
+      })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: /Service Expansion/i, level: 2 })
+    ).toBeInTheDocument()
+  })
+
+  it('renders specific steps', () => {
+    render(<Hero />)
+    expect(
+      screen.getByRole('heading', { name: /Initial Contact & Onboarding/i, level: 3 })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: /FFC Validation Checks/i, level: 3 })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: /FFC Offers Services/i, level: 3 })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: /Receiving Basic Services Package/i, level: 3 })
+    ).toBeInTheDocument()
+  })
+})

--- a/__tests__/components/free-for-charity-ffc-web-developer-training-guide-components/Hero/index.test.tsx
+++ b/__tests__/components/free-for-charity-ffc-web-developer-training-guide-components/Hero/index.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import Hero from '@/components/free-for-charity-ffc-web-developer-training-guide-components/Hero'
+
+describe('Hero Component - FFC Web Developer Training Guide', () => {
+  it('renders the main heading', () => {
+    render(<Hero />)
+    expect(
+      screen.getByRole('heading', {
+        name: /Free For Charity \(FFC\) Web Developer Training Guide/i,
+      })
+    ).toBeInTheDocument()
+  })
+
+  it('renders the Table of Contents', () => {
+    render(<Hero />)
+    expect(screen.getByRole('heading', { name: /Table of Contents/i })).toBeInTheDocument()
+  })
+
+  it('renders all sections from Table of Contents', () => {
+    render(<Hero />)
+
+    expect(screen.getAllByRole('link', { name: /FFC Hub by WHMCS/i })[0]).toBeInTheDocument()
+    expect(screen.getAllByRole('link', { name: /Cloudflare/i })[0]).toBeInTheDocument()
+    expect(screen.getAllByRole('link', { name: /Microsoft 365/i })[0]).toBeInTheDocument()
+    expect(screen.getAllByRole('link', { name: /InterServer Web Hosting/i })[0]).toBeInTheDocument()
+    expect(
+      screen.getAllByRole('link', { name: /DIVI \(WordPress Theme\)/i })[0]
+    ).toBeInTheDocument()
+    expect(
+      screen.getAllByRole('link', { name: /WPMUdev \(WordPress Plugins\)/i })[0]
+    ).toBeInTheDocument()
+    expect(
+      screen.getAllByRole('link', { name: /Microsoft Clarity \(Analytics\)/i })[0]
+    ).toBeInTheDocument()
+    expect(
+      screen.getAllByRole('link', { name: /Tawk.to Live Chat \(Support\)/i })[0]
+    ).toBeInTheDocument()
+    expect(screen.getAllByRole('link', { name: /Azure AI Language/i })[0]).toBeInTheDocument()
+    expect(screen.getAllByRole('link', { name: /Final Notes/i })[0]).toBeInTheDocument()
+  })
+
+  it('renders the main content sections', () => {
+    render(<Hero />)
+
+    expect(
+      screen.getByText(/WHMCS powers the FFC Hub, which handles domain name orders/i)
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/Cloudflare manages the DNS settings for charity domains/i)
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/Microsoft 365 provides the email hosting solution for charity accounts/i)
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/InterServer provides the hosting platform for charity websites/i)
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/DIVI is used to create visually appealing, responsive/i)
+    ).toBeInTheDocument()
+  })
+})

--- a/__tests__/components/home/HeroSection.test.tsx
+++ b/__tests__/components/home/HeroSection.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import Hero from '@/components/home/HeroSection'
+
+describe('Hero Section', () => {
+  it('renders the main heading', () => {
+    render(<Hero />)
+    const heading = screen.getByRole('heading', { name: /welcome to free for charity/i })
+    expect(heading).toBeInTheDocument()
+  })
+
+  it('renders the descriptive paragraph', () => {
+    render(<Hero />)
+    const paragraph = screen.getByText(
+      /connecting students, professionals, & businesses with charities in need/i
+    )
+    expect(paragraph).toBeInTheDocument()
+  })
+
+  it('renders the hero image', () => {
+    render(<Hero />)
+    const image = screen.getByRole('img', { name: /hero/i })
+    expect(image).toBeInTheDocument()
+    expect(image).toHaveAttribute('src')
+  })
+})


### PR DESCRIPTION
## Summary

Second rollup of Jules-authored test files extracted onto a clean branch off current main. Each source Jules PR conflicts with merged #234 on `.lycheeignore` and can't be force-pushed; this PR brings the test value into main with zero conflict.

## Tests added (6 files, ~20 new test cases)

| File | Source Jules PR |
|---|---|
| `__tests__/components/free-charity-web-hosting/BecomePartOfOurMission/BecomePartOfOurMission.test.tsx` | #188 |
| `__tests__/components/donate-components/General-donation.test.tsx` | #192 |
| `__tests__/components/free-for-charity-ffc-web-developer-training-guide-components/Hero/index.test.tsx` | #201 |
| `__tests__/components/home/HeroSection.test.tsx` | #211 |
| `__tests__/components/free-for-charity-ffc-service-delivery-stages-components/Hero/index.test.tsx` | #206 |
| `__tests__/components/charity-validation-guide-ensuring-mutual-benefit-through-comprehensive-validation-processes-components/Hero/index.test.tsx` | #212 |

Each test file is byte-for-byte identical to its Jules source (only the conflicting `.lycheeignore` additions are dropped).

## Skipped from this batch

- **#194** (TestimonialSlider test) — that PR's diff is 1764 additions across 16 files, far beyond a unit-test add. Needs separate triage before extraction.

## Test plan

- [x] `npm test` — 283/283 pass (was 263 before this commit, +20 from new tests)
- [ ] CI: lint + build + jest + Playwright + lychee

## Reviews

Will do 3-pass review (Copilot + manual + code-review skill) once CI starts.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGJYDDsAjZ1PjdeBTVV4Qh)_