### PR TITLE
chore: bump Node 20 → 24 LTS (Krypton) across all workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/deploy-cpanel-staging.yml
+++ b/.github/workflows/deploy-cpanel-staging.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/deploy-cpanel.yml
+++ b/.github/workflows/deploy-cpanel.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/deploy-gh-pages-staging.yml
+++ b/.github/workflows/deploy-gh-pages-staging.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Setup Pages

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Free For Charity is committed to providing a welcoming and inclusive environment
 
 ### Prerequisites
 
-- **Node.js**: Version 20.x (tested with v20.19.6)
+- **Node.js**: Version 24.x LTS (tested with v24.15.0)
 - **npm**: Comes with Node.js
 - **Git**: For version control
 - **Code Editor**: VS Code recommended with TypeScript support

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ For a complete list, see the [Site Map](#site-map) section below.
 
 ### Prerequisites
 
-- Node.js 20.x (tested with v20.19.6)
+- Node.js 24.x (tested with v24.15.0)
 - npm (comes with Node.js)
 
 ### Setup
@@ -407,7 +407,7 @@ The site uses **dual deployment** strategy:
 **Pipeline Steps**:
 
 1. Checkout repository
-2. Setup Node.js 20
+2. Setup Node.js 24
 3. Install dependencies with `npm ci`
 4. Install Playwright browsers
 5. Build with `NEXT_PUBLIC_BASE_PATH=/FFC-IN-freeforcharity.org`
@@ -589,4 +589,4 @@ This project is maintained by Free For Charity, a 501(c)(3) nonprofit organizati
 
 **Documentation Status**: ✅ Updated February 2026  
 **Next.js Version**: 16.0.10  
-**Node.js Version**: 20.x required
+**Node.js Version**: 24.x required

--- a/TESTING.md
+++ b/TESTING.md
@@ -6,7 +6,7 @@ This guide provides comprehensive documentation for testing the Free For Charity
 
 ### Prerequisites
 
-- Node.js 20.x installed
+- Node.js 24.x installed
 - Dependencies installed (`npm install`)
 - Built application (`npm run build`)
 
@@ -30,7 +30,7 @@ npm run test:ui       # Interactive Playwright UI
 ### 1. Verify Dependencies
 
 ```bash
-node --version        # Should be v20.x
+node --version        # Should be v24.x
 npm --version         # Should be 10.x
 ```
 
@@ -181,7 +181,7 @@ npx playwright test --debug
 Tests run automatically in GitHub Actions:
 
 - **Trigger**: Every push to main branch
-- **Environment**: Ubuntu latest with Node.js 20
+- **Environment**: Ubuntu latest with Node.js 24
 - **Browser Setup**: `npx playwright install --with-deps chromium`
 - **Build**: Built with `NEXT_PUBLIC_BASE_PATH=/freeforcharity-web`
 - **Retry Logic**: Failed tests retry 2 times
@@ -378,7 +378,7 @@ Key settings:
 **Pipeline Steps**:
 
 1. ✅ Checkout repository
-2. ✅ Setup Node.js 20 with caching
+2. ✅ Setup Node.js 24 with caching
 3. ✅ Install dependencies (`npm ci`)
 4. ✅ Restore Next.js build cache
 5. ✅ Install Playwright browsers with system dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@types/jest": "^30.0.0",
-        "@types/node": "^20",
+        "@types/node": "^24.12.4",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "cross-env": "^10.1.0",
@@ -4077,13 +4077,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.11.tgz",
-      "integrity": "sha512-uug3FEEGv0r+jrecvUUpbY8lLisvIjg6AAic6a2bSP5OEOLeJsDSnvhCDov7ipFFMXS3orMpzlmi0ZcuGkBbow==",
+      "version": "24.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/react": {
@@ -7916,6 +7916,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -15215,9 +15216,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/jest": "^30.0.0",
-    "@types/node": "^20",
+    "@types/node": "^24.12.4",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "cross-env": "^10.1.0",


### PR DESCRIPTION
## Summary

Node 20 enters end-of-active-maintenance later this year. Bumping to Node 24 LTS (Krypton) — currently the Active LTS line — keeps CI on a supported runtime well ahead of the EOL window.

## Picked: Node 24.x (LTS Krypton)

Per the user's spec: "the most modern variation that is stable and at least one week old." From `nodejs.org/dist/index.json`:

| Version | Status | Released |
|---|---|---|
| **v24.15.0** | Active LTS (Krypton) | 2026-04-15 (5+ weeks old) ✅ |
| v25.x | Current (no LTS) | Active development |
| v26.x | Current (no LTS) | 2026-05-05 (3 weeks old) |

Picked v24.x LTS for the production-grade stability guarantee. The minor pin in `setup-node` is `24` (no specific patch) — picks up the latest 24.x patch on each CI run.

## Changes

- All 5 workflows: `actions/setup-node` `node-version: '20'` → `'24'`
  - `ci.yml`, `deploy-cpanel.yml`, `deploy-cpanel-staging.yml`, `deploy-gh-pages-staging.yml`, `lighthouse.yml`
- `package.json` `@types/node`: `^20` → `^24.12.4` (matches runtime; this is the change Dependabot has been asking for in #99)

## Compatibility

- Next.js 16 (current) officially supports Node 22.x and 24.x.
- @next/swc native binaries are pre-built for Node 22/24 ABI.
- No source-code changes were needed.

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npm test` — 175 passed
- [x] `npm run build` — successful
- [ ] CI Test and Build (will use Node 24 from this PR)
- [ ] Manual: trigger deploy-cpanel.yml — should also pull 24 now

## Closes/supersedes

Closes the long-stale Dependabot #99 (`@types/node` 20 → 25), but pinned to 24 instead since the runtime is LTS 24.