### PR TITLE
feat: Azure API Management cPanel gateway (static-IP IaC)

### DIFF
--- a/.github/workflows/cpanel-apim-deploy.yml
+++ b/.github/workflows/cpanel-apim-deploy.yml
@@ -1,0 +1,128 @@
+name: 'Deploy cPanel APIM gateway'
+
+# Provisions the Azure API Management gateway that fronts the cPanel UAPI with
+# a STATIC public IP (so it can be whitelisted in Imunify360). Manual-dispatch
+# only. APIM provisioning takes ~30-45 minutes.
+#
+# Prerequisites (admin-side, one time):
+#   * An Azure deploy identity (service principal) with a federated credential
+#     for this repo's `cpanel-apim-deploy` environment, holding:
+#       - Contributor on the target resource group (to create APIM), and
+#       - permission to grant Key Vault access (e.g. User Access Administrator
+#         on the Key Vault if it uses RBAC, or Key Vault access-policy admin).
+#   * Environment `cpanel-apim-deploy` secrets:
+#       AZURE_DEPLOY_CLIENT_ID, AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID
+#   * The target resource group already exists.
+# See infra/cpanel-apim/README.md for the full procedure and cost.
+
+on:
+  workflow_dispatch:
+    inputs:
+      resource_group:
+        description: 'Target resource group (must already exist)'
+        required: true
+        type: string
+      location:
+        description: 'Azure region (e.g. eastus)'
+        required: true
+        default: 'eastus'
+        type: string
+      apim_name:
+        description: 'APIM instance name (globally unique; forms <name>.azure-api.net)'
+        required: true
+        type: string
+      publisher_email:
+        description: 'Publisher email (receives APIM service notices)'
+        required: true
+        type: string
+      cpanel_api_base_url:
+        description: 'cPanel UAPI base URL incl. port, e.g. https://hostname:2083'
+        required: true
+        type: string
+      key_vault_name:
+        description: 'Key Vault holding the cPanel secrets'
+        required: false
+        default: 'kv-ffc-admin-prod-cbm'
+        type: string
+      key_vault_resource_group:
+        description: 'Resource group of the Key Vault (for the access grant)'
+        required: true
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    name: 'Provision APIM + cPanel API'
+    runs-on: ubuntu-latest
+    environment: cpanel-apim-deploy
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Azure login (deploy identity)
+        uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.AZURE_DEPLOY_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: 'Phase 1 - deploy APIM service (~30-45 min)'
+        id: apim
+        run: |
+          set -euo pipefail
+          out=$(az deployment group create \
+            --resource-group "${{ inputs.resource_group }}" \
+            --name "cpanel-apim-$(date +%s)" \
+            --template-file infra/cpanel-apim/apim.bicep \
+            --parameters \
+              location="${{ inputs.location }}" \
+              apimName="${{ inputs.apim_name }}" \
+              publisherEmail="${{ inputs.publisher_email }}" \
+            --query properties.outputs -o json)
+          echo "principalId=$(echo "$out" | jq -r '.apimPrincipalId.value')" >> "$GITHUB_OUTPUT"
+          echo "staticIp=$(echo "$out" | jq -r '.apimStaticIp.value')"      >> "$GITHUB_OUTPUT"
+          echo "gatewayUrl=$(echo "$out" | jq -r '.gatewayUrl.value')"      >> "$GITHUB_OUTPUT"
+
+      - name: 'Grant APIM identity Get+List secrets on Key Vault'
+        env:
+          PID: ${{ steps.apim.outputs.principalId }}
+        run: |
+          set -euo pipefail
+          kvid=$(az keyvault show --name "${{ inputs.key_vault_name }}" --resource-group "${{ inputs.key_vault_resource_group }}" --query id -o tsv)
+          rbac=$(az keyvault show --name "${{ inputs.key_vault_name }}" --query properties.enableRbacAuthorization -o tsv)
+          if [ "$rbac" = "true" ]; then
+            echo "Key Vault uses RBAC -> assigning 'Key Vault Secrets User'"
+            az role assignment create \
+              --assignee-object-id "$PID" --assignee-principal-type ServicePrincipal \
+              --role "Key Vault Secrets User" --scope "$kvid"
+          else
+            echo "Key Vault uses access policies -> set-policy get/list"
+            az keyvault set-policy --name "${{ inputs.key_vault_name }}" --object-id "$PID" --secret-permissions get list
+          fi
+
+      - name: 'Phase 2 - deploy cPanel API + KV named values + policy'
+        run: |
+          set -euo pipefail
+          az deployment group create \
+            --resource-group "${{ inputs.resource_group }}" \
+            --name "cpanel-api-$(date +%s)" \
+            --template-file infra/cpanel-apim/apis.bicep \
+            --parameters \
+              apimName="${{ inputs.apim_name }}" \
+              keyVaultName="${{ inputs.key_vault_name }}" \
+              cpanelApiBaseUrl="${{ inputs.cpanel_api_base_url }}"
+
+      - name: 'Next steps'
+        run: |
+          {
+            echo "## cPanel APIM gateway deployed ✅"
+            echo ""
+            echo "1. **Whitelist this static IP in Imunify360** (cPanel → Imunify360 → Firewall → Whitelist):"
+            echo "   \`${{ steps.apim.outputs.staticIp }}\`"
+            echo "2. Gateway base: \`${{ steps.apim.outputs.gatewayUrl }}/cpanel/execute/<Module>/<func>\`"
+            echo "3. Get the subscription key and save it as repo secret \`APIM_SUBSCRIPTION_KEY\` (and \`${{ steps.apim.outputs.gatewayUrl }}\` as \`APIM_GATEWAY_URL\`). Key retrieval command is in infra/cpanel-apim/README.md."
+            echo "4. Verify with the **cPanel ops via APIM** workflow."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/cpanel-apim-deploy.yml
+++ b/.github/workflows/cpanel-apim-deploy.yml
@@ -82,9 +82,9 @@ jobs:
               apimName="${{ inputs.apim_name }}" \
               publisherEmail="${{ inputs.publisher_email }}" \
             --query properties.outputs -o json)
-          echo "principalId=$(echo "$out" | jq -r '.apimPrincipalId.value')" >> "$GITHUB_OUTPUT"
-          echo "staticIp=$(echo "$out" | jq -r '.apimStaticIp.value')"      >> "$GITHUB_OUTPUT"
-          echo "gatewayUrl=$(echo "$out" | jq -r '.gatewayUrl.value')"      >> "$GITHUB_OUTPUT"
+          echo "principalId=$(echo "$out" | jq -r '.apimPrincipalId.value')"            >> "$GITHUB_OUTPUT"
+          echo "staticIps=$(echo "$out" | jq -r '.apimStaticIps.value | join(\", \")')" >> "$GITHUB_OUTPUT"
+          echo "gatewayUrl=$(echo "$out" | jq -r '.gatewayUrl.value')"                  >> "$GITHUB_OUTPUT"
 
       - name: 'Grant APIM identity Get+List secrets on Key Vault'
         env:
@@ -94,10 +94,15 @@ jobs:
           kvid=$(az keyvault show --name "${{ inputs.key_vault_name }}" --resource-group "${{ inputs.key_vault_resource_group }}" --query id -o tsv)
           rbac=$(az keyvault show --name "${{ inputs.key_vault_name }}" --query properties.enableRbacAuthorization -o tsv)
           if [ "$rbac" = "true" ]; then
-            echo "Key Vault uses RBAC -> assigning 'Key Vault Secrets User'"
-            az role assignment create \
-              --assignee-object-id "$PID" --assignee-principal-type ServicePrincipal \
-              --role "Key Vault Secrets User" --scope "$kvid"
+            existing=$(az role assignment list --assignee "$PID" --role "Key Vault Secrets User" --scope "$kvid" --query "[0].id" -o tsv)
+            if [ -n "$existing" ]; then
+              echo "Key Vault Secrets User already assigned -> skipping (idempotent re-run)"
+            else
+              echo "Key Vault uses RBAC -> assigning 'Key Vault Secrets User'"
+              az role assignment create \
+                --assignee-object-id "$PID" --assignee-principal-type ServicePrincipal \
+                --role "Key Vault Secrets User" --scope "$kvid"
+            fi
           else
             echo "Key Vault uses access policies -> set-policy get/list"
             az keyvault set-policy --name "${{ inputs.key_vault_name }}" --object-id "$PID" --secret-permissions get list
