### PR TITLE
ci: gate deploy on CI green + full smoke suite post-deploy

### DIFF
--- a/.github/workflows/deploy-cpanel.yml
+++ b/.github/workflows/deploy-cpanel.yml
@@ -49,21 +49,33 @@ jobs:
           REF: ${{ github.sha }}
         run: |
           set -e
-          status=$(gh run list \
+          rows=$(gh run list \
             --workflow="CI - Build and Test" \
             --commit="$REF" \
-            --limit 1 \
-            --json status,conclusion \
-            --jq '.[0] // {}')
+            --limit 5 \
+            --json status,conclusion,databaseId,createdAt)
+          row_count=$(echo "$rows" | jq 'length')
+          if [ "$row_count" = "0" ]; then
+            echo "::error::No CI workflow run found for commit $REF."
+            echo "::error::This usually means:"
+            echo "::error::  - the commit was force-pushed after CI started (history rewritten)"
+            echo "::error::  - the CI workflow file was disabled or renamed since this commit"
+            echo "::error::  - the run was manually deleted"
+            echo "::error::Re-trigger CI on this ref before deploying:"
+            echo "::error::    gh workflow run 'CI - Build and Test' --ref $REF"
+            exit 1
+          fi
+          status=$(echo "$rows" | jq '.[0]')
           conclusion=$(echo "$status" | jq -r '.conclusion // "missing"')
           state=$(echo "$status" | jq -r '.status // "missing"')
-          echo "CI workflow on $REF: status=$state conclusion=$conclusion"
+          run_id=$(echo "$status" | jq -r '.databaseId // "?"')
+          echo "CI workflow on $REF: state=$state conclusion=$conclusion run_id=$run_id"
           if [ "$state" != "completed" ]; then
-            echo "::error::CI workflow has not finished on $REF (state=$state). Wait for CI to complete before deploying."
+            echo "::error::CI workflow on $REF is still $state (run $run_id). Wait for CI to complete before deploying."
             exit 1
           fi
           if [ "$conclusion" != "success" ]; then
-            echo "::error::CI workflow on $REF concluded with '$conclusion' — refuse to deploy."
+            echo "::error::CI workflow on $REF concluded with '$conclusion' (run $run_id) — refuse to deploy."
             exit 1
           fi
 

--- a/.github/workflows/deploy-cpanel.yml
+++ b/.github/workflows/deploy-cpanel.yml
@@ -23,6 +23,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 concurrency:
   group: deploy-cpanel
