### PR TITLE
feat: cutover-readiness — custom 404, smoke-test script, admin noindex

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
     "visual-regression": "node scripts/visual-regression/capture.mjs",
+    "smoke-test": "node scripts/smoke-test.mjs",
     "prepare": "husky"
   },
   "dependencies": {

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -36,7 +36,7 @@ function record(name, ok, detail) {
   process.stdout.write(`${ok ? PASS : FAIL} ${name}${detail ? ` — ${detail}` : ''}\n`)
 }
 
-async function head(path, { followRedirects = true } = {}) {
+async function request(path, { followRedirects = true } = {}) {
   const url = path.startsWith('http') ? path : `${BASE_URL}${path}`
   const controller = new AbortController()
   const timer = setTimeout(() => controller.abort(), TIMEOUT_MS)
@@ -56,13 +56,13 @@ async function head(path, { followRedirects = true } = {}) {
 }
 
 async function checkStatus(name, path, expected) {
-  const r = await head(path)
+  const r = await request(path)
   const ok = r.status === expected
   record(name, ok, `${path} → ${r.status}${r.error ? ` (${r.error})` : ''}`)
 }
 
 async function checkRedirect(name, path, expectedStatus, expectedLocationSuffix) {
-  const r = await head(path, { followRedirects: false })
+  const r = await request(path, { followRedirects: false })
   const locOk = r.location && r.location.endsWith(expectedLocationSuffix)
   const ok = r.status === expectedStatus && locOk
   record(name, ok, `${path} → ${r.status} ${r.location || '(no Location)'}`)
@@ -107,12 +107,23 @@ async function main() {
     await checkStatus(`sitemap ${path}`, path, 200)
   }
 
-  console.log(`\n-- canonical-form 301s (Apache-only; will fail on \`serve\`)`)
-  const slugSamples = sitemapPaths.filter((p) => p !== '/').slice(0, 5)
-  for (const path of slugSamples) {
-    const noSlash = path.replace(/\/$/, '')
-    await checkRedirect(`canonical /slug → /slug/`, noSlash, 301, path)
-    await checkRedirect(`legacy *.html → /slug/`, `${noSlash}.html`, 301, path)
+  // Canonical-form 301s only make sense in the trailingSlash: true
+  // world (PR #186): bare /foo → /foo/, /foo.html → /foo/. Detect by
+  // looking at the sitemap form — if it ships trailing slashes, the
+  // Apache config is the post-#186 variant and these assertions apply.
+  // Skip on a pre-#186 deploy where the export emits /foo.html and the
+  // .htaccess strips trailing slashes (the opposite invariant).
+  const sitemapHasTrailingSlash = sitemapPaths.some((p) => p !== '/' && p.endsWith('/'))
+  if (sitemapHasTrailingSlash) {
+    console.log(`\n-- canonical-form 301s (Apache-only; will fail on \`serve\`)`)
+    const slugSamples = sitemapPaths.filter((p) => p !== '/').slice(0, 5)
+    for (const path of slugSamples) {
+      const noSlash = path.replace(/\/$/, '')
+      await checkRedirect(`canonical /slug → /slug/`, noSlash, 301, path)
+      await checkRedirect(`legacy *.html → /slug/`, `${noSlash}.html`, 301, path)
+    }
+  } else {
+    console.log(`\n-- canonical-form 301s skipped (sitemap is no-slash → pre-trailingSlash export)`)
   }
 
   console.log(`\n-- WP→Next legacy redirects from docs/cutover-redirects.csv`)

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+/*
+ * scripts/smoke-test.mjs — post-deploy URL smoke test.
+ *
+ * Hits every URL in sitemap.xml on a target origin, plus the WP→Next
+ * legacy redirects from docs/cutover-redirects.csv, plus a few sanity
+ * checks (canonical-form 301s, /hub/ reachability, 404 page).
+ *
+ * Use this before flipping DNS to production, and again immediately
+ * after the document-root swap to catch regressions.
+ *
+ * Usage:
+ *   node scripts/smoke-test.mjs                                   # default: production origin
+ *   BASE_URL=https://staging.freeforcharity.org node scripts/smoke-test.mjs
+ *
+ * Exit code: 0 = all green, 1 = any failure.
+ */
+
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = resolve(__dirname, '..')
+
+const BASE_URL = (process.env.BASE_URL || 'https://www.freeforcharity.org').replace(/\/$/, '')
+const TIMEOUT_MS = Number(process.env.TIMEOUT_MS || 15000)
+
+const PASS = '\x1b[32m✓\x1b[0m'
+const FAIL = '\x1b[31m✗\x1b[0m'
+
+const results = []
+
+function record(name, ok, detail) {
+  results.push({ name, ok, detail })
+  process.stdout.write(`${ok ? PASS : FAIL} ${name}${detail ? ` — ${detail}` : ''}\n`)
+}
+
+async function head(path, { followRedirects = true } = {}) {
+  const url = path.startsWith('http') ? path : `${BASE_URL}${path}`
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS)
+  try {
+    const res = await fetch(url, {
+      method: 'GET',
+      redirect: followRedirects ? 'follow' : 'manual',
+      signal: controller.signal,
+      headers: { 'User-Agent': 'ffc-smoke-test/1.0' },
+    })
+    return { status: res.status, location: res.headers.get('location'), url: res.url }
+  } catch (err) {
+    return { status: 0, error: err.message }
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+async function checkStatus(name, path, expected) {
+  const r = await head(path)
+  const ok = r.status === expected
+  record(name, ok, `${path} → ${r.status}${r.error ? ` (${r.error})` : ''}`)
+}
+
+async function checkRedirect(name, path, expectedStatus, expectedLocationSuffix) {
+  const r = await head(path, { followRedirects: false })
+  const locOk = r.location && r.location.endsWith(expectedLocationSuffix)
+  const ok = r.status === expectedStatus && locOk
+  record(name, ok, `${path} → ${r.status} ${r.location || '(no Location)'}`)
+}
+
+function loadSitemapPaths() {
+  const localSitemap = resolve(repoRoot, 'out/sitemap.xml')
+  try {
+    const xml = readFileSync(localSitemap, 'utf8')
+    const locs = [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map((m) => m[1])
+    return locs.map((u) => new URL(u).pathname)
+  } catch {
+    return null
+  }
+}
+
+function loadCsvRedirects() {
+  const csvPath = resolve(repoRoot, 'docs/cutover-redirects.csv')
+  const text = readFileSync(csvPath, 'utf8')
+  const lines = text.split('\n').slice(1).filter(Boolean)
+  return lines.map((line) => {
+    const [source, target, code] = line.split(',')
+    return {
+      sourcePath: new URL(source).pathname + (new URL(source).hash || ''),
+      targetPath: new URL(target).pathname + (new URL(target).hash || ''),
+      code: Number(code),
+    }
+  })
+}
+
+async function main() {
+  console.log(`\nSmoke-testing ${BASE_URL}\n`)
+
+  const sitemapPaths = loadSitemapPaths()
+  if (!sitemapPaths) {
+    console.error('No out/sitemap.xml found — run `npm run build` first.')
+    process.exit(1)
+  }
+
+  console.log(`-- ${sitemapPaths.length} sitemap routes (expect 200 after redirect)`)
+  for (const path of sitemapPaths) {
+    await checkStatus(`sitemap ${path}`, path, 200)
+  }
+
+  console.log(`\n-- canonical-form 301s (Apache-only; will fail on \`serve\`)`)
+  const slugSamples = sitemapPaths.filter((p) => p !== '/').slice(0, 5)
+  for (const path of slugSamples) {
+    const noSlash = path.replace(/\/$/, '')
+    await checkRedirect(`canonical /slug → /slug/`, noSlash, 301, path)
+    await checkRedirect(`legacy *.html → /slug/`, `${noSlash}.html`, 301, path)
+  }
+
+  console.log(`\n-- WP→Next legacy redirects from docs/cutover-redirects.csv`)
+  const redirects = loadCsvRedirects()
+  for (const r of redirects) {
+    await checkRedirect(
+      `${r.code} ${r.sourcePath}`,
+      r.sourcePath,
+      r.code,
+      r.targetPath.split('#')[0]
+    )
+  }
+
+  console.log(`\n-- defense-in-depth`)
+  await checkStatus(`/hub/ reachable (WHMCS hand-off)`, '/hub/', 200)
+  await checkStatus(`unknown URL returns 404`, '/this-page-does-not-exist-xyz/', 404)
+  await checkStatus(`favicon`, '/favicon.ico', 200)
+  await checkStatus(`sitemap.xml`, '/sitemap.xml', 200)
+  await checkStatus(`robots.txt`, '/robots.txt', 200)
+
+  const failed = results.filter((r) => !r.ok)
+  console.log(`\n${results.length - failed.length}/${results.length} passed`)
+  if (failed.length) {
+    console.log(`\nFailures:`)
+    for (const f of failed) console.log(`  ${FAIL} ${f.name} — ${f.detail}`)
+    process.exit(1)
+  }
+  process.exit(0)
+}
+
+main()

--- a/src/app/ffcadmin-free-for-charity-cpanel-backup-sop/page.tsx
+++ b/src/app/ffcadmin-free-for-charity-cpanel-backup-sop/page.tsx
@@ -1,4 +1,11 @@
+import type { Metadata } from 'next'
 import Link from 'next/link'
+
+export const metadata: Metadata = {
+  title: 'cPanel Backup SOP',
+  description: 'Internal Free For Charity admin runbook for cPanel backups.',
+  robots: { index: false, follow: false },
+}
 
 export default function CpanelBackupSop() {
   return (

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,59 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+
+export const metadata: Metadata = {
+  title: 'Page Not Found',
+  description: 'The page you were looking for could not be found.',
+  robots: { index: false, follow: false },
+}
+
+const popularDestinations = [
+  { href: '/', label: 'Home' },
+  { href: '/about-us', label: 'About Us' },
+  { href: '/donate', label: 'Donate' },
+  { href: '/volunteer', label: 'Volunteer' },
+  { href: '/help-for-charities', label: 'Help for Charities' },
+  { href: '/contact-us', label: 'Contact Us' },
+]
+
+export default function NotFound() {
+  return (
+    <div className="pt-[140px] pb-[80px]">
+      <div className="w-[90%] md:w-[80%] mx-auto max-w-[720px] text-center" id="aria-font">
+        <p className="text-[14px] font-[500] text-[#666] uppercase tracking-wider mb-[10px]">
+          404 &mdash; Page Not Found
+        </p>
+        <h1 className="text-[36px] leading-[44px] font-[600] text-[#333] mb-[20px] md:text-[44px] md:leading-[52px]">
+          We couldn&rsquo;t find that page
+        </h1>
+        <p className="text-[16px] leading-[26px] font-[500] text-[#555] mb-[16px]">
+          The page may have moved, the URL may be misspelled, or it may no longer exist.
+        </p>
+        <p className="text-[16px] leading-[26px] font-[500] text-[#555] mb-[32px]">
+          Try one of the destinations below, or head back to the home page.
+        </p>
+
+        <ul className="grid grid-cols-1 sm:grid-cols-2 gap-[12px] mb-[32px] text-left max-w-[480px] mx-auto">
+          {popularDestinations.map((dest) => (
+            <li key={dest.href}>
+              <Link
+                href={dest.href}
+                className="block px-[16px] py-[12px] rounded border border-[#e5e5e5] text-[#333] hover:border-[#f47c20] hover:text-[#f47c20] transition-colors"
+              >
+                {dest.label}
+              </Link>
+            </li>
+          ))}
+        </ul>
+
+        <p className="text-[14px] leading-[22px] font-[500] text-[#888]">
+          Still can&rsquo;t find what you&rsquo;re looking for?{' '}
+          <Link href="/contact-us" className="text-[#f47c20] underline">
+            Get in touch
+          </Link>
+          .
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -6,6 +6,9 @@ export default function sitemap(): MetadataRoute.Sitemap {
   const baseUrl = 'https://www.freeforcharity.org'
   const now = new Date()
 
+  // Internal admin pages (/ffcadmin/, /ffcadmin-free-for-charity-cpanel-backup-sop/)
+  // are intentionally omitted. Both carry robots: { index: false } in
+  // their page-level metadata, so listing them here would be incoherent.
   const routes = [
     { path: '/', priority: 1, changeFrequency: 'weekly' as const },
     { path: '/about-us', priority: 0.9, changeFrequency: 'monthly' as const },


### PR DESCRIPTION
## Summary

Bundled cutover-readiness work that is independent of #186's trailing-slash concern. Four small items in one focused PR.

### Changes

**1. Custom `src/app/not-found.tsx` (branded 404 with nav)**
Replaces the bare Next.js default with a 404 that links to six common destinations (Home, About, Donate, Volunteer, Help for Charities, Contact) plus a fallback "Get in touch" link. Apache `ErrorDocument 404 /404.html` still points at `next build`'s output — it'll now render this page.

**2. `scripts/smoke-test.mjs` + `npm run smoke-test`**
Post-deploy URL verifier. Reads `out/sitemap.xml` + `docs/cutover-redirects.csv`, hits every URL on the target origin (`BASE_URL=...` env var, defaults to production), verifies:
- every sitemap route returns 200
- canonical-form 301s fire (no-slash and `*.html` → `/slug/`)
- every WP→Next legacy 301 from CSV fires to the right target
- `/hub/` reachable, unknown URL 404s, `/sitemap.xml` + `/robots.txt` + `/favicon.ico` are 200

Intended workflow:
```
npm run build
BASE_URL=https://staging.freeforcharity.org npm run smoke-test
# ... swap document root ...
BASE_URL=https://www.freeforcharity.org npm run smoke-test
```

Exits non-zero on any failure — wireable into CI post-deploy step (planned in a follow-up PR).

**3. `noindex` on `/ffcadmin-free-for-charity-cpanel-backup-sop/`**
The page body says "intentionally not indexed by search engines" but had **zero** metadata, so Google would have indexed it anyway. Added `robots: { index: false, follow: false }` matching the existing `/ffcadmin/` page.

**4. Comment on `src/app/sitemap.ts`**
Document why both `/ffcadmin/` routes are omitted from the sitemap (both noindex), so the next dev looking at the route-count delta doesn't think it's an oversight.

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npm test` — 263 passed
- [x] `npm run build` — successful, `out/404.html` regenerated with new content
- [x] Local smoke run against `serve` — script logic verified (Apache-specific checks correctly fail on `serve`, as documented)
- [ ] CI lint + jest + Playwright
- [ ] Post-deploy: smoke script runs green against the live cPanel deploy
- [ ] Manual: visit `/this-page-does-not-exist/` on production → branded 404 renders

## Compatible with #186

No conflict with the trailing-slash PR. When #186 lands, internal links here canonicalize via Apache `DirectorySlash` without further edits.

Refs #29

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGJYDDsAjZ1PjdeBTVV4Qh)_