@@ -120,8 +125,8 @@ jobs:
           {
             echo "## cPanel APIM gateway deployed ✅"
             echo ""
-            echo "1. **Whitelist this static IP in Imunify360** (cPanel → Imunify360 → Firewall → Whitelist):"
-            echo "   \`${{ steps.apim.outputs.staticIp }}\`"
+            echo "1. **Whitelist these static IP(s) in Imunify360** (cPanel → Imunify360 → Firewall → Whitelist) — add every address listed:"
+            echo "   \`${{ steps.apim.outputs.staticIps }}\`"
             echo "2. Gateway base: \`${{ steps.apim.outputs.gatewayUrl }}/cpanel/execute/<Module>/<func>\`"
             echo "3. Get the subscription key and save it as repo secret \`APIM_SUBSCRIPTION_KEY\` (and \`${{ steps.apim.outputs.gatewayUrl }}\` as \`APIM_GATEWAY_URL\`). Key retrieval command is in infra/cpanel-apim/README.md."
             echo "4. Verify with the **cPanel ops via APIM** workflow."

--- a/.github/workflows/cpanel-apim-deploy.yml
+++ b/.github/workflows/cpanel-apim-deploy.yml
@@ -125,8 +125,9 @@ jobs:
           {
             echo "## cPanel APIM gateway deployed ✅"
             echo ""
-            echo "1. **Whitelist these static IP(s) in Imunify360** (cPanel → Imunify360 → Firewall → Whitelist) — add every address listed:"
+            echo "1. **Whitelist these static IP(s) in Imunify360** — add every address listed:"
             echo "   \`${{ steps.apim.outputs.staticIps }}\`"
+            echo "   On a **shared host** the end-user cPanel UI has no Firewall/Whitelist tab — open a support ticket asking the host to whitelist these server-side. With WHM access, do it yourself: WHM → Imunify360 → Firewall → Whitelist."
             echo "2. Gateway base: \`${{ steps.apim.outputs.gatewayUrl }}/cpanel/execute/<Module>/<func>\`"
             echo "3. Get the subscription key and save it as repo secret \`APIM_SUBSCRIPTION_KEY\` (and \`${{ steps.apim.outputs.gatewayUrl }}\` as \`APIM_GATEWAY_URL\`). Key retrieval command is in infra/cpanel-apim/README.md."
             echo "4. Verify with the **cPanel ops via APIM** workflow."

--- a/.github/workflows/cpanel-apim-deploy.yml
+++ b/.github/workflows/cpanel-apim-deploy.yml
@@ -92,7 +92,7 @@ jobs:
         run: |
           set -euo pipefail
           kvid=$(az keyvault show --name "${{ inputs.key_vault_name }}" --resource-group "${{ inputs.key_vault_resource_group }}" --query id -o tsv)
-          rbac=$(az keyvault show --name "${{ inputs.key_vault_name }}" --query properties.enableRbacAuthorization -o tsv)
+          rbac=$(az keyvault show --name "${{ inputs.key_vault_name }}" --resource-group "${{ inputs.key_vault_resource_group }}" --query properties.enableRbacAuthorization -o tsv)
           if [ "$rbac" = "true" ]; then
             existing=$(az role assignment list --assignee "$PID" --role "Key Vault Secrets User" --scope "$kvid" --query "[0].id" -o tsv)
             if [ -n "$existing" ]; then

--- a/.github/workflows/cpanel-apim-deploy.yml
+++ b/.github/workflows/cpanel-apim-deploy.yml
@@ -69,18 +69,27 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
+      # All workflow_dispatch inputs and step outputs are passed through `env`
+      # and referenced as quoted shell variables, never interpolated directly
+      # into the run script. This avoids GitHub Actions script injection
+      # (a malicious input value cannot break out of the command).
       - name: 'Phase 1 - deploy APIM service (~30-45 min)'
         id: apim
+        env:
+          RESOURCE_GROUP: ${{ inputs.resource_group }}
+          LOCATION: ${{ inputs.location }}
+          APIM_NAME: ${{ inputs.apim_name }}
+          PUBLISHER_EMAIL: ${{ inputs.publisher_email }}
         run: |
           set -euo pipefail
           out=$(az deployment group create \
-            --resource-group "${{ inputs.resource_group }}" \
+            --resource-group "$RESOURCE_GROUP" \
             --name "cpanel-apim-$(date +%s)" \
             --template-file infra/cpanel-apim/apim.bicep \
             --parameters \
-              location="${{ inputs.location }}" \
-              apimName="${{ inputs.apim_name }}" \
-              publisherEmail="${{ inputs.publisher_email }}" \
+              location="$LOCATION" \
+              apimName="$APIM_NAME" \
+              publisherEmail="$PUBLISHER_EMAIL" \
             --query properties.outputs -o json)
           echo "principalId=$(echo "$out" | jq -r '.apimPrincipalId.value')"            >> "$GITHUB_OUTPUT"
           echo "staticIps=$(echo "$out" | jq -r '.apimStaticIps.value | join(\", \")')" >> "$GITHUB_OUTPUT"
@@ -89,10 +98,12 @@ jobs:
       - name: 'Grant APIM identity Get+List secrets on Key Vault'
         env:
           PID: ${{ steps.apim.outputs.principalId }}
+          KV_NAME: ${{ inputs.key_vault_name }}
+          KV_RG: ${{ inputs.key_vault_resource_group }}
         run: |
           set -euo pipefail
-          kvid=$(az keyvault show --name "${{ inputs.key_vault_name }}" --resource-group "${{ inputs.key_vault_resource_group }}" --query id -o tsv)
-          rbac=$(az keyvault show --name "${{ inputs.key_vault_name }}" --resource-group "${{ inputs.key_vault_resource_group }}" --query properties.enableRbacAuthorization -o tsv)
+          kvid=$(az keyvault show --name "$KV_NAME" --resource-group "$KV_RG" --query id -o tsv)
+          rbac=$(az keyvault show --name "$KV_NAME" --resource-group "$KV_RG" --query properties.enableRbacAuthorization -o tsv)
           if [ "$rbac" = "true" ]; then
             existing=$(az role assignment list --assignee "$PID" --role "Key Vault Secrets User" --scope "$kvid" --query "[0].id" -o tsv)
             if [ -n "$existing" ]; then
@@ -105,30 +116,38 @@ jobs:
             fi
           else
             echo "Key Vault uses access policies -> set-policy get/list"
-            az keyvault set-policy --name "${{ inputs.key_vault_name }}" --object-id "$PID" --secret-permissions get list
+            az keyvault set-policy --name "$KV_NAME" --object-id "$PID" --secret-permissions get list
           fi
 
       - name: 'Phase 2 - deploy cPanel API + KV named values + policy'
+        env:
+          RESOURCE_GROUP: ${{ inputs.resource_group }}
+          APIM_NAME: ${{ inputs.apim_name }}
+          KV_NAME: ${{ inputs.key_vault_name }}
+          CPANEL_API_BASE_URL: ${{ inputs.cpanel_api_base_url }}
         run: |
           set -euo pipefail
           az deployment group create \
-            --resource-group "${{ inputs.resource_group }}" \
+            --resource-group "$RESOURCE_GROUP" \
             --name "cpanel-api-$(date +%s)" \
             --template-file infra/cpanel-apim/apis.bicep \
             --parameters \
-              apimName="${{ inputs.apim_name }}" \
-              keyVaultName="${{ inputs.key_vault_name }}" \
-              cpanelApiBaseUrl="${{ inputs.cpanel_api_base_url }}"
+              apimName="$APIM_NAME" \
+              keyVaultName="$KV_NAME" \
+              cpanelApiBaseUrl="$CPANEL_API_BASE_URL"
 
       - name: 'Next steps'
+        env:
+          STATIC_IPS: ${{ steps.apim.outputs.staticIps }}
+          GATEWAY_URL: ${{ steps.apim.outputs.gatewayUrl }}
         run: |
           {
             echo "## cPanel APIM gateway deployed ✅"
             echo ""
             echo "1. **Whitelist these static IP(s) in Imunify360** — add every address listed:"
-            echo "   \`${{ steps.apim.outputs.staticIps }}\`"
+            echo "   \`$STATIC_IPS\`"
             echo "   On a **shared host** the end-user cPanel UI has no Firewall/Whitelist tab — open a support ticket asking the host to whitelist these server-side. With WHM access, do it yourself: WHM → Imunify360 → Firewall → Whitelist."
-            echo "2. Gateway base: \`${{ steps.apim.outputs.gatewayUrl }}/cpanel/execute/<Module>/<func>\`"
-            echo "3. Get the subscription key and save it as repo secret \`APIM_SUBSCRIPTION_KEY\` (and \`${{ steps.apim.outputs.gatewayUrl }}\` as \`APIM_GATEWAY_URL\`). Key retrieval command is in infra/cpanel-apim/README.md."
+            echo "2. Gateway base: \`$GATEWAY_URL/cpanel/execute/<Module>/<func>\`"
+            echo "3. Get the subscription key and save it as repo secret \`APIM_SUBSCRIPTION_KEY\` (and \`$GATEWAY_URL\` as \`APIM_GATEWAY_URL\`). Key retrieval command is in infra/cpanel-apim/README.md."
             echo "4. Verify with the **cPanel ops via APIM** workflow."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/cpanel-ops-via-apim.yml
+++ b/.github/workflows/cpanel-ops-via-apim.yml
@@ -55,7 +55,7 @@ jobs:
           QUERY: ${{ inputs.query }}
           METHOD: ${{ inputs.method }}
         run: |
-          set -uo pipefail
+          set -euo pipefail
           if [ -z "${BASE}" ] || [ -z "${KEY}" ]; then
             echo "::error::Set APIM_GATEWAY_URL and APIM_SUBSCRIPTION_KEY secrets first (see infra/cpanel-apim/README.md)."
             exit 1

--- a/.github/workflows/cpanel-ops-via-apim.yml
+++ b/.github/workflows/cpanel-ops-via-apim.yml
@@ -72,13 +72,16 @@ jobs:
           code=$(printf '%s' "${resp}" | tail -n1)
           body=$(printf '%s' "${resp}" | sed '$d')
           echo "HTTP ${code}"
+          # NOTE: Actions logs on a public repo are world-readable, and UAPI
+          # payloads can carry operationally sensitive data (domains, accounts,
+          # paths). Never echo the response body — log only status + the UAPI
+          # diagnostic fields (errors/messages), plus a harmless item count.
           status=$(printf '%s' "${body}" | jq -r '.status // empty' 2>/dev/null || true)
           if [ "${status}" = "1" ]; then
-            echo "✅ cPanel UAPI reachable through APIM (auth + whitelist OK)."
-            printf '%s' "${body}" | jq '.data' 2>/dev/null | head -n 40 || true
+            items=$(printf '%s' "${body}" | jq -r 'if (.data | type) == "array" then (.data | length | tostring) else "n/a" end' 2>/dev/null || echo "n/a")
+            echo "✅ cPanel UAPI reachable through APIM (auth + whitelist OK). data items: ${items}"
           else
-            echo "::warning::cPanel did not return status=1. First 600 bytes of response:"
-            printf '%s' "${body}" | head -c 600
-            echo ""
+            echo "::error::cPanel did not return status=1 (HTTP ${code}). Diagnostic fields only:"
+            printf '%s' "${body}" | jq -r '(.errors // [])[], (.messages // [])[]' 2>/dev/null | head -n 10 || true
             exit 1
           fi

--- a/.github/workflows/cpanel-ops-via-apim.yml
+++ b/.github/workflows/cpanel-ops-via-apim.yml
@@ -1,0 +1,84 @@
+name: 'cPanel ops via APIM'
+
+# Calls the cPanel UAPI THROUGH the Azure API Management gateway, so the request
+# reaches cPanel from APIM's static (whitelisted) IP instead of a GitHub-hosted
+# Azure runner IP that Imunify360 blocks.
+#
+# Requires repo (or environment) secrets, set after deploying the gateway:
+#   APIM_GATEWAY_URL       e.g. https://apim-ffc-cpanel.azure-api.net
+#   APIM_SUBSCRIPTION_KEY  the "cpanel-ops" subscription primary key
+#
+# Defaults to a harmless read-only UAPI call so it doubles as a connectivity
+# check that the whitelist + auth injection work end to end.
+
+on:
+  workflow_dispatch:
+    inputs:
+      module:
+        description: 'cPanel UAPI module'
+        required: true
+        default: 'DomainInfo'
+        type: string
+      function:
+        description: 'cPanel UAPI function'
+        required: true
+        default: 'list_domains'
+        type: string
+      query:
+        description: 'Optional query string, e.g. domain=freeforcharity.org'
+        required: false
+        default: ''
+        type: string
+      method:
+        description: 'HTTP method'
+        required: false
+        default: 'GET'
+        type: choice
+        options:
+          - GET
+          - POST
+
+permissions:
+  contents: read
+
+jobs:
+  call:
+    name: 'Call cPanel UAPI through APIM'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Invoke
+        env:
+          BASE: ${{ secrets.APIM_GATEWAY_URL }}
+          KEY: ${{ secrets.APIM_SUBSCRIPTION_KEY }}
+          MODULE: ${{ inputs.module }}
+          FUNCTION: ${{ inputs.function }}
+          QUERY: ${{ inputs.query }}
+          METHOD: ${{ inputs.method }}
+        run: |
+          set -uo pipefail
+          if [ -z "${BASE}" ] || [ -z "${KEY}" ]; then
+            echo "::error::Set APIM_GATEWAY_URL and APIM_SUBSCRIPTION_KEY secrets first (see infra/cpanel-apim/README.md)."
+            exit 1
+          fi
+          url="${BASE%/}/cpanel/execute/${MODULE}/${FUNCTION}"
+          if [ -n "${QUERY}" ]; then
+            url="${url}?${QUERY}"
+          fi
+          echo "→ ${METHOD} ${BASE%/}/cpanel/execute/${MODULE}/${FUNCTION}"
+          resp=$(curl -sS -X "${METHOD}" -w $'\n%{http_code}' \
+            -H "Ocp-Apim-Subscription-Key: ${KEY}" \
+            -H "Accept: application/json" \
+            "${url}")
+          code=$(printf '%s' "${resp}" | tail -n1)
+          body=$(printf '%s' "${resp}" | sed '$d')
+          echo "HTTP ${code}"
+          status=$(printf '%s' "${body}" | jq -r '.status // empty' 2>/dev/null || true)
+          if [ "${status}" = "1" ]; then
+            echo "✅ cPanel UAPI reachable through APIM (auth + whitelist OK)."
+            printf '%s' "${body}" | jq '.data' 2>/dev/null | head -n 40 || true
+          else
+            echo "::warning::cPanel did not return status=1. First 600 bytes of response:"
+            printf '%s' "${body}" | head -c 600
+            echo ""
+            exit 1
+          fi

--- a/infra/cpanel-apim/README.md
+++ b/infra/cpanel-apim/README.md
@@ -18,15 +18,15 @@ on the same instance and share the one static egress IP.
 
 ## Deployed instance (prod)
 
-| Thing                  | Value                                                       |
-| ---------------------- | ----------------------------------------------------------- |
-| APIM instance          | `apim-ffc-gateway-prod` (Developer tier, eastus)            |
-| Resource group         | `rg-ffc-admin-apim`                                         |
-| Gateway URL            | `https://apim-ffc-gateway-prod.azure-api.net`               |
-| cPanel API base        | `…/cpanel/execute/<Module>/<function>`                      |
-| **Static egress IP**   | **`20.231.116.111`** (whitelist this in Imunify360)         |
-| Subscription           | `cpanel-ops`                                                |
-| Subscription key (KV)  | `read-all-ffc-apim-gateway-subscription-key`                |
+| Thing                 | Value                                               |
+| --------------------- | --------------------------------------------------- |
+| APIM instance         | `apim-ffc-gateway-prod` (Developer tier, eastus)    |
+| Resource group        | `rg-ffc-admin-apim`                                 |
+| Gateway URL           | `https://apim-ffc-gateway-prod.azure-api.net`       |
+| cPanel API base       | `…/cpanel/execute/<Module>/<function>`              |
+| **Static egress IP**  | **`20.231.116.111`** (whitelist this in Imunify360) |
+| Subscription          | `cpanel-ops`                                        |
+| Subscription key (KV) | `read-all-ffc-apim-gateway-subscription-key`        |
 
 The IP is stable for the life of the instance but changes if APIM is deleted and
 recreated. Confirm it from the deployment outputs after any rebuild.
@@ -130,14 +130,14 @@ az deployment group create -g rg-ffc-cpanel-gateway \
 
 1. **Whitelist the static IP in Imunify360.** On a **shared host** (our case,
    InterServer `webhosting1900.is.cc`) the end-user cPanel Imunify360 panel only
-   exposes *Malware Scanner* and *Proactive Defense* — there is **no Firewall /
+   exposes _Malware Scanner_ and _Proactive Defense_ — there is **no Firewall /
    Whitelist tab**; that lives in WHM at the root/server level. So you must **open
    a support ticket asking the host to whitelist the IP** server-side in
    Imunify360's firewall/bot-protection allowlist. On a VPS/reseller plan where you
    control WHM, do it yourself: WHM → Imunify360 → Firewall → Whitelist.
    Until the IP is whitelisted, calls return HTTP 200 with body
    `{"message":"Access denied by Imunify360 bot-protection..."}` — that response
-   coming back *through the gateway* confirms auth + routing already work.
+   coming back _through the gateway_ confirms auth + routing already work.
 2. **Subscription key is stored in Key Vault** as
    `read-all-ffc-apim-gateway-subscription-key`, so CI pulls it the same KV-aligned
    way as the cPanel token (no repo secret needed). To re-read or rotate:

--- a/infra/cpanel-apim/README.md
+++ b/infra/cpanel-apim/README.md
@@ -29,13 +29,13 @@ GitHub Actions ──(subscription key)──▶ APIM (static IP) ──(cpanel 
 
 ## Cost (US list, approximate)
 
-| Tier | Monthly | Static IP | SLA | Use here |
-|---|---|---|---|---|
-| Consumption | ~$3.50 / million calls | ❌ | ✔️ | ❌ no static IP |
-| **Developer** (default) | **~$40–50** | ✔️ | ❌ none | ✅ cheapest that works |
-| Basic | ~$150 | ✔️ | ✔️ | if you need an SLA |
-| Basic v2 | ~$145 | ❌ | ✔️ | ❌ no static IP |
-| Standard v2 | ~$700/unit | ❌ | ✔️ | ❌ no static IP |
+| Tier                    | Monthly                | Static IP | SLA     | Use here               |
+| ----------------------- | ---------------------- | --------- | ------- | ---------------------- |
+| Consumption             | ~$3.50 / million calls | ❌        | ✔️      | ❌ no static IP        |
+| **Developer** (default) | **~$40–50**            | ✔️        | ❌ none | ✅ cheapest that works |
+| Basic                   | ~$150                  | ✔️        | ✔️      | if you need an SLA     |
+| Basic v2                | ~$145                  | ❌        | ✔️      | ❌ no static IP        |
+| Standard v2             | ~$700/unit             | ❌        | ✔️      | ❌ no static IP        |
 
 `apim.bicep` defaults to **Developer** (no SLA — fine for internal ops
 automation). A self-managed Azure VM with a static IP (~$10/mo) is cheaper
@@ -43,13 +43,13 @@ overall but is not a managed gateway.
 
 ## Files
 
-| File | Purpose |
-|---|---|
-| `apim.bicep` | Phase 1 — the APIM service (Developer tier, system-assigned identity). Outputs the static IP + identity principal ID. |
-| `apis.bicep` | Phase 2 — KV-linked secret named values, the cPanel backend (TLS validation off), the `/cpanel` API + GET/POST operations, the auth-injection policy, and a subscription. |
-| `policies/cpanel-api.xml` | API policy: routes to the `cpanel` backend and injects `Authorization: cpanel {{user}}:{{token}}`. |
-| `../../.github/workflows/cpanel-apim-deploy.yml` | Orchestrates phase 1 → grant KV access → phase 2. |
-| `../../.github/workflows/cpanel-ops-via-apim.yml` | Calls cPanel UAPI through the gateway (also a connectivity check). |
+| File                                              | Purpose                                                                                                                                                                   |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `apim.bicep`                                      | Phase 1 — the APIM service (Developer tier, system-assigned identity). Outputs the static IP + identity principal ID.                                                     |
+| `apis.bicep`                                      | Phase 2 — KV-linked secret named values, the cPanel backend (TLS validation off), the `/cpanel` API + GET/POST operations, the auth-injection policy, and a subscription. |
+| `policies/cpanel-api.xml`                         | API policy: routes to the `cpanel` backend and injects `Authorization: cpanel {{user}}:{{token}}`.                                                                        |
+| `../../.github/workflows/cpanel-apim-deploy.yml`  | Orchestrates phase 1 → grant KV access → phase 2.                                                                                                                         |
+| `../../.github/workflows/cpanel-ops-via-apim.yml` | Calls cPanel UAPI through the gateway (also a connectivity check).                                                                                                        |
 
 ## Prerequisites (one-time, admin)
 
@@ -68,17 +68,18 @@ overall but is not a managed gateway.
 
 Run the **Deploy cPanel APIM gateway** workflow (Actions → manual dispatch) with:
 
-| Input | Example |
-|---|---|
-| `resource_group` | `rg-ffc-cpanel-gateway` |
-| `location` | `eastus` |
-| `apim_name` | `apim-ffc-cpanel` (globally unique) |
-| `publisher_email` | an address that should receive APIM notices |
-| `cpanel_api_base_url` | `https://<hostname>:2083` (hostname is in the `...-server` KV secret) |
-| `key_vault_name` | `kv-ffc-admin-prod-cbm` |
-| `key_vault_resource_group` | the KV's resource group |
+| Input                      | Example                                                               |
+| -------------------------- | --------------------------------------------------------------------- |
+| `resource_group`           | `rg-ffc-cpanel-gateway`                                               |
+| `location`                 | `eastus`                                                              |
+| `apim_name`                | `apim-ffc-cpanel` (globally unique)                                   |
+| `publisher_email`          | an address that should receive APIM notices                           |
+| `cpanel_api_base_url`      | `https://<hostname>:2083` (hostname is in the `...-server` KV secret) |
+| `key_vault_name`           | `kv-ffc-admin-prod-cbm`                                               |
+| `key_vault_resource_group` | the KV's resource group                                               |
 
 The workflow:
+
 1. Deploys `apim.bicep` (**~30–45 min** — APIM provisioning is slow).
 2. Grants APIM's managed identity **Get + List secrets** on the Key Vault
    (auto-detects RBAC vs access-policy model).

--- a/infra/cpanel-apim/README.md
+++ b/infra/cpanel-apim/README.md
@@ -14,7 +14,10 @@ GitHub Actions ──(subscription key)──▶ APIM (static IP) ──(cpanel 
 
 This APIM instance is a **shared FFC gateway**, not cPanel-specific. cPanel is the
 first API onboarded (path `/cpanel`); future backends are added as additional APIs
-on the same instance and share the one static egress IP.
+on the same instance and share its static egress IP(s). Classic APIM exposes a
+single IP on the Developer tier (currently `20.231.116.111`) but can present more
+than one — `apim.bicep` outputs the full array, so **whitelist every address it
+lists**, not just the first.
 
 ## Deployed instance (prod)
 
@@ -138,9 +141,15 @@ az deployment group create -g rg-ffc-cpanel-gateway \
    Until the IP is whitelisted, calls return HTTP 200 with body
    `{"message":"Access denied by Imunify360 bot-protection..."}` — that response
    coming back _through the gateway_ confirms auth + routing already work.
-2. **Subscription key is stored in Key Vault** as
-   `read-all-ffc-apim-gateway-subscription-key`, so CI pulls it the same KV-aligned
-   way as the cPanel token (no repo secret needed). To re-read or rotate:
+2. **Subscription key.** The primary key is kept in Key Vault as
+   `read-all-ffc-apim-gateway-subscription-key` (the rotation source of truth).
+   The **cPanel ops via APIM** verify workflow consumes it as the GitHub Actions
+   secret `APIM_SUBSCRIPTION_KEY` (and the gateway URL as `APIM_GATEWAY_URL`), so
+   populate those two secrets from the KV value once. Unlike the cPanel token —
+   which never leaves Key Vault — this lower-sensitivity gateway key is surfaced to
+   CI as an Actions secret; rotating it means regenerating the APIM key and
+   refreshing both the KV secret and `APIM_SUBSCRIPTION_KEY`. To re-read it at the
+   source:
    ```bash
    az rest --method post --uri \
      "https://management.azure.com/subscriptions/<sub>/resourceGroups/rg-ffc-admin-apim/providers/Microsoft.ApiManagement/service/apim-ffc-gateway-prod/subscriptions/cpanel-ops/listSecrets?api-version=2022-08-01" \

--- a/infra/cpanel-apim/README.md
+++ b/infra/cpanel-apim/README.md
@@ -12,6 +12,25 @@ GitHub Actions ──(subscription key)──▶ APIM (static IP) ──(cpanel 
                                          └─ token+user pulled from Key Vault   └─ Imunify360 whitelists the APIM static IP
 ```
 
+This APIM instance is a **shared FFC gateway**, not cPanel-specific. cPanel is the
+first API onboarded (path `/cpanel`); future backends are added as additional APIs
+on the same instance and share the one static egress IP.
+
+## Deployed instance (prod)
+
+| Thing                  | Value                                                       |
+| ---------------------- | ----------------------------------------------------------- |
+| APIM instance          | `apim-ffc-gateway-prod` (Developer tier, eastus)            |
+| Resource group         | `rg-ffc-admin-apim`                                         |
+| Gateway URL            | `https://apim-ffc-gateway-prod.azure-api.net`               |
+| cPanel API base        | `…/cpanel/execute/<Module>/<function>`                      |
+| **Static egress IP**   | **`20.231.116.111`** (whitelist this in Imunify360)         |
+| Subscription           | `cpanel-ops`                                                |
+| Subscription key (KV)  | `read-all-ffc-apim-gateway-subscription-key`                |
+
+The IP is stable for the life of the instance but changes if APIM is deleted and
+recreated. Confirm it from the deployment outputs after any rebuild.
+
 ## Why this design
 
 - **Imunify360 blocks datacenter traffic, including Azure.** GitHub-hosted
@@ -109,19 +128,27 @@ az deployment group create -g rg-ffc-cpanel-gateway \
 
 ## Post-deploy
 
-1. **Whitelist the static IP in Imunify360**: cPanel → Imunify360 → Firewall →
-   Whitelist → add the IP from the run summary.
-2. **Retrieve the subscription key** and store it as repo secret
-   `APIM_SUBSCRIPTION_KEY` (and the gateway URL as `APIM_GATEWAY_URL`):
+1. **Whitelist the static IP in Imunify360.** On a **shared host** (our case,
+   InterServer `webhosting1900.is.cc`) the end-user cPanel Imunify360 panel only
+   exposes *Malware Scanner* and *Proactive Defense* — there is **no Firewall /
+   Whitelist tab**; that lives in WHM at the root/server level. So you must **open
+   a support ticket asking the host to whitelist the IP** server-side in
+   Imunify360's firewall/bot-protection allowlist. On a VPS/reseller plan where you
+   control WHM, do it yourself: WHM → Imunify360 → Firewall → Whitelist.
+   Until the IP is whitelisted, calls return HTTP 200 with body
+   `{"message":"Access denied by Imunify360 bot-protection..."}` — that response
+   coming back *through the gateway* confirms auth + routing already work.
+2. **Subscription key is stored in Key Vault** as
+   `read-all-ffc-apim-gateway-subscription-key`, so CI pulls it the same KV-aligned
+   way as the cPanel token (no repo secret needed). To re-read or rotate:
    ```bash
-   az apim subscription show -g rg-ffc-cpanel-gateway --service-name apim-ffc-cpanel \
-     --sid cpanel-ops --query primaryKey -o tsv
-   # (if the CLI lacks --query for the key, use: az rest --method post \
-   #   --url "https://management.azure.com/subscriptions/<sub>/resourceGroups/rg-ffc-cpanel-gateway/providers/Microsoft.ApiManagement/service/apim-ffc-cpanel/subscriptions/cpanel-ops/listSecrets?api-version=2022-08-01" \
-   #   --query primaryKey -o tsv)
+   az rest --method post --uri \
+     "https://management.azure.com/subscriptions/<sub>/resourceGroups/rg-ffc-admin-apim/providers/Microsoft.ApiManagement/service/apim-ffc-gateway-prod/subscriptions/cpanel-ops/listSecrets?api-version=2022-08-01" \
+     --query primaryKey -o tsv
    ```
 3. **Verify** with the **cPanel ops via APIM** workflow (defaults to a read-only
-   `DomainInfo/list_domains` call). `status: 1` ⇒ whitelist + auth injection work.
+   `DomainInfo/list_domains` call). Real JSON (not the Imunify block message) ⇒
+   whitelist + auth injection work end-to-end.
 
 ## Security notes
 

--- a/infra/cpanel-apim/README.md
+++ b/infra/cpanel-apim/README.md
@@ -1,0 +1,141 @@
+# cPanel API gateway on Azure API Management
+
+Fronts the InterServer **cPanel UAPI** with an **Azure API Management (APIM)**
+instance that has a **static public IP**. GitHub Actions calls APIM (with a
+subscription key); APIM injects the cPanel token auth and forwards the request
+from its static IP, which is whitelisted once in Imunify360. No secret ever
+leaves Key Vault into the pipeline, and there is no VM/runner to maintain.
+
+```
+GitHub Actions ──(subscription key)──▶ APIM (static IP) ──(cpanel token)──▶ cPanel UAPI :2083
+                                         │                                    ▲
+                                         └─ token+user pulled from Key Vault   └─ Imunify360 whitelists the APIM static IP
+```
+
+## Why this design
+
+- **Imunify360 blocks datacenter traffic, including Azure.** GitHub-hosted
+  runners egress from Azure IP ranges, and direct cPanel API calls from them are
+  blocked. A single **static, whitelistable IP** is the fix.
+- **Only the classic APIM tiers have a static IP.** Developer / Basic / Standard
+  / Premium get a dedicated static public IP. **Consumption and all v2 tiers
+  (Basic v2 / Standard v2 / Premium v2) run on shared infra with no deterministic
+  IP** — they can't be whitelisted (Microsoft's only guidance is "allowlist the
+  whole Azure region," which is impractical and insecure).
+  [MS Learn: IP addresses in APIM](https://learn.microsoft.com/azure/api-management/api-management-howto-ip-addresses)
+- **"When a request is sent from API Management to a public backend, a public IP
+  address will always be visible as the origin"** — that public IP is the static
+  one you whitelist. (Same doc.)
+
+## Cost (US list, approximate)
+
+| Tier | Monthly | Static IP | SLA | Use here |
+|---|---|---|---|---|
+| Consumption | ~$3.50 / million calls | ❌ | ✔️ | ❌ no static IP |
+| **Developer** (default) | **~$40–50** | ✔️ | ❌ none | ✅ cheapest that works |
+| Basic | ~$150 | ✔️ | ✔️ | if you need an SLA |
+| Basic v2 | ~$145 | ❌ | ✔️ | ❌ no static IP |
+| Standard v2 | ~$700/unit | ❌ | ✔️ | ❌ no static IP |
+
+`apim.bicep` defaults to **Developer** (no SLA — fine for internal ops
+automation). A self-managed Azure VM with a static IP (~$10/mo) is cheaper
+overall but is not a managed gateway.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `apim.bicep` | Phase 1 — the APIM service (Developer tier, system-assigned identity). Outputs the static IP + identity principal ID. |
+| `apis.bicep` | Phase 2 — KV-linked secret named values, the cPanel backend (TLS validation off), the `/cpanel` API + GET/POST operations, the auth-injection policy, and a subscription. |
+| `policies/cpanel-api.xml` | API policy: routes to the `cpanel` backend and injects `Authorization: cpanel {{user}}:{{token}}`. |
+| `../../.github/workflows/cpanel-apim-deploy.yml` | Orchestrates phase 1 → grant KV access → phase 2. |
+| `../../.github/workflows/cpanel-ops-via-apim.yml` | Calls cPanel UAPI through the gateway (also a connectivity check). |
+
+## Prerequisites (one-time, admin)
+
+1. **Azure deploy identity** — a service principal with a federated credential
+   for this repo's `cpanel-apim-deploy` environment, holding:
+   - **Contributor** on the target resource group, and
+   - rights to grant Key Vault access (**User Access Administrator** on the KV if
+     it uses RBAC, or Key Vault access-policy admin).
+2. **Environment `cpanel-apim-deploy` secrets:** `AZURE_DEPLOY_CLIENT_ID`,
+   `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`.
+3. **Target resource group** already created.
+4. **Key Vault secrets** present (already are): `wr-all-cbm-cpanel-ffc-interserver-api-token`,
+   `wr-all-cbm-cpanel-ffc-interserver-user`, `wr-all-cbm-cpanel-ffc-interserver-server`.
+
+## Deploy
+
+Run the **Deploy cPanel APIM gateway** workflow (Actions → manual dispatch) with:
+
+| Input | Example |
+|---|---|
+| `resource_group` | `rg-ffc-cpanel-gateway` |
+| `location` | `eastus` |
+| `apim_name` | `apim-ffc-cpanel` (globally unique) |
+| `publisher_email` | an address that should receive APIM notices |
+| `cpanel_api_base_url` | `https://<hostname>:2083` (hostname is in the `...-server` KV secret) |
+| `key_vault_name` | `kv-ffc-admin-prod-cbm` |
+| `key_vault_resource_group` | the KV's resource group |
+
+The workflow:
+1. Deploys `apim.bicep` (**~30–45 min** — APIM provisioning is slow).
+2. Grants APIM's managed identity **Get + List secrets** on the Key Vault
+   (auto-detects RBAC vs access-policy model).
+3. Deploys `apis.bicep` (named values, backend, API, policy, subscription).
+4. Prints the **static IP to whitelist** and the gateway URL in the run summary.
+
+### Manual equivalent (Azure CLI)
+
+```bash
+# Phase 1
+az deployment group create -g rg-ffc-cpanel-gateway \
+  --template-file infra/cpanel-apim/apim.bicep \
+  --parameters location=eastus apimName=apim-ffc-cpanel publisherEmail=you@ffc.org
+PID=$(az deployment group show -g rg-ffc-cpanel-gateway -n <deployment> --query properties.outputs.apimPrincipalId.value -o tsv)
+
+# Grant KV access (RBAC model shown)
+KVID=$(az keyvault show -n kv-ffc-admin-prod-cbm --query id -o tsv)
+az role assignment create --assignee-object-id "$PID" --assignee-principal-type ServicePrincipal \
+  --role "Key Vault Secrets User" --scope "$KVID"
+
+# Phase 2
+az deployment group create -g rg-ffc-cpanel-gateway \
+  --template-file infra/cpanel-apim/apis.bicep \
+  --parameters apimName=apim-ffc-cpanel keyVaultName=kv-ffc-admin-prod-cbm \
+               cpanelApiBaseUrl=https://<hostname>:2083
+```
+
+## Post-deploy
+
+1. **Whitelist the static IP in Imunify360**: cPanel → Imunify360 → Firewall →
+   Whitelist → add the IP from the run summary.
+2. **Retrieve the subscription key** and store it as repo secret
+   `APIM_SUBSCRIPTION_KEY` (and the gateway URL as `APIM_GATEWAY_URL`):
+   ```bash
+   az apim subscription show -g rg-ffc-cpanel-gateway --service-name apim-ffc-cpanel \
+     --sid cpanel-ops --query primaryKey -o tsv
+   # (if the CLI lacks --query for the key, use: az rest --method post \
+   #   --url "https://management.azure.com/subscriptions/<sub>/resourceGroups/rg-ffc-cpanel-gateway/providers/Microsoft.ApiManagement/service/apim-ffc-cpanel/subscriptions/cpanel-ops/listSecrets?api-version=2022-08-01" \
+   #   --query primaryKey -o tsv)
+   ```
+3. **Verify** with the **cPanel ops via APIM** workflow (defaults to a read-only
+   `DomainInfo/list_domains` call). `status: 1` ⇒ whitelist + auth injection work.
+
+## Security notes
+
+- The cPanel token and username live only in Key Vault; APIM pulls them via its
+  managed identity as **secret named values** (versionless URIs ⇒ auto-rotate).
+  They are never committed, logged, or passed through the pipeline.
+- Callers authenticate to APIM with a **subscription key** and never see the
+  cPanel token. Rotate the key with `az apim subscription regenerate-key`.
+- Backend TLS validation is disabled because cPanel presents a shared/self-signed
+  cert on :2083; the connection is still HTTPS-encrypted.
+
+## Scope / limits
+
+- APIM is **HTTP(S) only** — it fronts the cPanel **UAPI**, not SSH. UAPI covers
+  most automation (DomainInfo, Fileman, Cron, Mysql, Backup, etc.). SSH-only
+  runbook steps still need a separate path.
+- The `/cpanel/execute/{module}/{function}` operations map 1:1 to UAPI calls;
+  query/body params pass through unchanged.

--- a/infra/cpanel-apim/README.md
+++ b/infra/cpanel-apim/README.md
@@ -165,9 +165,24 @@ az deployment group create -g rg-ffc-cpanel-gateway \
   managed identity as **secret named values** (versionless URIs ⇒ auto-rotate).
   They are never committed, logged, or passed through the pipeline.
 - Callers authenticate to APIM with a **subscription key** and never see the
-  cPanel token. Rotate the key with `az apim subscription regenerate-key`.
+  cPanel token. The policy **strips `Ocp-Apim-Subscription-Key`** before
+  forwarding, so the gateway key never reaches cPanel or the host's logs.
+  Rotate the key with `az apim subscription regenerate-key`.
+- The policy applies a **rate limit** (300 calls / 60 s per subscription) as a
+  safety net, so a leaked key cannot be used to hammer the UAPI from the
+  whitelisted IP.
+- The gateway **refuses legacy TLS** (1.0/1.1, SSL3) and 3DES on both the
+  client and backend sides (`customProperties` in `apim.bicep`).
+- Deploy-workflow inputs are passed through `env` (never interpolated directly
+  into `run:`) to avoid GitHub Actions script injection.
 - Backend TLS validation is disabled because cPanel presents a shared/self-signed
-  cert on :2083; the connection is still HTTPS-encrypted.
+  cert on :2083; the connection is still HTTPS-encrypted but the backend's
+  identity is not verified. **Residual risk:** an attacker able to MITM the
+  APIM→cPanel hop could read the injected token. If the cPanel hostname presents
+  a valid CA-signed cert, re-enable `validateCertificateName` in `apis.bicep`.
+- The proxy exposes **any** UAPI `{module}/{function}` (reads and writes) and the
+  KV token is write-scoped. If your automation only reads, use a read-scoped
+  cPanel token and/or restrict modules in the policy to shrink blast radius.
 
 ## Scope / limits
 

--- a/infra/cpanel-apim/apim.bicep
+++ b/infra/cpanel-apim/apim.bicep
@@ -1,0 +1,62 @@
+// Phase 1: the API Management instance itself.
+//
+// Deploy this FIRST, then grant the output managed identity Get+List secrets
+// on the Key Vault, then deploy apis.bicep (which adds the KV-linked named
+// values + cPanel API). APIM takes ~30-45 min to provision.
+//
+// Static IP note: only the classic Developer/Basic/Standard/Premium tiers get
+// a dedicated STATIC public IP. Consumption and the v2 tiers (Basic v2 /
+// Standard v2 / Premium v2) run on shared infra with NO deterministic IP, so
+// they can't be whitelisted in Imunify360. Developer is the cheapest static-IP
+// tier (no SLA -- fine for internal ops automation).
+
+@description('Azure region for the APIM instance.')
+param location string = resourceGroup().location
+
+@description('APIM instance name (globally unique; forms <name>.azure-api.net).')
+param apimName string
+
+@description('Publisher email shown on the instance (required by Azure; receives service notices).')
+param publisherEmail string
+
+@description('Publisher / organization name.')
+param publisherName string = 'Free For Charity'
+
+@description('SKU. Must be a classic tier for a static IP. Developer = cheapest static IP, no SLA.')
+@allowed([
+  'Developer'
+  'Basic'
+  'Standard'
+  'Premium'
+])
+param skuName string = 'Developer'
+
+@description('Scale units.')
+param skuCapacity int = 1
+
+resource apim 'Microsoft.ApiManagement/service@2022-08-01' = {
+  name: apimName
+  location: location
+  sku: {
+    name: skuName
+    capacity: skuCapacity
+  }
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    publisherEmail: publisherEmail
+    publisherName: publisherName
+  }
+}
+
+@description('System-assigned identity principal ID. Grant this Get+List secrets on the Key Vault before deploying apis.bicep.')
+output apimPrincipalId string = apim.identity.principalId
+
+@description('Static public IP the cPanel host / Imunify360 sees on outbound calls. Whitelist this single address.')
+output apimStaticIp string = apim.properties.publicIPAddresses[0]
+
+@description('Gateway base URL; callers hit https://<gatewayUrl>/cpanel/execute/<Module>/<func>.')
+output gatewayUrl string = apim.properties.gatewayUrl
+
+output apimName string = apim.name

--- a/infra/cpanel-apim/apim.bicep
+++ b/infra/cpanel-apim/apim.bicep
@@ -47,6 +47,18 @@ resource apim 'Microsoft.ApiManagement/service@2022-08-01' = {
   properties: {
     publisherEmail: publisherEmail
     publisherName: publisherName
+    // Harden TLS: refuse legacy protocols/ciphers on both the client-facing
+    // gateway and the backend (cPanel) connection. cPanel on :2083 supports
+    // TLS 1.2, so disabling older protocols does not break the proxy.
+    customProperties: {
+      'Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls10': 'False'
+      'Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls11': 'False'
+      'Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Ssl30': 'False'
+      'Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Ciphers.TripleDes168': 'False'
+      'Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Backend.Protocols.Tls10': 'False'
+      'Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Backend.Protocols.Tls11': 'False'
+      'Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Backend.Protocols.Ssl30': 'False'
+    }
   }
 }
 

--- a/infra/cpanel-apim/apim.bicep
+++ b/infra/cpanel-apim/apim.bicep
@@ -53,8 +53,8 @@ resource apim 'Microsoft.ApiManagement/service@2022-08-01' = {
 @description('System-assigned identity principal ID. Grant this Get+List secrets on the Key Vault before deploying apis.bicep.')
 output apimPrincipalId string = apim.identity.principalId
 
-@description('Static public IP the cPanel host / Imunify360 sees on outbound calls. Whitelist this single address.')
-output apimStaticIp string = apim.properties.publicIPAddresses[0]
+@description('All static public IPs the cPanel host / Imunify360 may see on outbound calls. Whitelist EVERY address (a classic instance can expose more than one).')
+output apimStaticIps array = apim.properties.publicIPAddresses
 
 @description('Gateway base URL; callers hit https://<gatewayUrl>/cpanel/execute/<Module>/<func>.')
 output gatewayUrl string = apim.properties.gatewayUrl

--- a/infra/cpanel-apim/apis.bicep
+++ b/infra/cpanel-apim/apis.bicep
@@ -1,0 +1,165 @@
+// Phase 2: the cPanel UAPI proxy on an existing APIM instance.
+//
+// Adds:
+//   - two SECRET named values sourced from Key Vault (cpanel token + user),
+//     resolved by APIM's managed identity -- the secret value never transits
+//     this pipeline or the repo;
+//   - a backend pointing at the cPanel UAPI with TLS validation disabled
+//     (cPanel presents a shared/self-signed cert);
+//   - an API (path /cpanel) with GET/POST /execute/{module}/{function}
+//     operations and a subscription so callers authenticate with a key;
+//   - an API policy that injects "Authorization: cpanel {{user}}:{{token}}"
+//     and Accept: application/json, then forwards to the backend.
+//
+// PREREQUISITE: APIM's managed identity (apim.bicep output apimPrincipalId)
+// must already have Get+List secrets on the Key Vault, or the named values
+// fail to resolve.
+
+@description('Name of the existing APIM instance (from apim.bicep).')
+param apimName string
+
+@description('Key Vault name holding the cPanel secrets.')
+param keyVaultName string = 'kv-ffc-admin-prod-cbm'
+
+@description('KV secret name for the cPanel API token.')
+param tokenSecretName string = 'wr-all-cbm-cpanel-ffc-interserver-api-token'
+
+@description('KV secret name for the cPanel account username.')
+param userSecretName string = 'wr-all-cbm-cpanel-ffc-interserver-user'
+
+@description('cPanel UAPI base URL incl. port, e.g. https://hostname.example.net:2083 (the hostname is in KV secret wr-all-cbm-cpanel-ffc-interserver-server).')
+param cpanelApiBaseUrl string
+
+// Versionless KV secret identifiers => APIM auto-refreshes on rotation.
+var tokenSecretId = 'https://${keyVaultName}${environment().suffixes.keyvaultDns}/secrets/${tokenSecretName}'
+var userSecretId = 'https://${keyVaultName}${environment().suffixes.keyvaultDns}/secrets/${userSecretName}'
+
+resource apim 'Microsoft.ApiManagement/service@2022-08-01' existing = {
+  name: apimName
+}
+
+resource nvToken 'Microsoft.ApiManagement/service/namedValues@2022-08-01' = {
+  parent: apim
+  name: 'cpanel-api-token'
+  properties: {
+    displayName: 'cpanel-api-token'
+    secret: true
+    keyVault: {
+      secretIdentifier: tokenSecretId
+    }
+  }
+}
+
+resource nvUser 'Microsoft.ApiManagement/service/namedValues@2022-08-01' = {
+  parent: apim
+  name: 'cpanel-user'
+  properties: {
+    displayName: 'cpanel-user'
+    secret: true
+    keyVault: {
+      secretIdentifier: userSecretId
+    }
+  }
+}
+
+resource backend 'Microsoft.ApiManagement/service/backends@2022-08-01' = {
+  parent: apim
+  name: 'cpanel'
+  properties: {
+    url: cpanelApiBaseUrl
+    protocol: 'http'
+    tls: {
+      validateCertificateChain: false
+      validateCertificateName: false
+    }
+  }
+}
+
+resource api 'Microsoft.ApiManagement/service/apis@2022-08-01' = {
+  parent: apim
+  name: 'cpanel'
+  properties: {
+    displayName: 'cPanel UAPI proxy'
+    path: 'cpanel'
+    protocols: [
+      'https'
+    ]
+    subscriptionRequired: true
+    serviceUrl: cpanelApiBaseUrl
+  }
+}
+
+resource opGet 'Microsoft.ApiManagement/service/apis/operations@2022-08-01' = {
+  parent: api
+  name: 'uapi-get'
+  properties: {
+    displayName: 'UAPI GET'
+    method: 'GET'
+    urlTemplate: '/execute/{module}/{function}'
+    templateParameters: [
+      {
+        name: 'module'
+        type: 'string'
+        required: true
+      }
+      {
+        name: 'function'
+        type: 'string'
+        required: true
+      }
+    ]
+  }
+}
+
+resource opPost 'Microsoft.ApiManagement/service/apis/operations@2022-08-01' = {
+  parent: api
+  name: 'uapi-post'
+  properties: {
+    displayName: 'UAPI POST'
+    method: 'POST'
+    urlTemplate: '/execute/{module}/{function}'
+    templateParameters: [
+      {
+        name: 'module'
+        type: 'string'
+        required: true
+      }
+      {
+        name: 'function'
+        type: 'string'
+        required: true
+      }
+    ]
+  }
+}
+
+resource apiPolicy 'Microsoft.ApiManagement/service/apis/policies@2022-08-01' = {
+  parent: api
+  name: 'policy'
+  properties: {
+    format: 'rawxml'
+    value: loadTextContent('./policies/cpanel-api.xml')
+  }
+  dependsOn: [
+    nvToken
+    nvUser
+    backend
+  ]
+}
+
+// Subscription scoped to this API => the caller (CI) authenticates with its key.
+resource sub 'Microsoft.ApiManagement/service/subscriptions@2022-08-01' = {
+  parent: apim
+  name: 'cpanel-ops'
+  properties: {
+    displayName: 'cPanel ops (CI)'
+    scope: api.id
+    state: 'active'
+  }
+}
+
+@description('Call this base path: https://<gateway>/cpanel/execute/<Module>/<func>')
+output cpanelApiPath string = '${apim.properties.gatewayUrl}/cpanel/execute'
+
+@description('Retrieve the subscription key with: az apim subscription show ... or the REST listSecrets on this subscription id.')
+output subscriptionResourceId string = sub.id

--- a/infra/cpanel-apim/policies/cpanel-api.xml
+++ b/infra/cpanel-apim/policies/cpanel-api.xml
@@ -1,0 +1,38 @@
+<!--
+  cPanel UAPI proxy policy for Azure API Management.
+
+  Inbound:
+    - Route to the "cpanel" backend entity (base URL https://<cpanel-host>:2083,
+      with backend TLS validation disabled for cPanel's shared/self-signed cert).
+    - Inject the cPanel token auth header from Key Vault-backed named values:
+        Authorization: cpanel {{cpanel-user}}:{{cpanel-api-token}}
+      (named values are secret + sourced from kv-ffc-admin-prod-cbm via the
+      APIM managed identity, so no credential is stored in this repo).
+    - Force Accept: application/json so the cPanel OpenResty front returns JSON
+      instead of 415.
+
+  The caller (e.g. GitHub Actions) authenticates to APIM with a subscription
+  key (Ocp-Apim-Subscription-Key) and never sees the cPanel token. APIM's
+  static public IP is the source the cPanel host / Imunify360 sees.
+-->
+<policies>
+  <inbound>
+    <base />
+    <set-backend-service backend-id="cpanel" />
+    <set-header name="Authorization" exists-action="override">
+      <value>cpanel {{cpanel-user}}:{{cpanel-api-token}}</value>
+    </set-header>
+    <set-header name="Accept" exists-action="override">
+      <value>application/json</value>
+    </set-header>
+  </inbound>
+  <backend>
+    <base />
+  </backend>
+  <outbound>
+    <base />
+  </outbound>
+  <on-error>
+    <base />
+  </on-error>
+</policies>

--- a/infra/cpanel-apim/policies/cpanel-api.xml
+++ b/infra/cpanel-apim/policies/cpanel-api.xml
@@ -25,6 +25,10 @@
     <set-header name="Accept" exists-action="override">
       <value>application/json</value>
     </set-header>
+    <!-- Strip the APIM subscription key so it is never forwarded to cPanel /
+         the host's access logs. The caller authenticates to APIM with it; the
+         backend must never see it. -->
+    <set-header name="Ocp-Apim-Subscription-Key" exists-action="delete" />
   </inbound>
   <backend>
     <base />

--- a/infra/cpanel-apim/policies/cpanel-api.xml
+++ b/infra/cpanel-apim/policies/cpanel-api.xml
@@ -18,6 +18,10 @@
 <policies>
   <inbound>
     <base />
+    <!-- Safety net: cap throughput per subscription so a leaked key cannot be
+         used to hammer the cPanel UAPI (abuse / DoS) from the whitelisted IP.
+         Generous enough for ops automation; tune as needed. -->
+    <rate-limit-by-key calls="300" renewal-period="60" counter-key="@(context.Subscription?.Id ?? context.Request.IpAddress)" />
     <set-backend-service backend-id="cpanel" />
     <set-header name="Authorization" exists-action="override">
       <value>cpanel {{cpanel-user}}:{{cpanel-api-token}}</value>


### PR DESCRIPTION
## Why

Imunify360 on the InterServer cPanel host blocks datacenter traffic — **including Azure**. GitHub-hosted runners egress from Azure IPs, so direct cPanel API calls from CI are denied (proven by the earlier `test-cpanel-api-token` run). The fix is a single **static, whitelistable IP** in front of the cPanel UAPI.

This adds Infrastructure-as-Code for an **Azure API Management** gateway (Azure&#39;s managed API Gateway product) that:
- has a **static public IP** (whitelist once in Imunify360),
- pulls the cPanel token + username **directly from Key Vault** via its managed identity (no secret ever enters the pipeline),
- injects `Authorization: cpanel user:token` and forwards UAPI calls from its static IP.

```
GitHub Actions ──(APIM subscription key)──▶ APIM (static IP) ──(cpanel token from KV)──▶ cPanel UAPI :2083
```

The instance is a **shared FFC gateway**, not cPanel-specific — cPanel is the first API onboarded (`/cpanel`); future backends reuse the same instance and static IP.

## ✅ Deployed & verified (live)

| Thing | Value |
|---|---|
| APIM instance | `apim-ffc-gateway-prod` (Developer, eastus) |
| Resource group | `rg-ffc-admin-apim` |
| Gateway URL | `https://apim-ffc-gateway-prod.azure-api.net` |
| **Static egress IP** | **`20.231.116.111`** |
| Subscription key | stored in Key Vault as `read-all-ffc-apim-gateway-subscription-key` |

- [x] Phase 1 `apim.bicep` deployed (Succeeded)
- [x] APIM managed identity granted **Key Vault Secrets User** on `kv-ffc-admin-prod-cbm`
- [x] Phase 2 `apis.bicep` deployed; both KV-backed named values resolve (`code: Success`)
- [x] Live call through the gateway reaches cPanel — auth injection + routing confirmed working

**Last step (external):** the cPanel host is **shared**, so its end-user Imunify360 panel has no Firewall/Whitelist tab. A support ticket has been submitted to **InterServer** to whitelist `20.231.116.111` server-side. Until then, gateway calls return `{"message":"Access denied by Imunify360 bot-protection..."}` — that response coming back *through the gateway* is itself proof the auth/routing chain works.

- [ ] InterServer whitelists `20.231.116.111` in Imunify360 (ticket open)
- [ ] Final end-to-end verify (expect real UAPI JSON instead of the block message)

## Tier / cost rationale

Only **classic** APIM tiers have a static IP. **Consumption and all v2 tiers (Basic v2/Standard v2/Premium v2) run on shared infra with no whitelistable IP** ([MS Learn](https://learn.microsoft.com/azure/api-management/api-management-howto-ip-addresses)). Deployed on **Developer (~$40–50/mo, no SLA)** — the cheapest tier that works.

| Tier | ~Monthly | Static IP | Works |
|---|---|---|---|
| Consumption | ~$3.50/M calls | ❌ | ❌ |
| **Developer** | **~$40–50** | ✔️ | ✅ |
| Basic | ~$150 | ✔️ | ✅ (SLA) |
| Basic v2 | ~$145 | ❌ | ❌ |
| Standard v2 | ~$700/unit | ❌ | ❌ |

## What&#39;s here

- `infra/cpanel-apim/apim.bicep` — APIM service + system-assigned identity; outputs static IP + principal ID
- `infra/cpanel-apim/apis.bicep` — KV-linked secret named values, cPanel backend (TLS validation off for the self-signed :2083 cert), `/cpanel` API + GET/POST UAPI operations, auth-injection policy, subscription
- `infra/cpanel-apim/policies/cpanel-api.xml` — the policy
- `.github/workflows/cpanel-apim-deploy.yml` — phase 1 → grant KV access → phase 2 (manual dispatch)
- `.github/workflows/cpanel-ops-via-apim.yml` — calls UAPI through the gateway (also a connectivity check)
- `infra/cpanel-apim/README.md` — full procedure, deployed-instance record, security notes

Scope note: APIM is HTTP(S)-only — it fronts the cPanel **UAPI**, not SSH.

Refs the cPanel API token connectivity work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L5dsyzhYdTmrpkgTXar6pa)_