@@ -36,6 +37,35 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+
+      # Safety gate: refuse to deploy if the CI workflow (lint, jest,
+      # build, Playwright) on this exact commit isn't green. The deploy
+      # workflow itself doesn't re-run the test suite, so without this
+      # check an operator could ship a known-broken build.
+      - name: Verify CI is green for this ref
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          REF: ${{ github.sha }}
+        run: |
+          set -e
+          status=$(gh run list \
+            --workflow="CI - Build and Test" \
+            --commit="$REF" \
+            --limit 1 \
+            --json status,conclusion \
+            --jq '.[0] // {}')
+          conclusion=$(echo "$status" | jq -r '.conclusion // "missing"')
+          state=$(echo "$status" | jq -r '.status // "missing"')
+          echo "CI workflow on $REF: status=$state conclusion=$conclusion"
+          if [ "$state" != "completed" ]; then
+            echo "::error::CI workflow has not finished on $REF (state=$state). Wait for CI to complete before deploying."
+            exit 1
+          fi
+          if [ "$conclusion" != "success" ]; then
+            echo "::error::CI workflow on $REF concluded with '$conclusion' — refuse to deploy."
+            exit 1
+          fi
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -91,14 +121,25 @@ jobs:
             error_log
             .well-known/**
 
-      - name: Post-deploy smoke check
+      - name: Post-deploy smoke check (home reachable)
         env:
           DEPLOY_URL: https://freeforcharity.org/
         run: |
-          # Cloudflare proxy caches aggressively; bust with a header
+          # Quick reachability before the full smoke suite — bust Cloudflare
+          # cache so we observe the freshly-deployed origin.
           curl --fail --show-error --silent --location \
             --max-time 20 \
             -H "Cache-Control: no-cache" \
             -o /dev/null \
-            -w "Smoke: %{http_code} on %{url_effective} in %{time_total}s\n" \
+            -w "Home: %{http_code} on %{url_effective} in %{time_total}s\n" \
             "$DEPLOY_URL"
+
+      # Full smoke suite: every sitemap URL returns 200, every WP→Next
+      # 301 from docs/cutover-redirects.csv fires to the right target,
+      # /hub/ serves a WHMCS-marker body (not a stale index.html), an
+      # unknown URL returns 404, and key assets (sitemap.xml, robots.txt,
+      # favicon) are reachable. Fails the deploy job on any non-OK.
+      - name: Full smoke suite
+        env:
+          BASE_URL: https://freeforcharity.org
+        run: npm run smoke-test

--- a/.github/workflows/deploy-cpanel.yml
+++ b/.github/workflows/deploy-cpanel.yml
@@ -65,7 +65,13 @@ jobs:
             echo "::error::    gh workflow run 'CI - Build and Test' --ref $REF"
             exit 1
           fi
-          status=$(echo "$rows" | jq '.[0]')
+          # Pick the most recent run that actually decided an outcome —
+          # skip cancelled/skipped runs (operator cancel, concurrency
+          # group cancel, never-started skip) and fall through to an
+          # earlier run that ran the full suite. Without this, a manual
+          # cancel on the latest run would hide a previous green run and
+          # block the deploy.
+          status=$(echo "$rows" | jq '[.[] | select(.conclusion != "cancelled" and .conclusion != "skipped")][0] // .[0]')
           conclusion=$(echo "$status" | jq -r '.conclusion // "missing"')
           state=$(echo "$status" | jq -r '.status // "missing"')
           run_id=$(echo "$status" | jq -r '.databaseId // "?"')

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -45,7 +45,15 @@ async function request(path, { followRedirects = true } = {}) {
       method: 'GET',
       redirect: followRedirects ? 'follow' : 'manual',
       signal: controller.signal,
-      headers: { 'User-Agent': 'ffc-smoke-test/1.0' },
+      headers: {
+        'User-Agent': 'ffc-smoke-test/1.0',
+        // Bust the Cloudflare edge cache so a freshly-deployed origin
+        // is observed instead of a stale cached version. Without this,
+        // a smoke run immediately after deploy can pass against the
+        // pre-deploy HTML and report green on a regression.
+        'Cache-Control': 'no-cache',
+        Pragma: 'no-cache',
+      },
     })
     return { status: res.status, location: res.headers.get('location'), url: res.url }
   } catch (err) {

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -90,11 +90,13 @@ async function checkBodyContains(name, path, expectedSubstrings) {
   const subs = Array.isArray(expectedSubstrings) ? expectedSubstrings : [expectedSubstrings]
   const matched = r.body ? subs.find((s) => r.body.toLowerCase().includes(s.toLowerCase())) : null
   const ok = r.status >= 200 && r.status < 300 && Boolean(matched)
-  record(
-    name,
-    ok,
-    `${path} → ${r.status}${matched ? ` (body matches "${matched}")` : ' (no marker found)'}`
-  )
+  // Surface the underlying fetch failure (timeout / DNS / TLS) when the
+  // request didn't reach a response, instead of the misleading
+  // "no marker found" message.
+  const detail = r.error
+    ? `${path} → ${r.status} (${r.error})`
+    : `${path} → ${r.status}${matched ? ` (body matches "${matched}")` : ' (no marker found)'}`
+  record(name, ok, detail)
 }
 
 function loadSitemapPaths() {

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -36,7 +36,7 @@ function record(name, ok, detail) {
   process.stdout.write(`${ok ? PASS : FAIL} ${name}${detail ? ` — ${detail}` : ''}\n`)
 }
 
-async function head(path, { followRedirects = true } = {}) {
+async function head(path, { followRedirects = true, readBody = false } = {}) {
   const url = path.startsWith('http') ? path : `${BASE_URL}${path}`
   const controller = new AbortController()
   const timer = setTimeout(() => controller.abort(), TIMEOUT_MS)
@@ -47,7 +47,8 @@ async function head(path, { followRedirects = true } = {}) {
       signal: controller.signal,
       headers: { 'User-Agent': 'ffc-smoke-test/1.0' },
     })
-    return { status: res.status, location: res.headers.get('location'), url: res.url }
+    const body = readBody ? await res.text() : undefined
+    return { status: res.status, location: res.headers.get('location'), url: res.url, body }
   } catch (err) {
     return { status: 0, error: err.message }
   } finally {
@@ -66,6 +67,18 @@ async function checkRedirect(name, path, expectedStatus, expectedLocationSuffix)
   const locOk = r.location && r.location.endsWith(expectedLocationSuffix)
   const ok = r.status === expectedStatus && locOk
   record(name, ok, `${path} → ${r.status} ${r.location || '(no Location)'}`)
+}
+
+async function checkBodyContains(name, path, expectedSubstrings) {
+  const r = await head(path, { readBody: true })
+  const subs = Array.isArray(expectedSubstrings) ? expectedSubstrings : [expectedSubstrings]
+  const matched = r.body ? subs.find((s) => r.body.toLowerCase().includes(s.toLowerCase())) : null
+  const ok = r.status >= 200 && r.status < 300 && Boolean(matched)
+  record(
+    name,
+    ok,
+    `${path} → ${r.status}${matched ? ` (body matches "${matched}")` : ' (no marker found)'}`
+  )
 }
 
 function loadSitemapPaths() {
@@ -127,7 +140,14 @@ async function main() {
   }
 
   console.log(`\n-- defense-in-depth`)
-  await checkStatus(`/hub/ reachable (WHMCS hand-off)`, '/hub/', 200)
+  // WHMCS at /hub/ — assert response includes a WHMCS-specific marker so
+  // a stale index.html or directory listing doesn't pass as a healthy hub.
+  await checkBodyContains(`/hub/ serves WHMCS (not a placeholder)`, '/hub/', [
+    'whmcs',
+    'WHMCompleteSolution',
+    'cart.php',
+    'clientarea',
+  ])
   await checkStatus(`unknown URL returns 404`, '/this-page-does-not-exist-xyz/', 404)
   await checkStatus(`favicon`, '/favicon.ico', 200)
   await checkStatus(`sitemap.xml`, '/sitemap.xml', 200)


### PR DESCRIPTION
## Summary

Hardens the cutover deploy workflow so an operator can't accidentally ship a broken build, and replaces the shallow post-deploy HTTP-200 check with the full smoke suite from #241.

> **Stacked on top of #241** (`claude/cutover-readiness-prep`), because the smoke step relies on `scripts/smoke-test.mjs` which lands there. Merge #241 first; this PR will auto-rebase to main.

### Changes

**Refuse to deploy if CI hasn't passed on this ref**
`deploy-cpanel.yml` is `workflow_dispatch` only and never re-runs the test suite. Without this safety net, an operator can ship a known-broken build by triggering the workflow on a red commit. Added a "Verify CI is green for this ref" step that uses `gh run list` to look up the matching `CI - Build and Test` run for the deploy ref and fails if it isn't `completed` + `success`.

```yaml
- name: Verify CI is green for this ref
  env: { GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}, REF: ${{ github.sha }} }
  run: |
    status=$(gh run list --workflow="CI - Build and Test" --commit="$REF" --limit 1 --json status,conclusion --jq '.[0] // {}')
    # ... fail unless completed + success
```

Plays nicely with `workflow_dispatch` — the deploy still requires an explicit human trigger, just now refuses to fire on a red commit.

**Wire `scripts/smoke-test.mjs` into the deploy workflow**
Previous post-deploy step only verified the homepage returned HTTP 200. Replaced with `npm run smoke-test` against `BASE_URL=https://freeforcharity.org`:
- every URL in `out/sitemap.xml` returns 200
- every WP→Next 301 from `docs/cutover-redirects.csv` fires to the right target
- `/hub/` serves a WHMCS-marker body (see next item)
- unknown URL returns 404
- `/sitemap.xml`, `/robots.txt`, `/favicon.ico` reachable

The home-reachable curl step stays as a fast pre-check before the full suite (so we fail fast on total origin outage).

**Tighten `/hub/` assertion to validate response body**
Previously the smoke script accepted any 200 from `/hub/`. A stale `index.html` left over from a misconfigured deploy would silently pass. Added `checkBodyContains` helper that requires the response include one of:
- `whmcs`
- `WHMCompleteSolution`
- `cart.php`
- `clientarea`

A broken symlink or missing WHMCS install now reads as a hard deploy failure, not a green check.

## Test plan

- [x] `node --check scripts/smoke-test.mjs` — syntax OK
- [x] `npm run lint` — 0 errors
- [x] `npm test` — 263 passed
- [x] Local smoke run vs `serve` — script logic verified; `/hub/` correctly reports "no marker found" on the static-only test fixture (Apache + symlink will make this pass on the real cPanel host)
- [ ] CI lint + jest + Playwright on this branch
- [ ] Manual: trigger `deploy-cpanel.yml` against a commit with intentionally-failed CI → deploy refuses to fire
- [ ] Manual: trigger deploy on a green commit → CI-green gate passes, build + upload + smoke succeed against the live origin

## Why these three together

All three are deploy-pipeline integrity items: gate the deploy, observe the deploy, validate the most fragile component (WHMCS hand-off). Single PR keeps the deploy workflow reviewable as one cohesive change.

Refs #29

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGJYDDsAjZ1PjdeBTVV4Qh)_