### PR TITLE
feat: cPanel deploy verification, backup freshness + cutover rehearsal

### DIFF
--- a/.github/workflows/cpanel-backup-freshness.yml
+++ b/.github/workflows/cpanel-backup-freshness.yml
@@ -1,0 +1,105 @@
+name: 'cPanel backup freshness monitor'
+
+# Hard alarm for the off-server backup pipeline. The daily sync
+# (cpanel-softaculous-backup-sync.yml) already emits a per-folder freshness
+# WARNING from inside its run (it has the Graph token), which catches
+# "Softaculous stopped producing backups while the sync is still green."
+#
+# This complementary monitor catches the case that one can't: the sync
+# workflow itself stopped running or started failing (disabled, broken creds,
+# expired OneDrive refresh token, etc.). It only reads GitHub Actions run
+# history via GITHUB_TOKEN -- it does NOT mint a Graph token, so it cannot
+# collide with the sync's single-use (rotating) OneDrive refresh token.
+#
+# Alarms (fails the run) if either:
+#   * there is no SUCCESSFUL sync run within MAX_AGE_HOURS, or
+#   * the most recent sync run concluded in failure.
+
+on:
+  schedule:
+    - cron: '0 8 * * *' # daily 08:00 UTC, ~2h after the 06:00 sync
+  workflow_dispatch:
+    inputs:
+      max_age_hours:
+        description: 'Fail if no successful sync within this many hours'
+        required: false
+        default: '30'
+        type: string
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  monitor:
+    name: 'Check the backup sync is running and succeeding'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Inspect cpanel-softaculous-backup-sync run history'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          SYNC_WF: cpanel-softaculous-backup-sync.yml
+          MAX_AGE_HOURS: ${{ inputs.max_age_hours || '30' }}
+        run: |
+          set -euo pipefail
+          now=$(date -u +%s)
+          max_age=$(( MAX_AGE_HOURS * 3600 ))
+
+          runs=$(gh run list --workflow "$SYNC_WF" --limit 20 \
+            --json databaseId,status,conclusion,createdAt,updatedAt)
+
+          if [ "$(printf '%s' "$runs" | jq 'length')" -eq 0 ]; then
+            echo "::error::No runs found for ${SYNC_WF}. Is the workflow present/enabled?"
+            exit 1
+          fi
+
+          # Most recent run overall (by createdAt).
+          latest=$(printf '%s' "$runs" | jq -c 'sort_by(.createdAt) | last')
+          latest_concl=$(printf '%s' "$latest" | jq -r '.conclusion // ""')
+          latest_status=$(printf '%s' "$latest" | jq -r '.status // ""')
+          latest_when=$(printf '%s' "$latest" | jq -r '.updatedAt // .createdAt')
+
+          # Most recent SUCCESSFUL run.
+          last_ok=$(printf '%s' "$runs" | jq -c '[.[] | select(.conclusion=="success")] | sort_by(.updatedAt) | last // empty')
+
+          fail=0
+          if [ -z "$last_ok" ]; then
+            echo "::error::No successful ${SYNC_WF} run in the last 20 runs."
+            fail=1
+          else
+            ok_when=$(printf '%s' "$last_ok" | jq -r '.updatedAt // .createdAt')
+            ok_epoch=$(date -u -d "$ok_when" +%s)
+            age=$(( now - ok_epoch ))
+            age_h=$(( age / 3600 ))
+            echo "Last successful sync: ${ok_when} (${age_h}h ago, limit ${MAX_AGE_HOURS}h)"
+            if [ "$age" -gt "$max_age" ]; then
+              echo "::error::Last successful backup sync was ${age_h}h ago (> ${MAX_AGE_HOURS}h). Backups may be stale."
+              fail=1
+            fi
+          fi
+
+          # A currently in-progress run isn't a failure; only alarm on a
+          # decided failure of the most recent run.
+          if [ "$latest_status" = "completed" ] && [ "$latest_concl" != "success" ]; then
+            echo "::error::Most recent ${SYNC_WF} run concluded '${latest_concl}' at ${latest_when}."
+            fail=1
+          fi
+
+          {
+            echo "## Backup freshness monitor"
+            echo ""
+            echo "- Latest sync run: \`${latest_status}/${latest_concl:-?}\` at ${latest_when}"
+            if [ -n "$last_ok" ]; then
+              echo "- Last successful sync: ${ok_when} (${age_h}h ago)"
+            else
+              echo "- Last successful sync: **none in recent history**"
+            fi
+            echo "- Threshold: ${MAX_AGE_HOURS}h"
+            echo "- Result: $( [ "$fail" -eq 0 ] && echo '✅ healthy' || echo '⛔ ALARM' )"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$fail" -ne 0 ]; then
+            exit 1
+          fi
+          echo "✅ Backup pipeline healthy."

--- a/.github/workflows/cpanel-backup-freshness.yml
+++ b/.github/workflows/cpanel-backup-freshness.yml
@@ -43,6 +43,12 @@ jobs:
           MAX_AGE_HOURS: ${{ inputs.max_age_hours || '30' }}
         run: |
           set -euo pipefail
+          # Validate the dispatch input up front so a bad value fails with a
+          # clear message instead of a cryptic bash arithmetic syntax error.
+          if ! printf '%s' "$MAX_AGE_HOURS" | grep -Eq '^[1-9][0-9]*$'; then
+            echo "::error::max_age_hours must be a positive integer (got '${MAX_AGE_HOURS}')."
+            exit 1
+          fi
           now=$(date -u +%s)
           max_age=$(( MAX_AGE_HOURS * 3600 ))
 

--- a/.github/workflows/cpanel-cutover-rehearse.yml
+++ b/.github/workflows/cpanel-cutover-rehearse.yml
@@ -1,0 +1,221 @@
+name: 'cPanel cutover rehearsal (static overwrite, /hub-safe)'
+
+# Rehearses the REAL cutover mechanic on a THROWAWAY domain so we can prove,
+# before ever touching freeforcharity.org, that:
+#
+#   1. mirroring the Next.js static export into a live docroot with --delete
+#      cleanly replaces whatever was there ("the WordPress files that won't
+#      survive the migration"), AND
+#   2. a sibling /hub/ subdirectory (which on the apex is the real WHMCS
+#      install) is EXCLUDED from the mirror and KEEPS SERVING — the static
+#      export's own .htaccess hands /hub/ off untouched
+#      (`RewriteRule ^hub($|/) - [L]` + a DirectoryIndex that includes
+#      index.php), so WHMCS is unaffected.
+#
+# It plants a dummy hub/index.php (a stand-in for WHMCS), runs the exact same
+# lftp mirror + exclusions the apex cutover will use, then curls the test
+# domain to assert the static site serves AND /hub/ still returns the planted
+# PHP. NOTHING here can touch the apex: the apex domain and the public_html
+# docroot are hard-blocked below.
+#
+# Path: GH OIDC -> Azure -> Key Vault -> MAIN cPanel FTP creds (homed at the
+# account root, so it can write any docroot) -> lftp over FTPS.
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_domain:
+        description: 'Throwaway addon/sub domain to rehearse on (NOT freeforcharity.org)'
+        required: true
+        default: 'ffcdomains.org'
+        type: string
+      docroot:
+        description: 'Remote docroot for that domain, relative to the FTP home'
+        required: true
+        default: 'ffcdomains.org'
+        type: string
+      dry_run:
+        description: 'List the plan without writing anything (recommended first)'
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: cpanel-cutover-rehearse
+  cancel-in-progress: false
+
+jobs:
+  rehearse:
+    name: 'Rehearse static overwrite + /hub passthrough'
+    runs-on: ubuntu-latest
+    environment: cpanel-staging
+    steps:
+      - name: 'Guard: never the apex / public_html'
+        env:
+          TARGET: ${{ inputs.target_domain }}
+          DOCROOT: ${{ inputs.docroot }}
+        run: |
+          set -euo pipefail
+          # Defence in depth: this workflow is REHEARSAL-ONLY. The real apex
+          # cutover is a separate, deliberately more-gated action.
+          case "$TARGET" in
+            freeforcharity.org|www.freeforcharity.org)
+              echo "::error::Refusing to rehearse on the apex domain."; exit 1 ;;
+          esac
+          case "$DOCROOT" in
+            public_html|public_html/|/*|*..*)
+              echo "::error::Refusing: docroot must be a relative throwaway docroot, never public_html."; exit 1 ;;
+          esac
+          echo "Rehearsing on '${TARGET}' (docroot './${DOCROOT}/'), dry_run=${{ inputs.dry_run }}"
+
+      - uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Next.js static export
+        env:
+          NEXT_PUBLIC_BASE_PATH: ''
+        run: |
+          set -euo pipefail
+          npm run build
+          test -f ./out/index.html || { echo "::error::out/index.html missing"; exit 1; }
+          test -f ./out/.htaccess || { echo "::error::out/.htaccess missing (routing + /hub handoff live here)"; exit 1; }
+          echo "out/ ready: $(find out -type f | wc -l) files"
+
+      - name: 'Make the dummy WHMCS stand-in (hub/index.php)'
+        id: hub
+        run: |
+          set -euo pipefail
+          token="HUB_OK_$(date -u +%Y%m%d%H%M%S)_${RANDOM}"
+          echo "token=$token" >> "$GITHUB_OUTPUT"
+          mkdir -p hubstage/hub
+          # Minimal PHP so we can prove /hub/ is executed (not rewritten to a
+          # static .html) AFTER the static export overwrites the rest.
+          printf '<?php echo "%s"; %s\n' "$token" '// rehearsal WHMCS stand-in' > hubstage/hub/index.php
+          echo "Planted hub/index.php with token ${token}"
+
+      - name: Azure login (OIDC)
+        if: ${{ inputs.dry_run == false }}
+        uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.WR_ALL_FFC_AZURE_KV_CLIENT_ID }}
+          tenant-id: ${{ secrets.WR_ALL_FFC_AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
+
+      - name: Fetch MAIN cPanel FTP creds from Key Vault
+        if: ${{ inputs.dry_run == false }}
+        shell: pwsh
+        env:
+          KV_NAME: kv-ffc-admin-prod-cbm
+        run: |
+          $ErrorActionPreference = 'Stop'
+          . ./.github/scripts/Get-KvSecret.ps1
+          $vault = $env:KV_NAME.Trim()
+          $ftpHost = Get-KvSecret -VaultName $vault -Name 'wr-all-cbm-cpanel-ffc-interserver-ftp-host'
+          $ftpPort = Get-KvSecret -VaultName $vault -Name 'wr-all-cbm-cpanel-ffc-interserver-ftp-port'
+          $ftpUser = Get-KvSecret -VaultName $vault -Name 'wr-all-cbm-cpanel-ffc-interserver-ftp-user'
+          $ftpPw   = Get-KvSecret -VaultName $vault -Name 'wr-all-cbm-cpanel-ffc-interserver-ftp-password'
+          Write-Host "::add-mask::$ftpHost"
+          Write-Host "::add-mask::$ftpUser"
+          Write-Host "::add-mask::$ftpPw"
+          "CPANEL_FTP_HOST=$ftpHost" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "CPANEL_FTP_PORT=$ftpPort" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "CPANEL_FTP_USER=$ftpUser" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "CPANEL_FTP_PASSWORD=$ftpPw" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
+      - name: 'Pre-stage the WHMCS stand-in, then overwrite with static export'
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+          DOCROOT: ${{ inputs.docroot }}
+        run: |
+          set -euo pipefail
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "DRY RUN — would, against ./${DOCROOT}/ :"
+            echo "  1) upload hubstage/hub/index.php  -> ./${DOCROOT}/hub/index.php"
+            echo "  2) lftp mirror --reverse --delete ./out/ -> ./${DOCROOT}/"
+            echo "     excluding: hub/ cgi-bin/ .well-known/ .ftpquota .htpasswd error_log"
+            echo "  (hub/ is EXCLUDED from --delete, so the stand-in survives)"
+            exit 0
+          fi
+          sudo apt-get update -qq && sudo apt-get install -y -qq lftp
+          # Step 1: place the stand-in WHMCS (simulates the real ~/public_html/hub).
+          # Step 2: mirror the static export with --delete but EXCLUDE hub/ so it
+          # is preserved exactly like real WHMCS will be on the apex.
+          lftp <<LFTP 2>&1 | tail -200
+            set ftp:ssl-allow yes
+            set ftp:ssl-force yes
+            set ftp:ssl-protect-data yes
+            set ssl:verify-certificate no
+            set net:max-retries 3
+            set net:timeout 60
+            open -p "$CPANEL_FTP_PORT" -u "$CPANEL_FTP_USER","$CPANEL_FTP_PASSWORD" "ftp://$CPANEL_FTP_HOST"
+            mirror --reverse --parallel=2 --verbose=1 ./hubstage/ ./${DOCROOT}/
+            mirror --reverse --delete --parallel=4 --verbose=1 \
+              --exclude-glob 'hub' \
+              --exclude-glob 'hub/' \
+              --exclude-glob '.ftpquota' \
+              --exclude-glob '.htpasswd' \
+              --exclude-glob 'error_log' \
+              --exclude-glob '.well-known/' \
+              --exclude-glob 'cgi-bin/' \
+              ./out/ ./${DOCROOT}/
+            bye
+          LFTP
+          echo "Overwrite complete."
+
+      - name: 'Verify: static serves AND /hub/ passthrough survived'
+        if: ${{ inputs.dry_run == false }}
+        env:
+          TARGET: ${{ inputs.target_domain }}
+          HUB_TOKEN: ${{ steps.hub.outputs.token }}
+        run: |
+          set -euo pipefail
+          # Try https first, fall back to http (addon AutoSSL may lag).
+          base="https://${TARGET}"
+          if ! curl -sS -o /dev/null --max-time 20 "$base/" 2>/dev/null; then base="http://${TARGET}"; fi
+          echo "Testing against ${base}"
+          get() { curl -sS -m 25 -H 'Cache-Control: no-cache' -w '\n%{http_code}' "$1"; }
+
+          fail=0
+          # 1) Homepage = static export (has <title>)
+          r=$(get "$base/"); code=$(printf '%s' "$r" | tail -n1); body=$(printf '%s' "$r" | sed '$d')
+          if [ "$code" = "200" ] && printf '%s' "$body" | grep -q '<title>'; then
+            echo "  ✓ / -> 200 static homepage"
+          else echo "  ✗ / -> ${code} (no static homepage)"; fail=1; fi
+
+          # 2) Clean URL routing
+          code=$(curl -sS -m 25 -o /dev/null -w '%{http_code}' -H 'Cache-Control: no-cache' "$base/about-us")
+          [ "$code" = "200" ] && echo "  ✓ /about-us -> 200" || { echo "  ✗ /about-us -> ${code}"; fail=1; }
+
+          # 3) THE key assertion: /hub/ still executes PHP (WHMCS stand-in survived)
+          r=$(get "$base/hub/"); code=$(printf '%s' "$r" | tail -n1); body=$(printf '%s' "$r" | sed '$d')
+          if [ "$code" = "200" ] && printf '%s' "$body" | grep -q "$HUB_TOKEN"; then
+            echo "  ✓ /hub/ -> 200 and served the planted PHP token (passthrough OK)"
+          else echo "  ✗ /hub/ -> ${code}, token present: no — WHMCS would be at risk!"; fail=1; fi
+
+          # 4) Legacy WP path blocked by the static .htaccess
+          code=$(curl -sS -m 25 -o /dev/null -w '%{http_code}' "$base/wp-admin")
+          case "$code" in 301|302|403) echo "  ✓ /wp-admin -> ${code} (blocked/redirected)";; *) echo "  ✗ /wp-admin -> ${code}"; fail=1;; esac
+
+          {
+            echo "## Cutover rehearsal on ${TARGET}"
+            echo ""
+            echo "- Static overwrite with --delete (hub/ excluded): done"
+            echo "- /hub/ passthrough (WHMCS stand-in) survived: $( [ "$fail" -eq 0 ] && echo '✅ yes' || echo '⛔ CHECK FAILED' )"
+            echo ""
+            echo "Cleanup: this is a throwaway docroot; wipe via cPanel File Manager or re-dispatch a normal deploy."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          [ "$fail" -eq 0 ] || { echo "::error::Rehearsal assertions failed — do NOT proceed to the apex cutover."; exit 1; }
+          echo "✅ Rehearsal passed: static overwrite is /hub-safe."

--- a/.github/workflows/cpanel-cutover-rehearse.yml
+++ b/.github/workflows/cpanel-cutover-rehearse.yml
@@ -1,22 +1,32 @@
 name: 'cPanel cutover rehearsal (static overwrite, /hub-safe)'
 
-# Rehearses the REAL cutover mechanic on a THROWAWAY domain so we can prove,
-# before ever touching freeforcharity.org, that:
+# Rehearses the REAL apex cutover mechanic on a RESOLVING, non-apex docroot so
+# we can prove, before touching freeforcharity.org, that:
 #
 #   1. mirroring the Next.js static export into a live docroot with --delete
-#      cleanly replaces whatever was there ("the WordPress files that won't
+#      cleanly removes whatever was there ("the WordPress files that won't
 #      survive the migration"), AND
-#   2. a sibling /hub/ subdirectory (which on the apex is the real WHMCS
-#      install) is EXCLUDED from the mirror and KEEPS SERVING — the static
-#      export's own .htaccess hands /hub/ off untouched
-#      (`RewriteRule ^hub($|/) - [L]` + a DirectoryIndex that includes
-#      index.php), so WHMCS is unaffected.
+#   2. a sibling /hub/ subdirectory (the real WHMCS install on the apex) is
+#      EXCLUDED from the mirror and KEEPS SERVING — the static export's own
+#      .htaccess hands /hub/ off untouched (`RewriteRule ^hub($|/) - [L]` +
+#      `DirectoryIndex index.html index.php`), so WHMCS is unaffected.
 #
-# It plants a dummy hub/index.php (a stand-in for WHMCS), runs the exact same
-# lftp mirror + exclusions the apex cutover will use, then curls the test
-# domain to assert the static site serves AND /hub/ still returns the planted
-# PHP. NOTHING here can touch the apex: the apex domain and the public_html
-# docroot are hard-blocked below.
+# IMPORTANT — test bed: the addon domains (ffcdomains.org, ffchosting.com, …)
+# are Cloudflare-level 301 redirects and never reach their origin docroot, so
+# uploading to them proves nothing. The only resolving, docroot-serving target
+# is the staging subdomain. We therefore rehearse on
+# staging.freeforcharity.org by default.
+#
+# Faithful sequence on the test docroot:
+#   - plant a synthetic "old WP" marker file + a dummy hub/index.php (WHMCS
+#     stand-in),
+#   - run the exact lftp mirror --delete + exclusions the apex cutover will use,
+#   - curl (following redirects, cache-busted) to assert: static site serves,
+#     /about-us/ routes, /hub/ still executes the planted PHP, and the old WP
+#     marker is GONE.
+#
+# Nothing here can touch the apex: the apex domain and the public_html docroot
+# are hard-blocked below. dry_run defaults to true.
 #
 # Path: GH OIDC -> Azure -> Key Vault -> MAIN cPanel FTP creds (homed at the
 # account root, so it can write any docroot) -> lftp over FTPS.
@@ -25,14 +35,14 @@ on:
   workflow_dispatch:
     inputs:
       target_domain:
-        description: 'Throwaway addon/sub domain to rehearse on (NOT freeforcharity.org)'
+        description: 'Resolving, non-apex domain to rehearse on (NOT freeforcharity.org)'
         required: true
-        default: 'ffcdomains.org'
+        default: 'staging.freeforcharity.org'
         type: string
       docroot:
         description: 'Remote docroot for that domain, relative to the FTP home'
         required: true
-        default: 'ffcdomains.org'
+        default: 'staging.freeforcharity.org'
         type: string
       dry_run:
         description: 'List the plan without writing anything (recommended first)'
@@ -68,7 +78,7 @@ jobs:
           esac
           case "$DOCROOT" in
             public_html|public_html/|/*|*..*)
-              echo "::error::Refusing: docroot must be a relative throwaway docroot, never public_html."; exit 1 ;;
+              echo "::error::Refusing: docroot must be a relative non-apex docroot, never public_html."; exit 1 ;;
           esac
           echo "Rehearsing on '${TARGET}' (docroot './${DOCROOT}/'), dry_run=${{ inputs.dry_run }}"
 
@@ -91,19 +101,27 @@ jobs:
           npm run build
           test -f ./out/index.html || { echo "::error::out/index.html missing"; exit 1; }
           test -f ./out/.htaccess || { echo "::error::out/.htaccess missing (routing + /hub handoff live here)"; exit 1; }
+          test -f ./out/about-us/index.html || { echo "::error::out/about-us/index.html missing (trailingSlash export)"; exit 1; }
           echo "out/ ready: $(find out -type f | wc -l) files"
 
-      - name: 'Make the dummy WHMCS stand-in (hub/index.php)'
-        id: hub
+      - name: 'Stage synthetic old-WP marker + WHMCS stand-in'
+        id: stage
         run: |
           set -euo pipefail
           token="HUB_OK_$(date -u +%Y%m%d%H%M%S)_${RANDOM}"
+          marker="legacy-wp-${token}.html"
           echo "token=$token" >> "$GITHUB_OUTPUT"
+          echo "marker=$marker" >> "$GITHUB_OUTPUT"
+          # "Old WP" content that must be GONE after the overwrite proves --delete.
+          mkdir -p oldsite
+          printf '<html><body>OLD WORDPRESS %s</body></html>\n' "$token" > "oldsite/${marker}"
+          # WHMCS stand-in: a PHP-only dir (no index.html) that must SURVIVE,
+          # served via DirectoryIndex index.php after the static .htaccess hands
+          # /hub/ off. Kept in its own staging dir so it is uploaded without
+          # --delete and excluded from the static mirror.
           mkdir -p hubstage/hub
-          # Minimal PHP so we can prove /hub/ is executed (not rewritten to a
-          # static .html) AFTER the static export overwrites the rest.
-          printf '<?php echo "%s"; %s\n' "$token" '// rehearsal WHMCS stand-in' > hubstage/hub/index.php
-          echo "Planted hub/index.php with token ${token}"
+          printf '<?php echo "%s"; // rehearsal WHMCS stand-in\n' "$token" > hubstage/hub/index.php
+          echo "Planted ${marker} (must vanish) + hub/index.php token ${token} (must survive)"
 
       - name: Azure login (OIDC)
         if: ${{ inputs.dry_run == false }}
@@ -134,7 +152,7 @@ jobs:
           "CPANEL_FTP_USER=$ftpUser" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
           "CPANEL_FTP_PASSWORD=$ftpPw" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
 
-      - name: 'Pre-stage the WHMCS stand-in, then overwrite with static export'
+      - name: 'Plant old site + WHMCS stand-in, then overwrite with static export'
         env:
           DRY_RUN: ${{ inputs.dry_run }}
           DOCROOT: ${{ inputs.docroot }}
@@ -142,16 +160,15 @@ jobs:
           set -euo pipefail
           if [ "$DRY_RUN" = "true" ]; then
             echo "DRY RUN — would, against ./${DOCROOT}/ :"
-            echo "  1) upload hubstage/hub/index.php  -> ./${DOCROOT}/hub/index.php"
-            echo "  2) lftp mirror --reverse --delete ./out/ -> ./${DOCROOT}/"
+            echo "  1) upload oldsite/* (synthetic WP marker) — no delete"
+            echo "  2) upload hubstage/hub/index.php (WHMCS stand-in) — no delete"
+            echo "  3) lftp mirror --reverse --delete ./out/ -> ./${DOCROOT}/"
             echo "     excluding: hub/ cgi-bin/ .well-known/ .ftpquota .htpasswd error_log"
-            echo "  (hub/ is EXCLUDED from --delete, so the stand-in survives)"
+            echo "     (hub/ excluded from --delete, so the stand-in survives;"
+            echo "      the synthetic WP marker is NOT in out/, so --delete removes it)"
             exit 0
           fi
           sudo apt-get update -qq && sudo apt-get install -y -qq lftp
-          # Step 1: place the stand-in WHMCS (simulates the real ~/public_html/hub).
-          # Step 2: mirror the static export with --delete but EXCLUDE hub/ so it
-          # is preserved exactly like real WHMCS will be on the apex.
           lftp <<LFTP 2>&1 | tail -200
             set ftp:ssl-allow yes
             set ftp:ssl-force yes
@@ -160,6 +177,7 @@ jobs:
             set net:max-retries 3
             set net:timeout 60
             open -p "$CPANEL_FTP_PORT" -u "$CPANEL_FTP_USER","$CPANEL_FTP_PASSWORD" "ftp://$CPANEL_FTP_HOST"
+            mirror --reverse --parallel=2 --verbose=1 ./oldsite/ ./${DOCROOT}/
             mirror --reverse --parallel=2 --verbose=1 ./hubstage/ ./${DOCROOT}/
             mirror --reverse --delete --parallel=4 --verbose=1 \
               --exclude-glob 'hub' \
@@ -174,47 +192,48 @@ jobs:
           LFTP
           echo "Overwrite complete."
 
-      - name: 'Verify: static serves AND /hub/ passthrough survived'
+      - name: 'Verify: static serves, /hub/ survives, old WP gone'
         if: ${{ inputs.dry_run == false }}
         env:
           TARGET: ${{ inputs.target_domain }}
-          HUB_TOKEN: ${{ steps.hub.outputs.token }}
+          HUB_TOKEN: ${{ steps.stage.outputs.token }}
+          MARKER: ${{ steps.stage.outputs.marker }}
         run: |
           set -euo pipefail
-          # Try https first, fall back to http (addon AutoSSL may lag).
           base="https://${TARGET}"
           if ! curl -sS -o /dev/null --max-time 20 "$base/" 2>/dev/null; then base="http://${TARGET}"; fi
           echo "Testing against ${base}"
-          get() { curl -sS -m 25 -H 'Cache-Control: no-cache' -w '\n%{http_code}' "$1"; }
+          cb="cb=$(date -u +%s)_${RANDOM}"   # bust Cloudflare edge cache
+          # -L follows the trailingSlash DirectorySlash 301s; no-cache + unique
+          # query string defeat any edge caching on the orange-clouded staging host.
+          get()  { curl -sSL -m 25 -H 'Cache-Control: no-cache' -w '\n%{http_code}' "$1?$cb"; }
+          code() { curl -sSL -m 25 -o /dev/null -w '%{http_code}' -H 'Cache-Control: no-cache' "$1?$cb"; }
 
           fail=0
-          # 1) Homepage = static export (has <title>)
-          r=$(get "$base/"); code=$(printf '%s' "$r" | tail -n1); body=$(printf '%s' "$r" | sed '$d')
-          if [ "$code" = "200" ] && printf '%s' "$body" | grep -q '<title>'; then
-            echo "  ✓ / -> 200 static homepage"
-          else echo "  ✗ / -> ${code} (no static homepage)"; fail=1; fi
+          # 1) Homepage = static export
+          r=$(get "$base/"); c=$(printf '%s' "$r" | tail -n1); b=$(printf '%s' "$r" | sed '$d')
+          if [ "$c" = "200" ] && printf '%s' "$b" | grep -q '<title>'; then echo "  ✓ / -> 200 static homepage";
+          else echo "  ✗ / -> ${c} (no static homepage)"; fail=1; fi
 
-          # 2) Clean URL routing
-          code=$(curl -sS -m 25 -o /dev/null -w '%{http_code}' -H 'Cache-Control: no-cache' "$base/about-us")
-          [ "$code" = "200" ] && echo "  ✓ /about-us -> 200" || { echo "  ✗ /about-us -> ${code}"; fail=1; }
+          # 2) Clean-URL route (trailingSlash canonical)
+          c=$(code "$base/about-us/"); [ "$c" = "200" ] && echo "  ✓ /about-us/ -> 200" || { echo "  ✗ /about-us/ -> ${c}"; fail=1; }
 
-          # 3) THE key assertion: /hub/ still executes PHP (WHMCS stand-in survived)
-          r=$(get "$base/hub/"); code=$(printf '%s' "$r" | tail -n1); body=$(printf '%s' "$r" | sed '$d')
-          if [ "$code" = "200" ] && printf '%s' "$body" | grep -q "$HUB_TOKEN"; then
-            echo "  ✓ /hub/ -> 200 and served the planted PHP token (passthrough OK)"
-          else echo "  ✗ /hub/ -> ${code}, token present: no — WHMCS would be at risk!"; fail=1; fi
+          # 3) KEY: /hub/ still executes the planted PHP (WHMCS stand-in survived)
+          r=$(get "$base/hub/"); c=$(printf '%s' "$r" | tail -n1); b=$(printf '%s' "$r" | sed '$d')
+          if [ "$c" = "200" ] && printf '%s' "$b" | grep -q "$HUB_TOKEN"; then echo "  ✓ /hub/ -> 200 + planted PHP token (passthrough OK)";
+          else echo "  ✗ /hub/ -> ${c}, token present: no — WHMCS would be at risk!"; fail=1; fi
 
-          # 4) Legacy WP path blocked by the static .htaccess
-          code=$(curl -sS -m 25 -o /dev/null -w '%{http_code}' "$base/wp-admin")
-          case "$code" in 301|302|403) echo "  ✓ /wp-admin -> ${code} (blocked/redirected)";; *) echo "  ✗ /wp-admin -> ${code}"; fail=1;; esac
+          # 4) Old WP marker removed by --delete (the "won't survive" part)
+          c=$(code "$base/${MARKER}"); [ "$c" = "404" ] && echo "  ✓ /${MARKER} -> 404 (old WP removed)" || { echo "  ✗ /${MARKER} -> ${c} (old file lingered)"; fail=1; }
 
           {
             echo "## Cutover rehearsal on ${TARGET}"
             echo ""
             echo "- Static overwrite with --delete (hub/ excluded): done"
             echo "- /hub/ passthrough (WHMCS stand-in) survived: $( [ "$fail" -eq 0 ] && echo '✅ yes' || echo '⛔ CHECK FAILED' )"
+            echo "- Old WP marker removed: see checks above"
             echo ""
-            echo "Cleanup: this is a throwaway docroot; wipe via cPanel File Manager or re-dispatch a normal deploy."
+            echo "Cleanup: re-run the normal staging deploy to restore staging, and remove the leftover hub/ stand-in via cPanel File Manager."
           } >> "$GITHUB_STEP_SUMMARY"
 
           [ "$fail" -eq 0 ] || { echo "::error::Rehearsal assertions failed — do NOT proceed to the apex cutover."; exit 1; }

--- a/.github/workflows/cpanel-deploy-verify.yml
+++ b/.github/workflows/cpanel-deploy-verify.yml
@@ -1,0 +1,133 @@
+name: 'cPanel deploy verify (public_html_next)'
+
+# Read-only verification that a static-export deploy actually landed on disk in
+# ~/public_html_next/ -- the cloud-native replacement for the manual SSH / cPanel
+# Terminal checks in issue #152 (cutover step DEP2). It calls UAPI
+# Fileman/list_files THROUGH the Azure API Management gateway (static, whitelisted
+# IP), so no SSH and no runner-IP Imunify360 block.
+#
+# Fileman/list_files is on the gateway operation allowlist (PR #291); this
+# workflow adds NO new privilege -- it only reads a directory listing.
+#
+# Secrets (repo or environment):
+#   APIM_GATEWAY_URL       e.g. https://apim-ffc-gateway-prod.azure-api.net
+#   APIM_SUBSCRIPTION_KEY  the "cpanel-ops" subscription primary key
+#   CPANEL_USER            cPanel account username (for the /home/<user> path)
+#
+# What it asserts (mirrors #152 acceptance, minus the .htaccess *content* check
+# which needs file-read access this gateway intentionally does not expose):
+#   * index.html, 404.html, .htaccess and each route in `expect_files` exist
+#   * _next/static/chunks/ contains JS bundles (count > 0)
+
+on:
+  workflow_dispatch:
+    inputs:
+      subdir:
+        description: 'Directory under the account home to verify'
+        required: false
+        default: 'public_html_next'
+        type: string
+      expect_files:
+        description: 'Comma-separated route files that must exist'
+        required: false
+        default: 'index.html,404.html,about-us.html,donate.html'
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cpanel-deploy-verify
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: 'Verify ~/public_html_next/ via gateway'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Check deploy landed (Fileman/list_files via APIM)'
+        env:
+          BASE: ${{ secrets.APIM_GATEWAY_URL }}
+          KEY: ${{ secrets.APIM_SUBSCRIPTION_KEY }}
+          CPANEL_USER: ${{ secrets.CPANEL_USER }}
+          SUBDIR: ${{ inputs.subdir }}
+          EXPECT_FILES: ${{ inputs.expect_files }}
+        run: |
+          set -euo pipefail
+          if [ -z "${BASE:-}" ] || [ -z "${KEY:-}" ] || [ -z "${CPANEL_USER:-}" ]; then
+            echo "::error::Set APIM_GATEWAY_URL, APIM_SUBSCRIPTION_KEY and CPANEL_USER secrets first."
+            exit 1
+          fi
+          base="${BASE%/}"
+          # Normalize the subdir to a single leading-slash-free path segment set;
+          # reject anything with traversal so a dispatch input can't walk the FS.
+          case "$SUBDIR" in
+            *..*|/*) echo "::error::subdir must be a relative path with no '..'"; exit 1 ;;
+          esac
+          root="/home/${CPANEL_USER}/${SUBDIR}"
+
+          api() { curl -sS --max-time 45 -H "Ocp-Apim-Subscription-Key: ${KEY}" -H 'Accept: application/json' "$@"; }
+
+          # --- 1) Top-level files (index.html, 404.html, .htaccess + routes) ---
+          # only_these_files filters the listing to just the names we care about,
+          # show_hidden=1 so the dotfile .htaccess is included.
+          want=".htaccess,index.html,${EXPECT_FILES}"
+          listing=$(api --get \
+            --data-urlencode "dir=${root}" \
+            --data-urlencode "types=file" \
+            --data-urlencode "show_hidden=1" \
+            --data-urlencode "only_these_files=${want}" \
+            "${base}/cpanel/execute/Fileman/list_files")
+          status=$(printf '%s' "$listing" | jq -r '.status // 0' 2>/dev/null || echo 0)
+          if [ "$status" != "1" ]; then
+            echo "::error::Fileman/list_files failed for ${root} (status != 1). Diagnostics only:"
+            printf '%s' "$listing" | jq -r '(.errors // [])[], (.messages // [])[]' 2>/dev/null | head -n 5 || true
+            exit 1
+          fi
+          present=$(printf '%s' "$listing" | jq -r '[.data[]?.file] | @json')
+
+          missing=0
+          # NOTE: filenames of a public static site aren't secret, but we still
+          # print only present/MISSING booleans -- never the full server listing.
+          IFS=',' read -ra names <<< "$want"
+          for n in "${names[@]}"; do
+            n="$(printf '%s' "$n" | tr -d '[:space:]')"
+            [ -z "$n" ] && continue
+            if printf '%s' "$present" | jq -e --arg n "$n" 'index($n) != null' >/dev/null; then
+              echo "  ✓ ${n}"
+            else
+              echo "  ✗ ${n}: MISSING"
+              missing=$((missing + 1))
+            fi
+          done
+
+          # --- 2) JS bundles under _next/static/chunks/ ---
+          chunks=$(api --get \
+            --data-urlencode "dir=${root}/_next/static/chunks" \
+            --data-urlencode "types=file" \
+            "${base}/cpanel/execute/Fileman/list_files")
+          cstatus=$(printf '%s' "$chunks" | jq -r '.status // 0' 2>/dev/null || echo 0)
+          js_count=0
+          if [ "$cstatus" = "1" ]; then
+            js_count=$(printf '%s' "$chunks" | jq '[.data[]?.file | select(endswith(".js"))] | length' 2>/dev/null || echo 0)
+          fi
+          if [ "$js_count" -gt 0 ]; then
+            echo "  ✓ _next/static/chunks/: ${js_count} JS bundle(s)"
+          else
+            echo "  ✗ _next/static/chunks/: no JS bundles found"
+            missing=$((missing + 1))
+          fi
+
+          {
+            echo "## cPanel deploy verification — \`${SUBDIR}\`"
+            echo ""
+            echo "- Route/asset files checked: \`${want}\`"
+            echo "- JS bundles in \`_next/static/chunks/\`: **${js_count}**"
+            echo "- Missing/failed checks: **${missing}**"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$missing" -ne 0 ]; then
+            echo "::error::${missing} verification check(s) failed for ${root}. Re-run the deploy (it is idempotent)."
+            exit 1
+          fi
+          echo "✅ Deploy verified: all required files present in ${root}."

--- a/.github/workflows/cpanel-deploy-verify.yml
+++ b/.github/workflows/cpanel-deploy-verify.yml
@@ -28,9 +28,9 @@ on:
         default: 'public_html_next'
         type: string
       expect_files:
-        description: 'Comma-separated route files that must exist'
+        description: 'Extra route files that must exist (index.html, 404.html and .htaccess are ALWAYS checked)'
         required: false
-        default: 'index.html,404.html,about-us.html,donate.html'
+        default: 'about-us.html,donate.html'
         type: string
 
 permissions:
@@ -71,7 +71,11 @@ jobs:
           # --- 1) Top-level files (index.html, 404.html, .htaccess + routes) ---
           # only_these_files filters the listing to just the names we care about,
           # show_hidden=1 so the dotfile .htaccess is included.
-          want=".htaccess,index.html,${EXPECT_FILES}"
+          # Strip ALL whitespace so an input like "about-us.html, donate.html"
+          # can't send a leading-space filename to the API (false negative).
+          # index.html/404.html/.htaccess are always checked, regardless of input.
+          clean_expect=$(printf '%s' "$EXPECT_FILES" | tr -d '[:space:]')
+          want=".htaccess,index.html,404.html${clean_expect:+,$clean_expect}"
           listing=$(api --get \
             --data-urlencode "dir=${root}" \
             --data-urlencode "types=file" \

--- a/.github/workflows/cpanel-deploy-verify.yml
+++ b/.github/workflows/cpanel-deploy-verify.yml
@@ -16,7 +16,9 @@ name: 'cPanel deploy verify (public_html_next)'
 #
 # What it asserts (mirrors #152 acceptance, minus the .htaccess *content* check
 # which needs file-read access this gateway intentionally does not expose):
-#   * index.html, 404.html, .htaccess and each route in `expect_files` exist
+#   * top-level index.html, 404.html and .htaccess exist
+#   * each route in `expect_routes` exports as <route>/index.html (this repo
+#     uses trailingSlash:true, so routes are directories, not flat *.html)
 #   * _next/static/chunks/ contains JS bundles (count > 0)
 
 on:
@@ -27,10 +29,10 @@ on:
         required: false
         default: 'public_html_next'
         type: string
-      expect_files:
-        description: 'Extra route files that must exist (index.html, 404.html and .htaccess are ALWAYS checked)'
+      expect_routes:
+        description: 'Route dirs that must export <route>/index.html (top-level index.html/404.html/.htaccess are ALWAYS checked)'
         required: false
-        default: 'about-us.html,donate.html'
+        default: 'about-us,donate'
         type: string
 
 permissions:
@@ -51,7 +53,7 @@ jobs:
           KEY: ${{ secrets.APIM_SUBSCRIPTION_KEY }}
           CPANEL_USER: ${{ secrets.CPANEL_USER }}
           SUBDIR: ${{ inputs.subdir }}
-          EXPECT_FILES: ${{ inputs.expect_files }}
+          EXPECT_ROUTES: ${{ inputs.expect_routes }}
         run: |
           set -euo pipefail
           if [ -z "${BASE:-}" ] || [ -z "${KEY:-}" ] || [ -z "${CPANEL_USER:-}" ]; then
@@ -67,45 +69,40 @@ jobs:
           root="/home/${CPANEL_USER}/${SUBDIR}"
 
           api() { curl -sS --max-time 45 -H "Ocp-Apim-Subscription-Key: ${KEY}" -H 'Accept: application/json' "$@"; }
-
-          # --- 1) Top-level files (index.html, 404.html, .htaccess + routes) ---
-          # only_these_files filters the listing to just the names we care about,
-          # show_hidden=1 so the dotfile .htaccess is included.
-          # Strip ALL whitespace so an input like "about-us.html, donate.html"
-          # can't send a leading-space filename to the API (false negative).
-          # index.html/404.html/.htaccess are always checked, regardless of input.
-          clean_expect=$(printf '%s' "$EXPECT_FILES" | tr -d '[:space:]')
-          want=".htaccess,index.html,404.html${clean_expect:+,$clean_expect}"
-          listing=$(api --get \
-            --data-urlencode "dir=${root}" \
-            --data-urlencode "types=file" \
-            --data-urlencode "show_hidden=1" \
-            --data-urlencode "only_these_files=${want}" \
-            "${base}/cpanel/execute/Fileman/list_files")
-          status=$(printf '%s' "$listing" | jq -r '.status // 0' 2>/dev/null || echo 0)
-          if [ "$status" != "1" ]; then
-            echo "::error::Fileman/list_files failed for ${root} (status != 1). Diagnostics only:"
-            printf '%s' "$listing" | jq -r '(.errors // [])[], (.messages // [])[]' 2>/dev/null | head -n 5 || true
-            exit 1
-          fi
-          present=$(printf '%s' "$listing" | jq -r '[.data[]?.file] | @json')
+          # List a dir and return the file names present as a compact JSON array.
+          # On UAPI status!=1 (dir missing etc.) returns [] so callers see "missing".
+          list_names() { # $1=dir  $2=only_these_files (optional)
+            local args=(--get --data-urlencode "dir=$1" --data-urlencode "types=file" --data-urlencode "show_hidden=1")
+            [ -n "${2:-}" ] && args+=(--data-urlencode "only_these_files=$2")
+            api "${args[@]}" "${base}/cpanel/execute/Fileman/list_files" \
+              | jq -c 'if (.status==1) then [.data[]?.file] else [] end' 2>/dev/null || echo '[]'
+          }
+          has() { printf '%s' "$1" | jq -e --arg n "$2" 'any(.[]; . == $n)' >/dev/null; }
 
           missing=0
-          # NOTE: filenames of a public static site aren't secret, but we still
-          # print only present/MISSING booleans -- never the full server listing.
-          IFS=',' read -ra names <<< "$want"
-          for n in "${names[@]}"; do
-            n="$(printf '%s' "$n" | tr -d '[:space:]')"
-            [ -z "$n" ] && continue
-            if printf '%s' "$present" | jq -e --arg n "$n" 'index($n) != null' >/dev/null; then
-              echo "  ✓ ${n}"
-            else
-              echo "  ✗ ${n}: MISSING"
-              missing=$((missing + 1))
-            fi
+
+          # --- 1) Top-level files: index.html, 404.html, .htaccess (always) ---
+          top=$(list_names "$root" ".htaccess,index.html,404.html")
+          for n in .htaccess index.html 404.html; do
+            if has "$top" "$n"; then echo "  ✓ ${n}"; else echo "  ✗ ${n}: MISSING"; missing=$((missing + 1)); fi
           done
 
-          # --- 2) JS bundles under _next/static/chunks/ ---
+          # --- 2) Routes: trailingSlash:true exports <route>/index.html, so each
+          # route is a DIRECTORY; list it and require index.html inside. ---
+          routes=$(printf '%s' "$EXPECT_ROUTES" | tr -d '[:space:]')
+          checked_routes=""
+          if [ -n "$routes" ]; then
+            IFS=',' read -ra rlist <<< "$routes"
+            for r in "${rlist[@]}"; do
+              [ -z "$r" ] && continue
+              case "$r" in *..*|/*) echo "  ✗ ${r}: invalid route"; missing=$((missing + 1)); continue ;; esac
+              checked_routes="${checked_routes} ${r}"
+              names=$(list_names "${root}/${r}" "index.html")
+              if has "$names" "index.html"; then echo "  ✓ ${r}/index.html"; else echo "  ✗ ${r}/index.html: MISSING"; missing=$((missing + 1)); fi
+            done
+          fi
+
+          # --- 3) JS bundles under _next/static/chunks/ ---
           chunks=$(api --get \
             --data-urlencode "dir=${root}/_next/static/chunks" \
             --data-urlencode "types=file" \
@@ -125,7 +122,8 @@ jobs:
           {
             echo "## cPanel deploy verification — \`${SUBDIR}\`"
             echo ""
-            echo "- Route/asset files checked: \`${want}\`"
+            echo "- Top-level files checked: \`.htaccess, index.html, 404.html\`"
+            echo "- Route dirs checked (\`<route>/index.html\`): \`${checked_routes:-none}\`"
             echo "- JS bundles in \`_next/static/chunks/\`: **${js_count}**"
             echo "- Missing/failed checks: **${missing}**"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/infra/cpanel-apim/README.md
+++ b/infra/cpanel-apim/README.md
@@ -65,13 +65,14 @@ overall but is not a managed gateway.
 
 ## Files
 
-| File                                              | Purpose                                                                                                                                                                   |
-| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `apim.bicep`                                      | Phase 1 — the APIM service (Developer tier, system-assigned identity). Outputs the static IP + identity principal ID.                                                     |
-| `apis.bicep`                                      | Phase 2 — KV-linked secret named values, the cPanel backend (TLS validation off), the `/cpanel` API + GET/POST operations, the auth-injection policy, and a subscription. |
-| `policies/cpanel-api.xml`                         | API policy: routes to the `cpanel` backend and injects `Authorization: cpanel {{user}}:{{token}}`.                                                                        |
-| `../../.github/workflows/cpanel-apim-deploy.yml`  | Orchestrates phase 1 → grant KV access → phase 2.                                                                                                                         |
-| `../../.github/workflows/cpanel-ops-via-apim.yml` | Calls cPanel UAPI through the gateway (also a connectivity check).                                                                                                        |
+| File                                               | Purpose                                                                                                                                                                          |
+| -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `apim.bicep`                                       | Phase 1 — the APIM service (Developer tier, system-assigned identity). Outputs the static IP + identity principal ID.                                                            |
+| `apis.bicep`                                       | Phase 2 — KV-linked secret named values, the cPanel backend (TLS validation off), the `/cpanel` API + GET/POST operations, the auth-injection policy, and a subscription.        |
+| `policies/cpanel-api.xml`                          | API policy: routes to the `cpanel` backend and injects `Authorization: cpanel {{user}}:{{token}}`.                                                                               |
+| `../../.github/workflows/cpanel-apim-deploy.yml`   | Orchestrates phase 1 → grant KV access → phase 2.                                                                                                                                |
+| `../../.github/workflows/cpanel-ops-via-apim.yml`  | Calls cPanel UAPI through the gateway (also a connectivity check).                                                                                                               |
+| `../../.github/workflows/cpanel-deploy-verify.yml` | Read-only deploy check (#152): confirms `~/public_html_next/` has `index.html`, `.htaccess`, the route pages and `_next/static/chunks/` JS via allowlisted `Fileman/list_files`. |
 
 ## Prerequisites (one-time, admin)
 

--- a/scripts/onedrive_backup_sync.py
+++ b/scripts/onedrive_backup_sync.py
@@ -40,9 +40,26 @@ KEEP_MONTHLY_DAYS = 365
 # Freshness thresholds (hours). The newest archive in each folder should be no
 # older than this; otherwise Softaculous likely stopped producing backups even
 # though the sync itself is green. WHMCS is daily, WordPress weekly.
+def _int_env(name, default):
+    """Parse a positive-int env override; fall back (with a warning) on junk so
+    freshness — which is warning-only — can never crash the whole sync job."""
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        v = int(raw.strip())
+        if v <= 0:
+            raise ValueError
+        return v
+    except ValueError:
+        # print directly: this runs at import, before log() is defined.
+        print(f"::warning::{name}={raw!r} is not a positive integer; using default {default}", flush=True)
+        return default
+
+
 FRESH_MAX_HOURS = {
-    "whmcs.": int(os.environ.get("FRESH_WHMCS_MAX_H", "26")),
-    "wp.": int(os.environ.get("FRESH_WP_MAX_H", "192")),  # 8 days
+    "whmcs.": _int_env("FRESH_WHMCS_MAX_H", 26),
+    "wp.": _int_env("FRESH_WP_MAX_H", 192),  # 8 days
 }
 DATE_RE = re.compile(r"(\d{4})-(\d{2})-(\d{2})_(\d{2})-(\d{2})-(\d{2})")
 # Strict allowlist for backup filenames. The names come from the REMOTE server's

--- a/scripts/onedrive_backup_sync.py
+++ b/scripts/onedrive_backup_sync.py
@@ -37,6 +37,13 @@ DEST = {
 }
 KEEP_ALL_DAYS = 90
 KEEP_MONTHLY_DAYS = 365
+# Freshness thresholds (hours). The newest archive in each folder should be no
+# older than this; otherwise Softaculous likely stopped producing backups even
+# though the sync itself is green. WHMCS is daily, WordPress weekly.
+FRESH_MAX_HOURS = {
+    "whmcs.": int(os.environ.get("FRESH_WHMCS_MAX_H", "26")),
+    "wp.": int(os.environ.get("FRESH_WP_MAX_H", "192")),  # 8 days
+}
 DATE_RE = re.compile(r"(\d{4})-(\d{2})-(\d{2})_(\d{2})-(\d{2})-(\d{2})")
 # Strict allowlist for backup filenames. The names come from the REMOTE server's
 # directory listing and are used to build local + OneDrive paths, so reject
@@ -212,6 +219,32 @@ def ftps_connect():
     return ftp
 
 
+def check_freshness():
+    """Warn (don't fail) if the newest archive in a folder is older than its
+    threshold -- a sign Softaculous stopped producing backups. Reuses the
+    already-minted Graph token so it adds no second token consumer."""
+    now = datetime.datetime.now(datetime.timezone.utc)
+    stale = []
+    for prefix, folder in DEST.items():
+        dated = [dt for n, _ in list_children(folder).items() if (dt := file_date(n)) and n.startswith(prefix)]
+        if not dated:
+            log(f"Freshness: {folder}: NO dated archives found")
+            stale.append((prefix, folder, None))
+            continue
+        newest = max(dated)
+        age_h = (now - newest).total_seconds() / 3600.0
+        limit = FRESH_MAX_HOURS.get(prefix, 26)
+        flag = "STALE" if age_h > limit else "ok"
+        log(f"Freshness: {folder}: newest {newest:%Y-%m-%d %H:%M}Z ({age_h:.1f}h old, limit {limit}h) -> {flag}")
+        if age_h > limit:
+            stale.append((prefix, folder, age_h))
+    for prefix, folder, age_h in stale:
+        msg = f"{folder}: no archive younger than {FRESH_MAX_HOURS.get(prefix, 26)}h" if age_h is None \
+            else f"{folder}: newest archive is {age_h:.0f}h old (limit {FRESH_MAX_HOURS.get(prefix, 26)}h)"
+        log(f"::warning::Backup freshness: {msg}")
+    return stale
+
+
 def main():
     log(f"== Softaculous -> OneDrive sync ({'DRY-RUN' if DRY_RUN else 'live'}) ==")
     ftp = ftps_connect()
@@ -256,6 +289,10 @@ def main():
     for folder in DEST.values():
         log(f"Retention: {folder}")
         apply_retention(folder, list_children(folder))
+
+    # Freshness check (warning-only; the scheduled monitor workflow is the
+    # hard alarm). Run after retention so it reflects the final folder state.
+    check_freshness()
 
     log(f"Done. Uploaded {uploaded} new archive(s).")
 


### PR DESCRIPTION
## Why

Supporting-ops automation for the static-site cutover and the backup pipeline, on top of the merged gateway allowlist (#291) and OneDrive backup sync (#292).

## What's here

### 1. `cpanel-deploy-verify.yml` — deploy verification (#152)
Read-only check that a deploy landed in `~/public_html_next/` via the **allowlisted `Fileman/list_files`** through the gateway. This repo is `trailingSlash: true`, so it asserts top-level `index.html`/`404.html`/`.htaccess` **and** that each route in `expect_routes` exports as `<route>/index.html`, plus `_next/static/chunks/` JS. Cloud-native replacement for the manual SSH block in #152. No new gateway privilege.

### 2. `cpanel-backup-freshness.yml` + in-run check — backup freshness monitor
- Scheduled **hard alarm** that fails if there's no successful `cpanel-softaculous-backup-sync` run within `max_age_hours` (default 30h) or the latest run failed. Reads only Actions run history via `GITHUB_TOKEN` — **no Graph token**, so it can't collide with the sync's single-use rotating OneDrive refresh token.
- `onedrive_backup_sync.py` now emits a per-folder freshness `::warning::` (reusing the already-minted token) so "Softaculous stopped producing backups while the sync is green" is caught in-run.

### 3. `cpanel-cutover-rehearse.yml` — /hub-safe cutover rehearsal (#139)
Validates the **real apex cutover mechanic** before touching `freeforcharity.org`. Investigation of the live account established the cutover design:

> **In-place overwrite**: mirror the static export into the live docroot with `--delete` but **exclude `hub/`**. The docroot never moves, WHMCS (a *real* subdir at `~/public_html/hub`) is untouched, and the static export's own `.htaccess` hands `/hub/` off to it (`RewriteRule ^hub($|/) - [L]` + `DirectoryIndex index.html index.php`). The WordPress files are "the part that won't survive" — backed up, replaced.

Rehearses on **`staging.freeforcharity.org`** — the only resolving, docroot-serving non-apex host (the addon domains are Cloudflare 301 redirects that never reach origin). It plants a synthetic old-WP marker (must `404` after `--delete`) plus a dummy `hub/index.php` (WHMCS stand-in, must survive), runs the exact mirror + exclusions, then curls (redirect-following, cache-busted) to assert the static site serves, `/about-us/` routes, `/hub/` still executes the planted PHP, and the old marker is gone. **Hard-blocks** the apex domain and `public_html`; `dry_run` defaults to **true**.

## Safety / verification
- `py_compile` clean; freshness + jq logic unit-checked; YAML lints clean; prettier applied.
- Live account inspected read-only via the gateway (domains, docroots, `hub` location, `.htaccess` `/hub` handoff) to ground the cutover design.
- All Copilot review comments addressed (trailingSlash route checks + defensive input parsing).

## Next (after this merges)
Run the rehearsal dry-run → live on `staging.freeforcharity.org` → confirm `/hub/` passthrough. Only then build the **gated apex cutover + rollback** workflow (typed confirmation + approval environment + pre-cutover backup).

Refs #152, #139, #29. Refs FreeForCharity/FFC-IN-ClarkeMoyerAdmin#104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)