### PR TITLE
fix: repair dead external links across the site (full lycheeignore audit)

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -72,7 +72,6 @@ https://www.freeforcharity.org/**
 # Sites that block CI crawlers or are intentionally placeholder / flaky
 https://my.interserver.net/**
 https://www.interserver.net/**
-https://support.cloudflare.com/**
 https://www.webhostingtalk.com/**
 https://www.g2.com/**
 https://usertraining.lastpass.com/**
@@ -82,9 +81,6 @@ https://www.upwork.com/**
 https://www.clarity.ms/tag/**
 https://www.youtube.com/watch?v=example-*
 https://neilpatel.com/blog/microsoft-clarity/**
-https://www.nuance.com/dragon.html
-https://www.avepoint.com/blog/office-365/microsoft-365-nonprofits/**
-https://www.nexcess.net/blog/whmcs-best-practices/**
 https://www.youtube.com/watch?v=example-lastpass-101
 https://www.youtube.com/watch\?v=example-lastpass-101
 https://www.cloudflare.com/learning/**

--- a/src/components/free-for-charity-ffc-web-developer-training-guide-components/Hero/index.tsx
+++ b/src/components/free-for-charity-ffc-web-developer-training-guide-components/Hero/index.tsx
@@ -233,17 +233,13 @@ const Index = () => {
               </a>
             </li>
             <li className="underline  pl-[0.5rem] mb-[0.75rem] text-[14px] text-[#0066B8] leading-[26px] ">
-              <a
-                href="https://www.nexcess.net/blog/whmcs-best-practices/"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Blog Post on WHMCS Best Practices
+              <a href="https://docs.whmcs.com/" target="_blank" rel="noopener noreferrer">
+                WHMCS Official Documentation
               </a>
             </li>
             <li className="underline  pl-[0.5rem] mb-[0.75rem] text-[14px] text-[#0066B8] leading-[26px] ">
               <a
-                href="https://www.inmotionhosting.com/support/edu/whmcs/"
+                href="https://www.inmotionhosting.com/support/whmcs/"
                 target="_blank"
                 rel="noopener noreferrer"
               >
@@ -408,7 +404,11 @@ const Index = () => {
               </a>
             </li>
             <li className="underline  pl-[0.5rem] mb-[0.75rem] text-[14px] text-[#0066B8] leading-[26px] ">
-              <a href="https://support.cloudflare.com/" target="_blank" rel="noopener noreferrer">
+              <a
+                href="https://developers.cloudflare.com/support/"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
                 Cloudflare Support Portal
               </a>
             </li>
@@ -581,11 +581,7 @@ const Index = () => {
               </a>
             </li>
             <li className="underline  pl-[0.5rem] mb-[0.75rem] text-[14px] text-[#0066B8] leading-[26px] ">
-              <a
-                href="https://www.avepoint.com/blog/office-365/microsoft-365-nonprofits/"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
+              <a href="https://www.avepoint.com/blog" target="_blank" rel="noopener noreferrer">
                 Blog Guide by AvePoint
               </a>
             </li>

--- a/src/components/free-for-charity-ffc-web-developer-training-guide-components/Hero/index.tsx
+++ b/src/components/free-for-charity-ffc-web-developer-training-guide-components/Hero/index.tsx
@@ -609,7 +609,7 @@ const Index = () => {
             </li>
             <li className="underline  pl-[0.5rem] mb-[0.75rem] text-[14px] text-[#0066B8] leading-[26px] ">
               <a
-                href="https://techcommunity.microsoft.com/t5/nonprofits/ct-p/Nonprofits"
+                href="https://techcommunity.microsoft.com/category/microsoftfornonprofits"
                 target="_blank"
                 rel="noopener noreferrer"
               >
@@ -1018,12 +1018,12 @@ const Index = () => {
             </li>
             <li className="underline pl-[0.5rem] text-[#0066B8] mb-[0.75rem] text-[14px] leading-[26px]">
               <a
-                href="https://techcommunity.microsoft.com/t5/microsoft-clarity-blog/bg-p/ClarityBlog"
+                href="https://clarity.microsoft.com/blog/"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-[#0066B8] underline"
               >
-                Tech Community Discussions
+                Microsoft Clarity Blog
               </a>
             </li>
           </ul>

--- a/src/components/free-for-charity-ffc-web-developer-training-guide-components/Hero/index.tsx
+++ b/src/components/free-for-charity-ffc-web-developer-training-guide-components/Hero/index.tsx
@@ -233,8 +233,12 @@ const Index = () => {
               </a>
             </li>
             <li className="underline  pl-[0.5rem] mb-[0.75rem] text-[14px] text-[#0066B8] leading-[26px] ">
-              <a href="https://docs.whmcs.com/" target="_blank" rel="noopener noreferrer">
-                WHMCS Official Documentation
+              <a
+                href="https://docs.whmcs.com/9-0/installation-guide/initial-configuration/enhancing-security/"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                WHMCS Security Best Practices (Official Guide)
               </a>
             </li>
             <li className="underline  pl-[0.5rem] mb-[0.75rem] text-[14px] text-[#0066B8] leading-[26px] ">

--- a/src/components/free-for-charitys-tools-for-success-components/Six-Grid-Cards/index.tsx
+++ b/src/components/free-for-charitys-tools-for-success-components/Six-Grid-Cards/index.tsx
@@ -9,7 +9,7 @@ export default function ToolsPage() {
       title: 'QuickBooks Online ($75 per year with 5 users)',
       description:
         'If your accounting is not right a lot will suffer. Techsoup offers the discounts for QuickBooks the industry leader in accounting. Both online and offline versions are offered at the same price.',
-      link: 'https://www.techsoup.org/products/quickbooks-online-plus--1-year-initial-subscription--5-users--G-49616--',
+      link: 'https://www.techsoup.org/products/quickbooks-online-plus-1-year-subscription-5-users-g-49616-',
     },
     {
       logo: '/Images/googleLogo.webp',
@@ -40,7 +40,7 @@ export default function ToolsPage() {
       title: 'GrantStation (199$ per year)',
       description:
         'Best tool if you have a dedicated grant writer or a grant worthy type of charity.',
-      link: 'http://www.techsoup.org/products/grantstation-%28discounted%29--G-2575-',
+      link: 'https://www.techsoup.org/products/grantstation-1-year-membership-g-2575-',
     },
     {
       logo: '/Images/mailchimpLogo.webp',

--- a/src/components/free-for-charitys-tools-for-success-components/Two-Cards/index.tsx
+++ b/src/components/free-for-charitys-tools-for-success-components/Two-Cards/index.tsx
@@ -41,7 +41,7 @@ const index = () => {
               </>
             }
             buttonText="Available Here"
-            buttonLink="https://www.nuance.com/dragon.html"
+            buttonLink="https://dragon.nuance.com/en-us/dragon"
             imageSrc="/Images/dragon-logo.webp" // 👈 image passed as prop
           />
         </div>


### PR DESCRIPTION
## Why

The "Check external links" (lychee) job was failing, and rather than ignore the offenders, this PR **finds the correct current URLs and fixes them**. It also audits the **entire `.lycheeignore` list** — verifying each entry against its real source URL instead of assuming "blocks bots" — and removes the entries that were actually masking dead/moved links.

## 1. The two hard CI failures (dead → migrated)

Old Microsoft **Tech Community** `/t5/...` board URLs now 302-redirect into a login/SSO wall (the `403` lychee reported):

| Link | Old (dead) | New (verified public) |
|---|---|---|
| Nonprofits "Community Forum Discussions" | `techcommunity.microsoft.com/t5/nonprofits/...` | `techcommunity.microsoft.com/category/microsoftfornonprofits` |
| Clarity (relabeled "Microsoft Clarity Blog") | `techcommunity.microsoft.com/t5/microsoft-clarity-blog/...` | `clarity.microsoft.com/blog/` |

## 2. Full `.lycheeignore` audit — six more genuinely broken links

Every ignore entry was checked against its actual URL in the source. **Six were moved/dead, not bot-blocks**, and are now repaired and **un-ignored** (corrected targets return 200):

| What | Old (404/500/redirect-to-404) | Fixed to |
|---|---|---|
| TechSoup GrantStation | `…/grantstation-%28discounted%29--G-2575-` | `…/grantstation-1-year-membership-g-2575-` |
| TechSoup QuickBooks | `…/quickbooks-online-plus--1-year-initial-subscription--5-users--G-49616--` | `…/quickbooks-online-plus-1-year-subscription-5-users-g-49616-` |
| Cloudflare support | `support.cloudflare.com/` | `developers.cloudflare.com/support/` |
| InMotion WHMCS guide | `inmotionhosting.com/support/edu/whmcs/` | `inmotionhosting.com/support/whmcs/` |
| AvePoint M365-nonprofits post | `avepoint.com/blog/office-365/microsoft-365-nonprofits/` | `avepoint.com/blog` |
| Nexcess WHMCS best-practices (removed) | `nexcess.net/blog/whmcs-best-practices/` | `docs.whmcs.com/` (relabeled "WHMCS Official Documentation") |
| Nuance Dragon (consumer line discontinued) | `nuance.com/dragon.html` | `dragon.nuance.com/en-us/dragon` |

Removed the four now-obsolete ignore lines (`support.cloudflare.com`, `nuance.com/dragon.html`, the AvePoint old path, the Nexcess article). TechSoup/InMotion stay ignored — the corrected URLs are right but those hosts genuinely bot-block.

## 3. Verified as true bot-blocks (left ignored — links are correct)

Confirmed reachable for humans but block automated fetch (403/999/captcha), so the ignore is legitimate: LinkedIn, Facebook, X, YouTube, G2, Upwork, GuideStar/Candid, SiteGround, Cloudwards, WebHostingTalk, LastPass portals, `privacy.microsoft.com` (301s correctly), plus the runtime script-fragment and localhost/placeholder entries.

## Verification

All seven replacement URLs were fetched and confirmed live (HTTP 200) before committing; the dead originals were confirmed 404 / redirect-to-404 / SSO-wall. lychee accepts `200,206,301,302,307,308`. If CI surfaces a bot-block on any of the four un-ignored hosts, a targeted ignore will be re-added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L5dsyzhYdTmrpkgTXar6pa)_