### PR TITLE
feat(analytics): commit public IDs as defaults + Playwright coverage

### DIFF
--- a/src/components/cookie-consent/index.tsx
+++ b/src/components/cookie-consent/index.tsx
@@ -2,20 +2,13 @@
 
 import { useState, useEffect, useRef, useCallback } from 'react'
 import Link from 'next/link'
-
-// Tracking IDs come from build-time env vars. No placeholder fallbacks:
-// a missing var must mean "don't load the script" — never "load with a
-// fake/dev ID" — so we don't risk shipping bogus or accidentally-real
-// hardcoded keys to production.
-const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID || ''
-const META_PIXEL_ID = process.env.NEXT_PUBLIC_META_PIXEL_ID || ''
-const CLARITY_PROJECT_ID = process.env.NEXT_PUBLIC_CLARITY_PROJECT_ID || ''
-const GTM_CONTAINER_ID = process.env.NEXT_PUBLIC_GTM_CONTAINER_ID || ''
-// Tawk.to live-chat widget. Property + widget IDs in the form
-// "65bf15eb0ff6374032c915d9/1hlp6r8hc" — same format the dashboard
-// shows. Loads as a functional cookie (visitor-support tooling),
-// not an analytics one, so it's not behind the analytics consent gate.
-const TAWK_TO_PROPERTY = process.env.NEXT_PUBLIC_TAWK_TO_PROPERTY || ''
+import {
+  GA_MEASUREMENT_ID,
+  META_PIXEL_ID,
+  CLARITY_PROJECT_ID,
+  GTM_CONTAINER_ID,
+  TAWK_TO_PROPERTY,
+} from '@/lib/analytics-config'
 
 // Define type for GTM dataLayer events
 interface DataLayerEvent {

--- a/src/components/sentry-init/index.tsx
+++ b/src/components/sentry-init/index.tsx
@@ -2,20 +2,19 @@
 
 import { useEffect } from 'react'
 import * as Sentry from '@sentry/browser'
+import { SENTRY_DSN, SENTRY_ENVIRONMENT } from '@/lib/analytics-config'
 
 // Client-only Sentry initializer. Sits in the root layout as a sibling
 // of CookieConsent so it loads as early as possible without depending
 // on consent (errors and CSP violations are functional/necessary, not
 // analytics — capturing them is required to keep the site running).
 //
-// No-op when NEXT_PUBLIC_SENTRY_DSN is unset, so the import + bundle
-// cost is the only overhead until an operator wires Sentry up.
+// No-op when SENTRY_DSN is unset, so the import + bundle cost is the
+// only overhead until an operator wires Sentry up.
 //
 // We use @sentry/browser rather than @sentry/nextjs because this is a
 // pure static export — there's no Next.js server runtime to integrate
 // with, and @sentry/browser is significantly smaller.
-const SENTRY_DSN = process.env.NEXT_PUBLIC_SENTRY_DSN || ''
-const SENTRY_ENVIRONMENT = process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT || 'production'
 
 export default function SentryInit() {
   useEffect(() => {

--- a/src/lib/analytics-config.ts
+++ b/src/lib/analytics-config.ts
@@ -17,21 +17,28 @@
 //
 // Anything genuinely secret (FTP creds, API tokens) stays in GitHub
 // Actions secrets and never appears here.
+//
+// `??` (not `||`) so a build can DISABLE an integration by setting its
+// env var to an empty string — e.g. a staging build with
+// `NEXT_PUBLIC_GA_MEASUREMENT_ID=""` gets an empty ID (loader no-ops),
+// whereas `||` would treat "" as falsy and fall back to the default,
+// making it impossible to turn off. An unset var is `undefined`, which
+// `??` correctly resolves to the default.
 
-export const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID || 'G-541Y8JRDLX'
+export const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID ?? 'G-541Y8JRDLX'
 
-export const GTM_CONTAINER_ID = process.env.NEXT_PUBLIC_GTM_CONTAINER_ID || 'GTM-NJ4DXH9'
+export const GTM_CONTAINER_ID = process.env.NEXT_PUBLIC_GTM_CONTAINER_ID ?? 'GTM-NJ4DXH9'
 
-export const CLARITY_PROJECT_ID = process.env.NEXT_PUBLIC_CLARITY_PROJECT_ID || 'nzldyj4h3k'
+export const CLARITY_PROJECT_ID = process.env.NEXT_PUBLIC_CLARITY_PROJECT_ID ?? 'nzldyj4h3k'
 
 export const TAWK_TO_PROPERTY =
-  process.env.NEXT_PUBLIC_TAWK_TO_PROPERTY || '65bf15eb0ff6374032c915d9/1hlp6r8hc'
+  process.env.NEXT_PUBLIC_TAWK_TO_PROPERTY ?? '65bf15eb0ff6374032c915d9/1hlp6r8hc'
 
 // No Meta Pixel or Sentry project configured yet — these stay empty
 // until an operator sets the env var (or adds a default here once a
 // real ID exists). Empty = the corresponding loader is a no-op.
-export const META_PIXEL_ID = process.env.NEXT_PUBLIC_META_PIXEL_ID || ''
+export const META_PIXEL_ID = process.env.NEXT_PUBLIC_META_PIXEL_ID ?? ''
 
-export const SENTRY_DSN = process.env.NEXT_PUBLIC_SENTRY_DSN || ''
+export const SENTRY_DSN = process.env.NEXT_PUBLIC_SENTRY_DSN ?? ''
 
-export const SENTRY_ENVIRONMENT = process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT || 'production'
+export const SENTRY_ENVIRONMENT = process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT ?? 'production'

--- a/src/lib/analytics-config.ts
+++ b/src/lib/analytics-config.ts
@@ -1,0 +1,37 @@
+// Public analytics / widget IDs.
+//
+// These are NOT secrets. Every one of them is emitted into the client
+// HTML/JS of any site that uses them and is trivially visible in page
+// source — GA4 measurement IDs, GTM container IDs, Clarity project IDs,
+// and Tawk.to property IDs are all public by design. Treating them as
+// GitHub Actions "secrets" gave no security benefit and had a real cost:
+// only the production deploy workflow injected them, so CI builds, local
+// builds, and Playwright runs all built with empty IDs — meaning the
+// analytics integration was untestable and only worked in production.
+//
+// Committing the real production values here as defaults makes the
+// integration identical across every build (local, CI, production) and
+// testable in Playwright. Each value is still overridable via its
+// NEXT_PUBLIC_* env var, so a staging deploy can point at different
+// properties by setting the env var at build time.
+//
+// Anything genuinely secret (FTP creds, API tokens) stays in GitHub
+// Actions secrets and never appears here.
+
+export const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID || 'G-541Y8JRDLX'
+
+export const GTM_CONTAINER_ID = process.env.NEXT_PUBLIC_GTM_CONTAINER_ID || 'GTM-NJ4DXH9'
+
+export const CLARITY_PROJECT_ID = process.env.NEXT_PUBLIC_CLARITY_PROJECT_ID || 'nzldyj4h3k'
+
+export const TAWK_TO_PROPERTY =
+  process.env.NEXT_PUBLIC_TAWK_TO_PROPERTY || '65bf15eb0ff6374032c915d9/1hlp6r8hc'
+
+// No Meta Pixel or Sentry project configured yet — these stay empty
+// until an operator sets the env var (or adds a default here once a
+// real ID exists). Empty = the corresponding loader is a no-op.
+export const META_PIXEL_ID = process.env.NEXT_PUBLIC_META_PIXEL_ID || ''
+
+export const SENTRY_DSN = process.env.NEXT_PUBLIC_SENTRY_DSN || ''
+
+export const SENTRY_ENVIRONMENT = process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT || 'production'

--- a/tests/analytics-loading.spec.ts
+++ b/tests/analytics-loading.spec.ts
@@ -1,0 +1,92 @@
+import { test, expect, type Page } from '@playwright/test'
+
+/**
+ * Analytics + widget loading tests.
+ *
+ * Drives real consent "traffic" through the cookie banner and asserts
+ * the right third-party scripts get injected with the right public IDs.
+ * These are committed defaults (see src/lib/analytics-config.ts), so the
+ * build under test — local, CI, or production — always has them, which
+ * is exactly why this is testable in CI at all.
+ *
+ * Consent model (from cookie-consent/index.tsx):
+ *   - necessary + functional: always on  → Tawk.to (functional) loads
+ *     once the banner is dismissed by any choice
+ *   - analytics (opt-in)                 → GA4 + GTM + Clarity
+ *   - marketing (opt-in)                 → Meta Pixel (no ID yet, no-op)
+ */
+
+const GA_MEASUREMENT_ID = 'G-541Y8JRDLX'
+const GTM_CONTAINER_ID = 'GTM-NJ4DXH9'
+const CLARITY_PROJECT_ID = 'nzldyj4h3k'
+const TAWK_TO_PROPERTY = '65bf15eb0ff6374032c915d9'
+
+// Count <script> elements whose src OR inline text references a marker.
+async function scriptCount(page: Page, marker: string): Promise<number> {
+  return page.evaluate((m) => {
+    const scripts = Array.from(document.querySelectorAll('script'))
+    return scripts.filter((s) => (s.src && s.src.includes(m)) || s.textContent?.includes(m)).length
+  }, marker)
+}
+
+async function clearConsent(page: Page) {
+  await page.goto('/')
+  await page.evaluate(() => {
+    localStorage.clear()
+    document.cookie = 'cookie-consent=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;'
+  })
+  await page.reload()
+}
+
+test.describe('Analytics + widget loading', () => {
+  test.beforeEach(async ({ context }) => {
+    await context.clearCookies()
+  })
+
+  test('no analytics scripts load before the visitor consents', async ({ page }) => {
+    await clearConsent(page)
+    // Banner is showing; no choice made yet. Analytics must NOT be present.
+    expect(await scriptCount(page, 'googletagmanager.com/gtag')).toBe(0)
+    expect(await scriptCount(page, 'googletagmanager.com/gtm.js')).toBe(0)
+    expect(await scriptCount(page, 'clarity.ms')).toBe(0)
+  })
+
+  test('Accept All injects GA4, GTM, and Clarity with the right IDs', async ({ page }) => {
+    await clearConsent(page)
+    await page.getByRole('button', { name: 'Accept All' }).click()
+
+    // GA4 direct gtag loader
+    await expect
+      .poll(() => scriptCount(page, `gtag/js?id=${GA_MEASUREMENT_ID}`), { timeout: 8000 })
+      .toBeGreaterThan(0)
+
+    // GTM container loader (inline snippet references the container ID)
+    await expect
+      .poll(() => scriptCount(page, GTM_CONTAINER_ID), { timeout: 8000 })
+      .toBeGreaterThan(0)
+
+    // Microsoft Clarity (inline snippet references the project ID)
+    await expect
+      .poll(() => scriptCount(page, CLARITY_PROJECT_ID), { timeout: 8000 })
+      .toBeGreaterThan(0)
+  })
+
+  test('Decline All keeps analytics scripts out', async ({ page }) => {
+    await clearConsent(page)
+    await page.getByRole('button', { name: 'Decline All' }).click()
+    // Give the page a moment; nothing analytics should appear.
+    await page.waitForTimeout(1500)
+    expect(await scriptCount(page, `gtag/js?id=${GA_MEASUREMENT_ID}`)).toBe(0)
+    expect(await scriptCount(page, 'googletagmanager.com/gtm.js')).toBe(0)
+    expect(await scriptCount(page, 'clarity.ms')).toBe(0)
+  })
+
+  test('Tawk.to live chat loads on functional consent (any dismissal)', async ({ page }) => {
+    await clearConsent(page)
+    // Decline All still grants necessary + functional — Tawk is functional.
+    await page.getByRole('button', { name: 'Decline All' }).click()
+    await expect
+      .poll(() => scriptCount(page, `embed.tawk.to/${TAWK_TO_PROPERTY}`), { timeout: 8000 })
+      .toBeGreaterThan(0)
+  })
+})

--- a/tests/analytics-loading.spec.ts
+++ b/tests/analytics-loading.spec.ts
@@ -1,4 +1,10 @@
 import { test, expect, type Page } from '@playwright/test'
+import {
+  GA_MEASUREMENT_ID,
+  GTM_CONTAINER_ID,
+  CLARITY_PROJECT_ID,
+  TAWK_TO_PROPERTY,
+} from '../src/lib/analytics-config'
 
 /**
  * Analytics + widget loading tests.
@@ -9,17 +15,17 @@ import { test, expect, type Page } from '@playwright/test'
  * build under test — local, CI, or production — always has them, which
  * is exactly why this is testable in CI at all.
  *
+ * IDs are imported from the same config module the app uses, so a
+ * future ID change (or a staging build that overrides them) keeps the
+ * test aligned with the build under test rather than asserting a
+ * hard-coded value the app no longer uses.
+ *
  * Consent model (from cookie-consent/index.tsx):
  *   - necessary + functional: always on  → Tawk.to (functional) loads
  *     once the banner is dismissed by any choice
  *   - analytics (opt-in)                 → GA4 + GTM + Clarity
  *   - marketing (opt-in)                 → Meta Pixel (no ID yet, no-op)
  */
-
-const GA_MEASUREMENT_ID = 'G-541Y8JRDLX'
-const GTM_CONTAINER_ID = 'GTM-NJ4DXH9'
-const CLARITY_PROJECT_ID = 'nzldyj4h3k'
-const TAWK_TO_PROPERTY = '65bf15eb0ff6374032c915d9'
 
 // Count <script> elements whose src OR inline text references a marker.
 async function scriptCount(page: Page, marker: string): Promise<number> {
@@ -74,8 +80,13 @@ test.describe('Analytics + widget loading', () => {
   test('Decline All keeps analytics scripts out', async ({ page }) => {
     await clearConsent(page)
     await page.getByRole('button', { name: 'Decline All' }).click()
-    // Give the page a moment; nothing analytics should appear.
-    await page.waitForTimeout(1500)
+    // Bound the wait on a real event instead of an arbitrary sleep:
+    // Decline All still grants functional consent, so Tawk.to loads.
+    // Once Tawk is present we know the post-consent loaders have run —
+    // at which point analytics must still be absent.
+    await expect
+      .poll(() => scriptCount(page, `embed.tawk.to/${TAWK_TO_PROPERTY}`), { timeout: 8000 })
+      .toBeGreaterThan(0)
     expect(await scriptCount(page, `gtag/js?id=${GA_MEASUREMENT_ID}`)).toBe(0)
     expect(await scriptCount(page, 'googletagmanager.com/gtm.js')).toBe(0)
     expect(await scriptCount(page, 'clarity.ms')).toBe(0)


### PR DESCRIPTION
## Summary

The operator correctly pointed out: `NEXT_PUBLIC_*` analytics IDs **aren't secrets** (they're baked into client JS and visible in page source), and storing them as deploy-only GitHub secrets meant **CI/local builds had empty IDs** — so the integration was untestable and only worked in production.

This moves the real public IDs into `src/lib/analytics-config.ts` as env-overridable defaults, and adds Playwright coverage that drives real consent traffic.

## Changes

- **`src/lib/analytics-config.ts`** (new) — real public IDs as defaults, each still overridable via its `NEXT_PUBLIC_*` env var (staging can point elsewhere):
  - `GA_MEASUREMENT_ID` → `G-541Y8JRDLX`
  - `GTM_CONTAINER_ID` → `GTM-NJ4DXH9`
  - `CLARITY_PROJECT_ID` → `nzldyj4h3k`
  - `TAWK_TO_PROPERTY` → `65bf…r8hc`
  - `META_PIXEL_ID` / `SENTRY_DSN` → empty (none configured yet)
- **`cookie-consent` + `sentry-init`** — import from the config instead of reading `process.env` inline.
- **`tests/analytics-loading.spec.ts`** (new) — 4 tests, all passing against a no-env build:
  - no GA4/GTM/Clarity before consent
  - Accept All injects all three with correct IDs
  - Decline All keeps analytics out
  - Tawk.to loads on functional consent

## Reverses #236's "no fallbacks" rule — deliberately

#236 removed *placeholder* fallbacks so we'd never ship a **fake** id. This ships the **real** public ids — the opposite concern. Genuinely-secret values (FTP creds) stay in Actions secrets and never appear here.

## Test plan

- [x] `npm run build` with NO env vars → IDs baked into the export chunk
- [x] `npm run lint` — 0 errors
- [x] `npx playwright test tests/analytics-loading.spec.ts` — 4/4 pass
- [ ] CI full suite

## ⚠️ Follow-up needed: staging/dev data pollution

Because the IDs now default in every build, staging + localhost will also send hits to the production GA4 property. See the discussion on the PR — needs a decision on hostname gating vs GA4 data filter.