### PR TITLE
docs: clarify Cloudflare Bulk Redirects decision + lychee post-cutover plan

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -39,9 +39,23 @@ https://dash.cloudflare.com/**
 
 # Internal GitHub Actions badge URLs — always valid when the workflow exists
 https://github.com/FreeForCharity/FFC-IN-freeforcharity.org/actions/**
-# Sites that block CI crawlers or are intentionally placeholder / flaky
+
+# Pre-cutover: the apex domain still points at WordPress, so any link in
+# the Next.js source pointing at https://freeforcharity.org/* would hit
+# WP and report misleading 200s/404s. Skip until cutover lands.
+#
+# POST-CUTOVER ACTION: once the document-root swap is complete and the
+# 48-hour soak has passed, narrow these to only the /hub/ subpath
+# (WHMCS — third-party app, we don't own the URL surface):
+#     https://freeforcharity.org/hub/**
+#     https://www.freeforcharity.org/hub/**
+# That lets lychee validate every /about-us, /donate, /volunteer, etc.
+# against the live new site, catching broken internal links the next
+# time someone touches a navigation component.
 https://freeforcharity.org/**
 https://www.freeforcharity.org/**
+
+# Sites that block CI crawlers or are intentionally placeholder / flaky
 https://my.interserver.net/**
 https://www.interserver.net/**
 https://support.cloudflare.com/**

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -45,10 +45,11 @@ https://github.com/FreeForCharity/FFC-IN-freeforcharity.org/actions/**
 # WP and report misleading 200s/404s. Skip until cutover lands.
 #
 # POST-CUTOVER ACTION: once the document-root swap is complete and the
-# 48-hour soak has passed, narrow these to only the /hub/ subpath
-# (WHMCS — third-party app, we don't own the URL surface):
-#     https://freeforcharity.org/hub/**
-#     https://www.freeforcharity.org/hub/**
+# 48-hour soak has passed, narrow these to only the paths we don't own:
+#     https://freeforcharity.org/hub/**          (WHMCS, third-party)
+#     https://www.freeforcharity.org/hub/**      (WHMCS, third-party)
+#     https://freeforcharity.org/cdn-cgi/**      (Cloudflare-managed)
+#     https://www.freeforcharity.org/cdn-cgi/**  (Cloudflare-managed)
 # That lets lychee validate every /about-us, /donate, /volunteer, etc.
 # against the live new site, catching broken internal links the next
 # time someone touches a navigation component.

--- a/docs/CUTOVER-REDIRECTS.md
+++ b/docs/CUTOVER-REDIRECTS.md
@@ -117,11 +117,15 @@ After cutover, smoke-test 5 sample URLs in an incognito browser:
 
 ---
 
-## Optional Cloudflare Bulk Redirects (skip unless needed)
+## Cloudflare Bulk Redirects (do NOT enable by default — see top of file)
 
-Only do this if you want redirects to fire at Cloudflare's edge instead
-of reaching the InterServer origin. It's redundant with `.htaccess` and
-adds a second place to keep in sync — most teams skip it.
+The intro section at the top of this document is the authoritative
+guidance: **skip this by default**. The CSV is shipped as a backup,
+not as something to flip on alongside `.htaccess`. The steps below
+exist so that, if the day comes when `.htaccess` is removed (e.g.
+migrating off cPanel) or you need edge-side preemption for a 301
+storm, you have a documented path to enable the rule without
+guessing. Until then, don't.
 
 1. Sign in to [dash.cloudflare.com](https://dash.cloudflare.com) →
    account level (not zone) → **Bulk Redirects**.

--- a/docs/CUTOVER-REDIRECTS.md
+++ b/docs/CUTOVER-REDIRECTS.md
@@ -8,12 +8,22 @@ ships with the static export and handles every redirect listed below at
 the InterServer Apache origin. No Cloudflare changes are required for
 the redirects to fire.
 
-**Optional secondary implementation:** the same redirects are also
-available as a Cloudflare [Bulk Redirects](https://developers.cloudflare.com/rules/url-forwarding/bulk-redirects/)
-import file at [`docs/cutover-redirects.csv`](cutover-redirects.csv) —
-useful if you want redirects to fire at Cloudflare's edge instead of
-the origin (saves a hop). Either source-of-truth works; don't enable
-both unless you accept the redundancy.
+**Cloudflare Bulk Redirects: DO NOT enable by default.** The same
+redirects are available as a Cloudflare [Bulk Redirects](https://developers.cloudflare.com/rules/url-forwarding/bulk-redirects/)
+import file at [`docs/cutover-redirects.csv`](cutover-redirects.csv).
+`.htaccess` is the single source of truth. Enabling the Cloudflare
+rule on top would double-source the redirect map and force every
+edit to happen in two places.
+
+**Enable the Cloudflare rule only if:**
+
+- `.htaccess` is ever removed (e.g. migrating off cPanel to a static
+  host without `.htaccess` semantics), or
+- you specifically want to preempt the origin hop for crawler traffic
+  during heavy 301 storms.
+
+The CSV is otherwise dead-weight kept in sync as a backup. Don't
+touch the toggle without updating this doc.
 
 ---
 


### PR DESCRIPTION
## Summary

Two doc-only sharpenings to close ambiguity in the cutover paperwork.

### Changes

**`docs/CUTOVER-REDIRECTS.md`** — rewrites the "optional secondary implementation" section into a load-bearing decision. The Cloudflare Bulk Redirects CSV at `docs/cutover-redirects.csv` stays in the repo as a backup, but the doc now explicitly says **"DO NOT enable by default"** and spells out the two scenarios where flipping the toggle would be warranted (`.htaccess` removal, edge preemption for 301 storms). Forecloses the ambiguity an operator might hit reading the previous wording and accidentally double-sourcing the redirect map.

**`.lycheeignore`** — annotates the `https://freeforcharity.org/**` and `https://www.freeforcharity.org/**` ignore patterns with an explicit `POST-CUTOVER ACTION` comment. Pre-cutover the apex still points at WordPress, so any internal link in the Next.js source would hit WP and report misleading 200s/404s. Once the document-root swap is done and the soak is over, the operator should narrow these to `/hub/**` only (WHMCS, third-party, not our concern) and let lychee validate every other internal link against the live new site.

## Test plan

- [x] No source code changes; build/test irrelevant
- [x] Pre-commit hook green
- [ ] Manual: confirm the operator reading `CUTOVER-REDIRECTS.md` can answer "should I enable Cloudflare Bulk Redirects?" without ambiguity
- [ ] Post-cutover: someone updates the `.lycheeignore` per the embedded action note and verifies lychee PR runs catch broken internal links

Refs #29

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGJYDDsAjZ1PjdeBTVV4Qh)_