### PR TITLE
test: image-path integrity, donation flows, cookie modal a11y

### DIFF
--- a/__tests__/data/image-paths.test.ts
+++ b/__tests__/data/image-paths.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Image-path integrity tests for src/data/**
+ *
+ * Walks every data file and asserts that every imageUrl-shaped string
+ * resolves to a real file under public/. Catches the failure mode where
+ * a referenced image is renamed/deleted from public/ but the JSON entry
+ * still points at the old path — invisible until a visitor lands on
+ * the page and gets a broken card.
+ *
+ * Scope: local paths only. External HTTPS images (LinkedIn, GuideStar)
+ * are not exercised by this test — they belong in the lychee/linkinator
+ * external-link checks.
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+
+const repoRoot = resolve(__dirname, '..', '..')
+const publicDir = join(repoRoot, 'public')
+const dataDir = join(repoRoot, 'src', 'data')
+
+const IMAGE_FIELDS = ['imageUrl', 'image', 'avatar', 'photo', 'src', 'heroImg']
+
+function collectJsonFiles(dir: string): string[] {
+  const out: string[] = []
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      out.push(...collectJsonFiles(full))
+    } else if (entry.endsWith('.json')) {
+      out.push(full)
+    }
+  }
+  return out
+}
+
+function* walkImagePaths(value: unknown, parentKey = ''): Generator<{ key: string; path: string }> {
+  if (value === null || value === undefined) return
+  if (typeof value === 'string') {
+    if (IMAGE_FIELDS.includes(parentKey) && value.startsWith('/')) {
+      yield { key: parentKey, path: value }
+    }
+    return
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) yield* walkImagePaths(item, parentKey)
+    return
+  }
+  if (typeof value === 'object') {
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      yield* walkImagePaths(v, k)
+    }
+  }
+}
+
+describe('src/data image-path integrity', () => {
+  const jsonFiles = collectJsonFiles(dataDir)
+
+  it('finds at least one data JSON file', () => {
+    expect(jsonFiles.length).toBeGreaterThan(0)
+  })
+
+  describe.each(jsonFiles.map((f) => [f.replace(repoRoot + '/', ''), f]))('%s', (_label, file) => {
+    const parsed = JSON.parse(readFileSync(file as string, 'utf8'))
+    const refs = [...walkImagePaths(parsed)]
+
+    if (refs.length === 0) {
+      // Some data files (faqs, testimonials) carry no image refs at
+      // all. Skip them — they're not relevant to this invariant.
+      it('has no local image paths to validate', () => {
+        expect(refs.length).toBe(0)
+      })
+      return
+    }
+
+    it.each(refs.map((r) => [`${r.key}=${r.path}`, r]))(
+      '%s resolves to an existing file in public/',
+      (_l, ref) => {
+        const r = ref as { key: string; path: string }
+        const resolved = join(publicDir, r.path.replace(/^\//, ''))
+        expect({ path: r.path, exists: existsSync(resolved) }).toEqual({
+          path: r.path,
+          exists: true,
+        })
+      }
+    )
+  })
+})

--- a/src/components/cookie-consent/index.tsx
+++ b/src/components/cookie-consent/index.tsx
@@ -378,7 +378,11 @@ export default function CookieConsent() {
             </h2>
             <p className="text-gray-600 mb-6">
               We use cookies to enhance your browsing experience and analyze our traffic. You can
-              choose which types of cookies you allow.
+              choose which types of cookies you allow. For full details, see our{' '}
+              <Link href="/cookie-policy" className="text-blue-600 hover:underline">
+                Cookie Policy
+              </Link>
+              .
             </p>
 
             {/* Necessary Cookies */}

