### PR TITLE
harden: operation allowlist on the cPanel APIM gateway

### DIFF
--- a/infra/cpanel-apim/README.md
+++ b/infra/cpanel-apim/README.md
@@ -180,9 +180,20 @@ az deployment group create -g rg-ffc-cpanel-gateway \
   identity is not verified. **Residual risk:** an attacker able to MITM the
   APIM→cPanel hop could read the injected token. If the cPanel hostname presents
   a valid CA-signed cert, re-enable `validateCertificateName` in `apis.bicep`.
-- The proxy exposes **any** UAPI `{module}/{function}` (reads and writes) and the
-  KV token is write-scoped. If your automation only reads, use a read-scoped
-  cPanel token and/or restrict modules in the policy to shrink blast radius.
+- **Blast-radius control — operation allowlist.** On shared cPanel the API
+  token is unavoidably **full-access**: the user-level _Manage API Tokens_ UI
+  only supports rename/revoke — it cannot scope a token's privileges or
+  restrict it by IP (those are WHM/root features we don't have). So the gateway
+  policy enforces an **allowlist** of the exact UAPI `{module}/{function}` calls
+  our automation uses (backup/list/restore + the read-only `list_*` views) and
+  returns **403** for anything else. Extend the list in
+  `policies/cpanel-api.xml` as new operations are needed.
+- **De-facto IP restriction.** Because Imunify360 blocks port 2083 from any
+  non-whitelisted IP, a leaked cPanel token cannot be used over the API from an
+  arbitrary IP anyway — only from the gateway's static IP (and operator IPs the
+  host already trusts). This compensates for the missing per-token IP allowlist.
+- **Rotation** is the primary token hygiene: revoke + recreate the cPanel token,
+  update the KV secret, and APIM auto-refreshes the named value (no redeploy).
 
 ## Scope / limits
 

--- a/infra/cpanel-apim/README.md
+++ b/infra/cpanel-apim/README.md
@@ -188,7 +188,7 @@ az deployment group create -g rg-ffc-cpanel-gateway \
   our automation uses (backup/list/restore + the read-only `list_*` views) and
   returns **403** for anything else. Extend the list in
   `policies/cpanel-api.xml` as new operations are needed.
-- **De-facto IP restriction.** Because Imunify360 blocks port 2083 from any
+- **De facto IP restriction.** Because Imunify360 blocks port 2083 from any
   non-whitelisted IP, a leaked cPanel token cannot be used over the API from an
   arbitrary IP anyway — only from the gateway's static IP (and operator IPs the
   host already trusts). This compensates for the missing per-token IP allowlist.

--- a/infra/cpanel-apim/policies/cpanel-api.xml
+++ b/infra/cpanel-apim/policies/cpanel-api.xml
@@ -22,6 +22,46 @@
          used to hammer the cPanel UAPI (abuse / DoS) from the whitelisted IP.
          Generous enough for ops automation; tune as needed. -->
     <rate-limit-by-key calls="300" renewal-period="60" counter-key="@(context.Subscription?.Id ?? context.Request.IpAddress)" />
+    <!-- Operation allowlist. The cPanel API token is full-access at the user
+         level (shared hosting cannot scope a token or restrict it by IP), so
+         the gateway caps the blast radius: it forwards ONLY the specific UAPI
+         module/function calls our automation uses and rejects anything else
+         with 403. A leaked subscription key therefore cannot invoke arbitrary
+         destructive UAPI operations. Extend the list as new ops are needed. -->
+    <set-variable name="op" value="@{
+        var p = context.Request.MatchedParameters;
+        var m = p.ContainsKey(&quot;module&quot;) ? p[&quot;module&quot;] : &quot;&quot;;
+        var f = p.ContainsKey(&quot;function&quot;) ? p[&quot;function&quot;] : &quot;&quot;;
+        return (m + &quot;/&quot; + f).ToLowerInvariant();
+    }" />
+    <choose>
+      <when condition="@(!new[] {
+          &quot;backup/fullbackup_to_homedir&quot;,
+          &quot;backup/fullbackup_to_ftp&quot;,
+          &quot;backup/fullbackup_to_scp&quot;,
+          &quot;backup/list_backups&quot;,
+          &quot;backup/restore&quot;,
+          &quot;fileman/list_files&quot;,
+          &quot;domaininfo/list_domains&quot;,
+          &quot;ftp/list_ftp&quot;,
+          &quot;cron/list_lines&quot;,
+          &quot;email/list_forwarders&quot;,
+          &quot;email/list_filters&quot;,
+          &quot;mysql/list_databases&quot;,
+          &quot;mysql/list_users&quot;,
+          &quot;tokens/list_tokens&quot;,
+          &quot;quota/get_quota_info&quot;,
+          &quot;statsbar/get_stats&quot;
+        }.Contains((string)context.Variables[&quot;op&quot;]))">
+        <return-response>
+          <set-status code="403" reason="Operation not allowed" />
+          <set-header name="Content-Type" exists-action="override">
+            <value>application/json</value>
+          </set-header>
+          <set-body>{"error":"This UAPI operation is not on the gateway allowlist (infra/cpanel-apim/policies/cpanel-api.xml)."}</set-body>
+        </return-response>
+      </when>
+    </choose>
     <set-backend-service backend-id="cpanel" />
     <set-header name="Authorization" exists-action="override">
       <value>cpanel {{cpanel-user}}:{{cpanel-api-token}}</value>


### PR DESCRIPTION
## Why

On shared cPanel the API token is unavoidably **full-access** — the user-level *Manage API Tokens* UI only supports rename/revoke (confirmed in the panel); it can't scope a token's privileges or restrict it by IP (those are WHM/root features we don't have). So the strongest available control is to **cap the blast radius at the gateway**.

## What

The inbound policy now enforces an **operation allowlist**: it forwards only the exact UAPI `{module}/{function}` calls our automation uses and returns **403** for everything else — *before* the cPanel token is even injected. A leaked subscription key (or compromised CI) therefore cannot invoke arbitrary destructive UAPI operations.

Allowlisted today:
- **Backups:** `Backup/fullbackup_to_homedir`, `…_to_ftp`, `…_to_scp`, `Backup/list_backups`, `Backup/restore`, `Fileman/list_files`
- **Read-only audit/inventory:** `DomainInfo/list_domains`, `Ftp/list_ftp`, `Cron/list_lines`, `Email/list_forwarders`, `Email/list_filters`, `Mysql/list_databases`, `Mysql/list_users`, `Tokens/list_tokens`, `Quota/get_quota_info`, `StatsBar/get_stats`

Extend the list in `policies/cpanel-api.xml` as new operations are needed.

## Verified live (already deployed to `apim-ffc-gateway-prod`)
| Call | Result |
|---|---|
| `Mysql/list_databases` (allowed) | ✅ `200`, real data |
| `Email/list_pops` (not listed) | ⛔ `403` allowlist rejection |
| `Email/add_pop` (write, not listed) | ⛔ `403` allowlist rejection |

## Docs
README security notes updated — corrects the earlier (inaccurate for shared cPanel) "use a read-scoped token" advice and documents the three real compensating controls: **operation allowlist**, **Imunify360 de-facto IP restriction** (port 2083 blocked for non-whitelisted IPs), and **token rotation** (revoke → recreate → update KV → APIM auto-refreshes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L5dsyzhYdTmrpkgTXar6pa)_