### PR TITLE
perf: capture WP Lighthouse baseline + drop TTL pre-flight step

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -29,3 +29,4 @@ playwright-report
 # Other
 .DS_Store
 *.pem
+docs/performance-baseline/

--- a/.prettierignore
+++ b/.prettierignore
@@ -29,4 +29,7 @@ playwright-report
 # Other
 .DS_Store
 *.pem
-docs/performance-baseline/
+# Skip Lighthouse-generated JSON — it's machine output, not prose, and
+# prettier-formatting it would create a giant noise diff on every refresh.
+# The hand-written README stays prettier-managed.
+docs/performance-baseline/*.json

--- a/docs/CUTOVER-HANDOFF.md
+++ b/docs/CUTOVER-HANDOFF.md
@@ -102,7 +102,7 @@ because it lives in a sibling directory.
 
    The deploy workflow (`.github/workflows/deploy-cpanel.yml`) already maps these secrets into the `npm run build` step's `env:` block. Once the secret is populated in repo settings, the next deploy bakes the value into the static export (no further workflow edit needed). Without the secret, the corresponding analytics script never loads (no placeholder fallbacks).
 
-5. **(Optional) lower DNS TTL** to 300s ([#136](https://github.com/FreeForCharity/FFC-IN-freeforcharity.org/issues/136)). Not strictly required because DNS isn't changing, but useful if you want to keep the rollback window short. **Restore after T+48h** — see Post-flip step 3 below.
+5. **DNS TTL — leave on "Auto"** ([#136](https://github.com/FreeForCharity/FFC-IN-freeforcharity.org/issues/136)). For this cutover, DNS doesn't change — the swap happens at the cPanel document-root level on the same origin. Cloudflare's "Auto" TTL already serves proxied records at 300s, so manually lowering buys nothing and forgetting to restore it after costs subsequent-deploy propagation time. **Skip this step unless you're also planning a DNS change** (and you aren't).
 
 ### First deploy (creates `public_html_next/`)
 
@@ -139,7 +139,7 @@ because it lives in a sibling directory.
 
 1. **First 30 min** ([#141](https://github.com/FreeForCharity/FFC-IN-freeforcharity.org/issues/141)) — keep an eye on Apache error logs, Cloudflare 5xx rate, WHMCS at `/hub/`. Per [`docs/STAGING-CHECKLIST.md`](STAGING-CHECKLIST.md) §8.
 2. **48-hour soak** ([#142](https://github.com/FreeForCharity/FFC-IN-freeforcharity.org/issues/142)) — let organic traffic + an off-hours billing cycle hit the new stack before declaring it stable.
-3. **At T+48h: restore DNS TTL** (if you lowered it pre-flight in step 5). Cloudflare → DNS → set the apex record TTL back to **Auto** (or **3600s** if explicit). Owner: same operator who lowered the TTL. Skipping this leaves subsequent deploys eating an extra propagation cycle.
+3. **DNS TTL: nothing to do.** Cloudflare "Auto" is what we want. The Auto setting already serves proxied apex records at 300s. Manually pinning a value (and forgetting to restore it) is the failure mode this step was guarding against — pre-flight step 5 above no longer recommends lowering it.
 4. **14-day decommission** ([#144](https://github.com/FreeForCharity/FFC-IN-freeforcharity.org/issues/144)) — archive WordPress files, drop WP database. Confirms there have been no rollback-triggering incidents during the soak window.
 
 ### If anything breaks

--- a/docs/performance-baseline/README.md
+++ b/docs/performance-baseline/README.md
@@ -1,0 +1,34 @@
+# WordPress baseline — captured 2026-05-24 (mobile, Lighthouse 11)
+
+Compare against the Next.js Lighthouse CI after cutover.
+
+| Page | Perf | A11y | Best | SEO | LCP (s) | CLS | TBT (ms) |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| `about-us` | 77 | 63 | 73 | 85 | 2.5 | 0.011 | 612 |
+| `contact-us` | 59 | 63 | 73 | 85 | 4.2 | 0.12 | 640 |
+| `donate` | 60 | 65 | 73 | 85 | 4.8 | 0.089 | 578 |
+| `help-for-charities` | 71 | 63 | 73 | 85 | 2.7 | 0.067 | 709 |
+| `home` | 57 | 69 | 73 | 77 | 2.5 | 0.238 | 898 |
+
+## Methodology
+
+- Tool: Lighthouse 11 CLI, mobile form factor, Chromium 1208 (Playwright-bundled)
+- Flags: `--ignore-certificate-errors --no-sandbox --headless=new`
+- Origin: live WordPress at `https://freeforcharity.org` (pre-cutover state)
+- Each page run once (no median-of-3) — directional baseline, not a benchmark
+- Only summary metrics are committed (the full Lighthouse JSON embeds
+  base64-encoded screenshots that GitHub secret-scanning false-positive
+  flags as Azure bot keys). To regenerate a full HTML report locally:
+
+  ```bash
+  npx lighthouse https://freeforcharity.org/ \
+    --form-factor=mobile --output=html \
+    --output-path=/tmp/wp-home.html \
+    --chrome-flags="--headless=new --no-sandbox --ignore-certificate-errors"
+  ```
+
+## How to compare post-cutover
+
+After the document-root swap and 48-hour soak, run Lighthouse against the new
+Next.js export at the same URLs and append a `next-` prefixed report set.
+Delta of > 10 points on perf or LCP > +500ms is worth investigating.

--- a/docs/performance-baseline/README.md
+++ b/docs/performance-baseline/README.md
@@ -1,18 +1,20 @@
-# WordPress baseline — captured 2026-05-24 (mobile, Lighthouse 11)
+# WordPress baseline — captured 2026-05-24 (mobile, Lighthouse 13.3.0)
 
 Compare against the Next.js Lighthouse CI after cutover.
 
-| Page | Perf | A11y | Best | SEO | LCP (s) | CLS | TBT (ms) |
-|---|---:|---:|---:|---:|---:|---:|---:|
-| `about-us` | 77 | 63 | 73 | 85 | 2.5 | 0.011 | 612 |
-| `contact-us` | 59 | 63 | 73 | 85 | 4.2 | 0.12 | 640 |
-| `donate` | 60 | 65 | 73 | 85 | 4.8 | 0.089 | 578 |
-| `help-for-charities` | 71 | 63 | 73 | 85 | 2.7 | 0.067 | 709 |
-| `home` | 57 | 69 | 73 | 77 | 2.5 | 0.238 | 898 |
+| Page                 | Perf | A11y | Best | SEO | LCP (s) |   CLS | TBT (ms) |
+| -------------------- | ---: | ---: | ---: | --: | ------: | ----: | -------: |
+| `about-us`           |   77 |   63 |   73 |  85 |     2.5 | 0.011 |      612 |
+| `contact-us`         |   59 |   63 |   73 |  85 |     4.2 |  0.12 |      640 |
+| `donate`             |   60 |   65 |   73 |  85 |     4.8 | 0.089 |      578 |
+| `help-for-charities` |   71 |   63 |   73 |  85 |     2.7 | 0.067 |      709 |
+| `home`               |   57 |   69 |   73 |  77 |     2.5 | 0.238 |      898 |
 
 ## Methodology
 
-- Tool: Lighthouse 11 CLI, mobile form factor, Chromium 1208 (Playwright-bundled)
+- Tool: Lighthouse 13.3.0 CLI, mobile form factor
+- Chromium: whatever your system Chrome resolves to; in our run, the
+  Playwright-bundled Chromium 1208 was used by setting `CHROME_PATH=...`
 - Flags: `--ignore-certificate-errors --no-sandbox --headless=new`
 - Origin: live WordPress at `https://freeforcharity.org` (pre-cutover state)
 - Each page run once (no median-of-3) — directional baseline, not a benchmark
@@ -21,6 +23,10 @@ Compare against the Next.js Lighthouse CI after cutover.
   flags as Azure bot keys). To regenerate a full HTML report locally:
 
   ```bash
+  # Optional: pin to the same Chromium binary the baseline used. Without
+  # CHROME_PATH set, lighthouse uses whatever Chrome it finds on $PATH.
+  export CHROME_PATH=$(npx --yes @playwright/browser-chromium@latest find chromium)
+
   npx lighthouse https://freeforcharity.org/ \
     --form-factor=mobile --output=html \
     --output-path=/tmp/wp-home.html \

--- a/docs/performance-baseline/wp-about-us.report.json
+++ b/docs/performance-baseline/wp-about-us.report.json
@@ -1,0 +1,63 @@
+{
+  "finalDisplayedUrl": "https://freeforcharity.org/about-us/",
+  "fetchTime": "2026-05-24T17:03:30.075Z",
+  "lighthouseVersion": "13.3.0",
+  "configSettings": {
+    "formFactor": "mobile"
+  },
+  "categories": {
+    "performance": {
+      "score": 0.77,
+      "title": "Performance"
+    },
+    "accessibility": {
+      "score": 0.63,
+      "title": "Accessibility"
+    },
+    "best-practices": {
+      "score": 0.73,
+      "title": "Best Practices"
+    },
+    "seo": {
+      "score": 0.85,
+      "title": "SEO"
+    }
+  },
+  "audits": {
+    "largest-contentful-paint": {
+      "numericValue": 2481.8405,
+      "displayValue": "2.5\u00a0s",
+      "score": 0.9
+    },
+    "cumulative-layout-shift": {
+      "numericValue": 0.010807793051216437,
+      "displayValue": "0.011",
+      "score": 1
+    },
+    "total-blocking-time": {
+      "numericValue": 611.5,
+      "displayValue": "610\u00a0ms",
+      "score": 0.49
+    },
+    "first-contentful-paint": {
+      "numericValue": 1957.1385000000002,
+      "displayValue": "2.0\u00a0s",
+      "score": 0.85
+    },
+    "speed-index": {
+      "numericValue": 5183.295406885443,
+      "displayValue": "5.2\u00a0s",
+      "score": 0.6
+    },
+    "interactive": {
+      "numericValue": 8711.74885,
+      "displayValue": "8.7\u00a0s",
+      "score": 0.36
+    },
+    "server-response-time": {
+      "numericValue": 2072,
+      "displayValue": "Root document took 2,070\u00a0ms",
+      "score": 0
+    }
+  }
+}

--- a/docs/performance-baseline/wp-contact-us.report.json
+++ b/docs/performance-baseline/wp-contact-us.report.json
@@ -1,0 +1,63 @@
+{
+  "finalDisplayedUrl": "https://freeforcharity.org/contact-us/",
+  "fetchTime": "2026-05-24T17:04:11.198Z",
+  "lighthouseVersion": "13.3.0",
+  "configSettings": {
+    "formFactor": "mobile"
+  },
+  "categories": {
+    "performance": {
+      "score": 0.59,
+      "title": "Performance"
+    },
+    "accessibility": {
+      "score": 0.63,
+      "title": "Accessibility"
+    },
+    "best-practices": {
+      "score": 0.73,
+      "title": "Best Practices"
+    },
+    "seo": {
+      "score": 0.85,
+      "title": "SEO"
+    }
+  },
+  "audits": {
+    "largest-contentful-paint": {
+      "numericValue": 4230.607,
+      "displayValue": "4.2\u00a0s",
+      "score": 0.43
+    },
+    "cumulative-layout-shift": {
+      "numericValue": 0.11986698478329795,
+      "displayValue": "0.12",
+      "score": 0.84
+    },
+    "total-blocking-time": {
+      "numericValue": 639.9999999999995,
+      "displayValue": "640\u00a0ms",
+      "score": 0.46
+    },
+    "first-contentful-paint": {
+      "numericValue": 2083.6095,
+      "displayValue": "2.1\u00a0s",
+      "score": 0.81
+    },
+    "speed-index": {
+      "numericValue": 5536.467847273574,
+      "displayValue": "5.5\u00a0s",
+      "score": 0.54
+    },
+    "interactive": {
+      "numericValue": 8348.658800000001,
+      "displayValue": "8.3\u00a0s",
+      "score": 0.39
+    },
+    "server-response-time": {
+      "numericValue": 1960,
+      "displayValue": "Root document took 1,960\u00a0ms",
+      "score": 0
+    }
+  }
+}

--- a/docs/performance-baseline/wp-donate.report.json
+++ b/docs/performance-baseline/wp-donate.report.json
@@ -1,0 +1,63 @@
+{
+  "finalDisplayedUrl": "https://freeforcharity.org/donate/",
+  "fetchTime": "2026-05-24T17:03:48.683Z",
+  "lighthouseVersion": "13.3.0",
+  "configSettings": {
+    "formFactor": "mobile"
+  },
+  "categories": {
+    "performance": {
+      "score": 0.6,
+      "title": "Performance"
+    },
+    "accessibility": {
+      "score": 0.65,
+      "title": "Accessibility"
+    },
+    "best-practices": {
+      "score": 0.73,
+      "title": "Best Practices"
+    },
+    "seo": {
+      "score": 0.85,
+      "title": "SEO"
+    }
+  },
+  "audits": {
+    "largest-contentful-paint": {
+      "numericValue": 4785.3305,
+      "displayValue": "4.8\u00a0s",
+      "score": 0.31
+    },
+    "cumulative-layout-shift": {
+      "numericValue": 0.08938882385507911,
+      "displayValue": "0.089",
+      "score": 0.92
+    },
+    "total-blocking-time": {
+      "numericValue": 578,
+      "displayValue": "580\u00a0ms",
+      "score": 0.51
+    },
+    "first-contentful-paint": {
+      "numericValue": 1104.2869999999998,
+      "displayValue": "1.1\u00a0s",
+      "score": 0.99
+    },
+    "speed-index": {
+      "numericValue": 6370.151041901208,
+      "displayValue": "6.4\u00a0s",
+      "score": 0.41
+    },
+    "interactive": {
+      "numericValue": 8828.77015,
+      "displayValue": "8.8\u00a0s",
+      "score": 0.35
+    },
+    "server-response-time": {
+      "numericValue": 3040,
+      "displayValue": "Root document took 3,040\u00a0ms",
+      "score": 0
+    }
+  }
+}

--- a/docs/performance-baseline/wp-help-for-charities.report.json
+++ b/docs/performance-baseline/wp-help-for-charities.report.json
@@ -1,0 +1,63 @@
+{
+  "finalDisplayedUrl": "https://freeforcharity.org/help-for-charities/",
+  "fetchTime": "2026-05-24T17:04:29.531Z",
+  "lighthouseVersion": "13.3.0",
+  "configSettings": {
+    "formFactor": "mobile"
+  },
+  "categories": {
+    "performance": {
+      "score": 0.71,
+      "title": "Performance"
+    },
+    "accessibility": {
+      "score": 0.63,
+      "title": "Accessibility"
+    },
+    "best-practices": {
+      "score": 0.73,
+      "title": "Best Practices"
+    },
+    "seo": {
+      "score": 0.85,
+      "title": "SEO"
+    }
+  },
+  "audits": {
+    "largest-contentful-paint": {
+      "numericValue": 2723.4539999999997,
+      "displayValue": "2.7\u00a0s",
+      "score": 0.85
+    },
+    "cumulative-layout-shift": {
+      "numericValue": 0.06671635378428262,
+      "displayValue": "0.067",
+      "score": 0.97
+    },
+    "total-blocking-time": {
+      "numericValue": 708.9070000000015,
+      "displayValue": "710\u00a0ms",
+      "score": 0.42
+    },
+    "first-contentful-paint": {
+      "numericValue": 1952.7240000000002,
+      "displayValue": "2.0\u00a0s",
+      "score": 0.85
+    },
+    "speed-index": {
+      "numericValue": 6194.260479418703,
+      "displayValue": "6.2\u00a0s",
+      "score": 0.43
+    },
+    "interactive": {
+      "numericValue": 8831.148899999998,
+      "displayValue": "8.8\u00a0s",
+      "score": 0.35
+    },
+    "server-response-time": {
+      "numericValue": 2643,
+      "displayValue": "Root document took 2,640\u00a0ms",
+      "score": 0
+    }
+  }
+}

--- a/docs/performance-baseline/wp-home.report.json
+++ b/docs/performance-baseline/wp-home.report.json
@@ -1,0 +1,63 @@
+{
+  "finalDisplayedUrl": "https://freeforcharity.org/",
+  "fetchTime": "2026-05-24T17:03:08.577Z",
+  "lighthouseVersion": "13.3.0",
+  "configSettings": {
+    "formFactor": "mobile"
+  },
+  "categories": {
+    "performance": {
+      "score": 0.57,
+      "title": "Performance"
+    },
+    "accessibility": {
+      "score": 0.69,
+      "title": "Accessibility"
+    },
+    "best-practices": {
+      "score": 0.73,
+      "title": "Best Practices"
+    },
+    "seo": {
+      "score": 0.77,
+      "title": "SEO"
+    }
+  },
+  "audits": {
+    "largest-contentful-paint": {
+      "numericValue": 2519.3259999999996,
+      "displayValue": "2.5\u00a0s",
+      "score": 0.89
+    },
+    "cumulative-layout-shift": {
+      "numericValue": 0.2379448017041151,
+      "displayValue": "0.238",
+      "score": 0.52
+    },
+    "total-blocking-time": {
+      "numericValue": 897.5000000000005,
+      "displayValue": "900\u00a0ms",
+      "score": 0.31
+    },
+    "first-contentful-paint": {
+      "numericValue": 1938.004,
+      "displayValue": "1.9\u00a0s",
+      "score": 0.86
+    },
+    "speed-index": {
+      "numericValue": 6818.615323246632,
+      "displayValue": "6.8\u00a0s",
+      "score": 0.34
+    },
+    "interactive": {
+      "numericValue": 9634.01575,
+      "displayValue": "9.6\u00a0s",
+      "score": 0.29
+    },
+    "server-response-time": {
+      "numericValue": 2180,
+      "displayValue": "Root document took 2,180\u00a0ms",
+      "score": 0
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Two cutover-doc improvements bundled.

### 1. WordPress Lighthouse baseline

Captured 2026-05-24 against the live WP origin (just before cutover) on 5 representative pages. Lets us spot post-cutover regressions vs the WP floor instead of guessing.

| Page | Perf | LCP | CLS | TBT |
|---|---:|---:|---:|---:|
| home | 57 | 2.5s | **0.238** | 898ms |
| about-us | 77 | 2.5s | 0.011 | 612ms |
| donate | 60 | **4.8s** | 0.089 | 578ms |
| contact-us | 59 | 4.2s | 0.12 | 640ms |
| help-for-charities | 71 | 2.7s | 0.067 | 709ms |

Highlights: home has poor CLS (0.238 — visible content shifts); donate has bad LCP (4.8s). Both are easy wins for the Next.js redesign to beat.

Only summary metrics are committed (categories scores + 7 CWV audits per page). Full HTML reports aren't checked in — they embed base64 screenshots that GitHub secret-scanning false-positive flags as Azure bot keys, and they'd add ~4MB per run to the repo. The README has a one-line invocation to regenerate any HTML report locally on demand.

### 2. Drop the TTL-lowering pre-flight step

Per operator feedback: Cloudflare's "Auto" TTL already serves proxied apex records at 300s, so manually lowering buys nothing for this cutover (DNS isn't changing — the swap is at the cPanel docroot level on the same origin). Forgetting to restore a manually-pinned TTL costs subsequent deploy propagation time.

- Pre-flight step 5 rewritten: "leave Auto alone"
- Post-flip step 3 rewritten: "nothing to do"

## Test plan

- [x] Lighthouse reports captured against live WP and committed
- [x] CUTOVER-HANDOFF.md still scans cleanly
- [x] No source code changes; build/test irrelevant
- [ ] Post-cutover: re-run lighthouse against the new origin, append to this dir, diff

Refs #29