--- a/tests/donation-flows.spec.ts
+++ b/tests/donation-flows.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Donation-flow smoke tests
+ *
+ * The site has no first-party donation form — every conversion goes
+ * through a third-party widget:
+ *   - PayPal hosted buttons on /donate/
+ *   - Zeffy iframe on /free-for-charity-endowment-fund/
+ *
+ * If a button is broken or an iframe fails to mount, the donation
+ * funnel silently dies and revenue stops. These tests are intentionally
+ * shallow — they don't drive a payment, just assert the controls
+ * render and point at the right endpoints. Third-party widget internal
+ * behaviour is out of scope (Zeffy/PayPal own that surface).
+ */
+
+const PAYPAL_HOSTED_BUTTON_IDS = ['9ZKQ23YC3G2J2', '243G37NHXSRY8']
+const ZEFFY_EMBED_HOSTS = ['zeffy.com']
+
+test.describe('Donation flows', () => {
+  test('/donate exposes at least one PayPal donate link with a hosted button ID', async ({
+    page,
+  }) => {
+    await page.goto('/donate')
+    await expect(page).toHaveTitle(/donate/i)
+
+    // PayPal links are <a href="https://www.paypal.com/donate/?hosted_button_id=...">
+    // — the components ship them as static markup, so they're present
+    // immediately without hydration.
+    const paypalLinks = page.locator('a[href*="paypal.com/donate"]')
+    await expect(paypalLinks.first()).toBeVisible()
+    const hrefs = await paypalLinks.evaluateAll((nodes) =>
+      nodes.map((n) => (n as HTMLAnchorElement).href)
+    )
+    const matched = hrefs.find((href) =>
+      PAYPAL_HOSTED_BUTTON_IDS.some((id) => href.includes(`hosted_button_id=${id}`))
+    )
+    expect(
+      matched,
+      `no PayPal href matches a known hosted_button_id: ${hrefs.join(', ')}`
+    ).toBeTruthy()
+  })
+
+  test('/free-for-charity-endowment-fund mounts the Zeffy donation iframe', async ({ page }) => {
+    await page.goto('/free-for-charity-endowment-fund')
+
+    // The Zeffy form is an <iframe src="https://www.zeffy.com/embed/...">.
+    // We wait for the element to be attached, then for its src attribute
+    // to reference zeffy.com — that catches both the "iframe element
+    // never rendered" and "iframe rendered with wrong src" failure modes.
+    const zeffyFrame = page.locator('iframe[src*="zeffy.com"]').first()
+    await expect(zeffyFrame).toBeAttached({ timeout: 15000 })
+
+    const src = await zeffyFrame.getAttribute('src')
+    expect(src).toBeTruthy()
+    expect(ZEFFY_EMBED_HOSTS.some((h) => src!.includes(h))).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

Closes three pre-flip test-coverage gaps. All three are visitor-impact protections — they fail loud if a regression slips in.

### Changes

**1. `__tests__/data/image-paths.test.ts` — local image-path integrity**
Walks every JSON file under `src/data/**` (team, testimonials, FAQ entries) and asserts every `imageUrl`-shaped string starting with `/` resolves to a real file under `public/`. Catches the failure mode where an image is renamed/deleted from `public/` but the JSON entry still references the old path — invisible until a visitor lands on the page and gets a broken card. Five team-member image refs exercised today; the discovery is generic so new data files are covered automatically.

External HTTPS image refs (LinkedIn, GuideStar) are intentionally out of scope — they belong in the lychee/linkinator external-link checks.

**2. `tests/donation-flows.spec.ts` — donation-funnel smoke**
Playwright smoke test that the two third-party donation widgets actually render:

| Route | Assertion |
|---|---|
| `/donate` | at least one `<a href="…paypal.com/donate?hosted_button_id=…">` matches a known hosted button ID (`9ZKQ23YC3G2J2` or `243G37NHXSRY8`) |
| `/free-for-charity-endowment-fund` | an `<iframe src="…zeffy.com/embed/…">` is attached to the DOM |

Deliberately shallow — doesn't drive a real payment. We only assert the controls render with the right endpoints. If a button breaks or an iframe fails to mount, this catches the silent revenue-stop; third-party widget internals are Zeffy's/PayPal's surface.

**3. `src/components/cookie-consent/index.tsx` — Cookie Policy link in preferences modal**
The banner links to `/privacy-policy` and `/cookie-policy`, but the modal's intro paragraph had no path to the full disclosure — borderline GDPR Art. 7 ("informed consent"). One inline `<Link href="/cookie-policy">Cookie Policy</Link>` in the preamble.

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npm test` — 274 passed (was 263, +11 from image-path test)
- [x] `npm run build` — successful
- [x] `npx playwright test tests/donation-flows.spec.ts tests/cookie-consent.spec.ts` — 16 passed (2 new donation-flow + 14 cookie-consent including the modal text the new link sits in)
- [ ] CI full Playwright run
- [ ] Manual: rename `public/Images/member1.webp` locally → `npm test` fails loudly with the missing-file path

## Why these together

All three are anti-regression tests for visitor-impacting silent failures. Single PR keeps them reviewable as one cohesive "test-coverage expansion" without dragging in unrelated refactors.

Refs #29

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGJYDDsAjZ1PjdeBTVV4Qh)_