### PR TITLE
feat: two-phase apex cutover — verified WP snapshot (STEP 1) + gated flip (STEP 2)

### DIFF
--- a/.github/workflows/cpanel-apex-cutover.yml
+++ b/.github/workflows/cpanel-apex-cutover.yml
@@ -1,0 +1,328 @@
+name: 'cPanel APEX cutover (WordPress -> static, /hub-safe)'
+
+# THE real apex cutover for freeforcharity.org, and its rollback. This is
+# destructive and runs against the LIVE site, so it is heavily gated:
+#   * dry_run defaults to TRUE and prints an exact plan (incl. lftp --dry-run
+#     showing every add/delete) without writing anything;
+#   * a typed `confirm` phrase is required for any live write;
+#   * runs in the cpanel-staging Environment (proven creds); add required
+#     reviewers to a dedicated environment for a second human approval gate;
+#   * a fresh WordPress + WHMCS backup is REQUIRED before a live cutover.
+#
+# Mechanic (proven /hub-safe by cpanel-cutover-rehearse.yml on staging):
+#   The apex docroot stays ~/public_html. We DON'T move it (WHMCS lives at
+#   ~/public_html/hub as a real dir and must not move). Instead:
+#     1. MOVE the WordPress files aside, server-side, into a timestamped sister
+#        dir ~/public_html_wp_precutover_<ts>/ (FTP rename = instant, no
+#        download) — this is the on-server rollback snapshot. hub/, cgi-bin/,
+#        .well-known/, the parked-domain docroot and system dotfiles are KEPT
+#        in place (never moved, never deleted).
+#     2. Mirror the Next.js static export into the now-clean ~/public_html/.
+#   The static export's own .htaccess hands /hub/ off to WHMCS untouched
+#   (`RewriteRule ^hub($|/) - [L]` + `DirectoryIndex index.html index.php`).
+#
+# Rollback = delete the static files from ~/public_html/ (keepers preserved)
+# and move the snapshot WordPress files back. WHMCS and both databases are
+# never touched by either direction.
+#
+# Creds: GH OIDC -> Azure -> Key Vault (MAIN cPanel FTP creds + the read-only
+# gateway subscription key). The MAIN FTP account is homed at the account root,
+# so it can write ~/public_html and create sibling dirs.
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'cutover (WP->static) or rollback (static->WP)'
+        required: true
+        default: 'cutover'
+        type: choice
+        options: [cutover, rollback]
+      confirm:
+        description: 'Type exactly: CUTOVER freeforcharity.org   (required for any live write)'
+        required: false
+        default: ''
+        type: string
+      snapshot_dir:
+        description: 'Rollback only: the public_html_wp_precutover_<ts> dir to restore from'
+        required: false
+        default: ''
+        type: string
+      dry_run:
+        description: 'Preview only — write nothing (default true)'
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  id-token: write
+  contents: read
+  actions: read # backup-freshness gate reads sync run history
+
+concurrency:
+  group: cpanel-apex-cutover
+  cancel-in-progress: false
+
+env:
+  APEX: freeforcharity.org
+  DOCROOT: public_html
+  # Entries in ~/public_html that must NEVER be moved or deleted by either
+  # direction. hub = WHMCS; wh1319644.ispot.cc = a parked-domain docroot;
+  # the rest are cPanel/system. The static export replaces everything else.
+  KEEP: 'hub cgi-bin .well-known .cache .tmb .ftpquota .htpasswd error_log .htpasswds wh1319644.ispot.cc'
+
+jobs:
+  cutover:
+    name: 'Apex cutover / rollback'
+    runs-on: ubuntu-latest
+    # Reuses the proven cpanel-staging environment (it holds the MAIN-account
+    # FTP creds + the OIDC federated credential that deploy-cpanel.yml uses).
+    # For a second, human approval gate, create a dedicated environment with a
+    # federated credential for its subject + required reviewers and switch here.
+    environment: cpanel-staging
+    timeout-minutes: 60
+    steps:
+      - name: 'Gate: confirm phrase (required for live writes)'
+        env:
+          ACTION: ${{ inputs.action }}
+          CONFIRM: ${{ inputs.confirm }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          echo "action=${ACTION} dry_run=${DRY_RUN}"
+          if [ "$DRY_RUN" != "true" ]; then
+            if [ "$CONFIRM" != "CUTOVER freeforcharity.org" ]; then
+              echo "::error::Live write requires confirm='CUTOVER freeforcharity.org' exactly."
+              exit 1
+            fi
+          fi
+
+      - uses: actions/checkout@v6
+
+      - name: Setup Node
+        if: ${{ inputs.action == 'cutover' }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install + build static export
+        if: ${{ inputs.action == 'cutover' }}
+        env:
+          NEXT_PUBLIC_BASE_PATH: ''
+        run: |
+          set -euo pipefail
+          npm ci
+          npm run build
+          test -f ./out/index.html
+          test -f ./out/.htaccess
+          test -f ./out/about-us/index.html
+          echo "out/ ready: $(find out -type f | wc -l) files"
+
+      - name: 'Backup-freshness gate (cutover, live only)'
+        if: ${{ inputs.action == 'cutover' && inputs.dry_run == false }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Refuse to wipe WordPress unless a successful Softaculous->OneDrive
+          # sync (the restorable WP+WHMCS backup) ran in the last 30h.
+          ok=$(gh run list --workflow cpanel-softaculous-backup-sync.yml --limit 20 \
+                 --json conclusion,updatedAt \
+               | jq -r '[.[]|select(.conclusion=="success")]|sort_by(.updatedAt)|last|.updatedAt // empty')
+          if [ -z "$ok" ]; then echo "::error::No successful backup sync found — run it before cutover."; exit 1; fi
+          age=$(( $(date -u +%s) - $(date -u -d "$ok" +%s) ))
+          echo "Last successful backup sync: ${ok} ($((age/3600))h ago)"
+          if [ "$age" -gt 108000 ]; then
+            echo "::error::Latest restorable backup is >30h old. Run cpanel-softaculous-backup-sync.yml first."
+            exit 1
+          fi
+
+      - name: Azure login (OIDC)
+        uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.WR_ALL_FFC_AZURE_KV_CLIENT_ID }}
+          tenant-id: ${{ secrets.WR_ALL_FFC_AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
+
+      - name: Fetch creds from Key Vault (FTP + gateway key)
+        shell: pwsh
+        env:
+          KV_NAME: kv-ffc-admin-prod-cbm
+        run: |
+          $ErrorActionPreference = 'Stop'
+          . ./.github/scripts/Get-KvSecret.ps1
+          $v = $env:KV_NAME.Trim()
+          $h = Get-KvSecret -VaultName $v -Name 'wr-all-cbm-cpanel-ffc-interserver-ftp-host'
+          $p = Get-KvSecret -VaultName $v -Name 'wr-all-cbm-cpanel-ffc-interserver-ftp-port'
+          $u = Get-KvSecret -VaultName $v -Name 'wr-all-cbm-cpanel-ffc-interserver-ftp-user'
+          $pw= Get-KvSecret -VaultName $v -Name 'wr-all-cbm-cpanel-ffc-interserver-ftp-password'
+          $key=Get-KvSecret -VaultName $v -Name 'read-all-ffc-apim-gateway-subscription-key'
+          foreach ($s in @($h,$u,$pw,$key)) { Write-Host "::add-mask::$s" }
+          "CPANEL_FTP_HOST=$h"  | Out-File $env:GITHUB_ENV -Append -Encoding utf8
+          "CPANEL_FTP_PORT=$p"  | Out-File $env:GITHUB_ENV -Append -Encoding utf8
+          "CPANEL_FTP_USER=$u"  | Out-File $env:GITHUB_ENV -Append -Encoding utf8
+          "CPANEL_FTP_PASSWORD=$pw" | Out-File $env:GITHUB_ENV -Append -Encoding utf8
+          "APIM_KEY=$key"       | Out-File $env:GITHUB_ENV -Append -Encoding utf8
+
+      - name: 'Pre-flight: WHMCS present + capture /hub baseline'
+        env:
+          APIM_BASE: ${{ secrets.APIM_GATEWAY_URL }}
+        run: |
+          set -euo pipefail
+          base="${APIM_BASE:-https://apim-ffc-gateway-prod.azure-api.net}"
+          api(){ curl -sS --max-time 45 -H "Ocp-Apim-Subscription-Key: ${APIM_KEY}" -H 'Accept: application/json' "$@"; }
+          # WHMCS must be a real dir with configuration.php — abort if not.
+          whmcs=$(api --get --data-urlencode "dir=/home/${CPANEL_FTP_USER}/public_html/hub" \
+                    --data-urlencode "only_these_files=configuration.php" --data-urlencode "types=file" \
+                    "${base}/cpanel/execute/Fileman/list_files" | jq -r '[.data[]?.file]|length')
+          if [ "${whmcs:-0}" -lt 1 ]; then echo "::error::WHMCS configuration.php not found at public_html/hub — aborting."; exit 1; fi
+          echo "WHMCS present at public_html/hub ✓"
+          # Baseline /hub/ (WHMCS) so we can prove it's unchanged after cutover.
+          hb=$(curl -sSL -m 25 -o /dev/null -w '%{http_code}' "https://${APEX}/hub/?cb=$$" || echo 000)
+          echo "HUB_BASELINE=$hb" >> "$GITHUB_ENV"
+          echo "/hub/ baseline status: ${hb}"
+
+      - name: 'Plan move-set (entries to snapshot)'
+        if: ${{ inputs.action == 'cutover' }}
+        env:
+          APIM_BASE: ${{ secrets.APIM_GATEWAY_URL }}
+        run: |
+          set -euo pipefail
+          base="${APIM_BASE:-https://apim-ffc-gateway-prod.azure-api.net}"
+          api(){ curl -sS --max-time 45 -H "Ocp-Apim-Subscription-Key: ${APIM_KEY}" -H 'Accept: application/json' "$@"; }
+          listing=$(api --get --data-urlencode "dir=/home/${CPANEL_FTP_USER}/public_html" \
+                      --data-urlencode "show_hidden=1" "${base}/cpanel/execute/Fileman/list_files")
+          [ "$(printf '%s' "$listing" | jq -r '.status')" = "1" ] || { echo "::error::cannot list public_html"; exit 1; }
+          # Move everything EXCEPT keepers and dotfiles (but DO move WP's .htaccess,
+          # which the static export replaces). Keepers/dotfiles stay in place.
+          moveset=$(printf '%s' "$listing" | jq -r --arg keep "$KEEP" '
+            ($keep|split(" ")) as $k
+            | [ .data[]?.file
+                | select(. as $f | ($k|index($f))|not)
+                | select((startswith(".")|not) or . == ".htaccess") ] | .[]')
+          printf '%s\n' "$moveset" > moveset.txt
+          echo "Will snapshot $(wc -l < moveset.txt) entries:"; sed 's/^/  - /' moveset.txt
+          if ! grep -q . moveset.txt; then echo "::warning::move-set is empty (already cut over?)"; fi
+
+      - name: 'CUTOVER'
+        if: ${{ inputs.action == 'cutover' }}
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          ts=$(date -u +%Y%m%d%H%M%S)
+          snap="public_html_wp_precutover_${ts}"
+          echo "SNAPSHOT_DIR=${snap}" >> "$GITHUB_ENV"
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "DRY RUN — would:"
+            echo "  1) mkdir ~/${snap}"
+            echo "  2) server-side MOVE each move-set entry: public_html/<e> -> ${snap}/<e>"
+            sed 's/^/       - /' moveset.txt
+            echo "  3) mirror --delete ./out/ -> ./public_html/ (keeping: ${KEEP})"
+            sudo apt-get update -qq && sudo apt-get install -y -qq lftp
+            echo "  --- lftp --dry-run preview of step 3 (no writes) ---"
+            lftp <<LFTP 2>&1 | tail -120
+              set ftp:ssl-allow yes; set ftp:ssl-force yes; set ftp:ssl-protect-data yes; set ssl:verify-certificate no
+              open -p "$CPANEL_FTP_PORT" -u "$CPANEL_FTP_USER","$CPANEL_FTP_PASSWORD" "ftp://$CPANEL_FTP_HOST"
+              mirror --reverse --delete --dry-run --verbose=1 \
+                --exclude-glob 'hub' --exclude-glob 'hub/' --exclude-glob 'cgi-bin/' \
+                --exclude-glob '.well-known/' --exclude-glob 'wh1319644.ispot.cc/' \
+                --exclude-glob '.ftpquota' --exclude-glob '.htpasswd' --exclude-glob 'error_log' \
+                ./out/ ./public_html/
+              bye
+          LFTP
+            echo "DRY RUN complete — nothing was written."
+            exit 0
+          fi
+          sudo apt-get update -qq && sudo apt-get install -y -qq lftp
+          # Build the server-side move commands (FTP rename; instant, no download).
+          # Newlines are produced at runtime by printf so the YAML block scalar
+          # stays intact.
+          mv_cmds=$(while IFS= read -r e; do [ -n "$e" ] && printf 'mv "public_html/%s" "%s/%s"\n' "$e" "$snap" "$e"; done < moveset.txt)
+          lftp <<LFTP 2>&1 | tail -200
+            set ftp:ssl-allow yes; set ftp:ssl-force yes; set ftp:ssl-protect-data yes; set ssl:verify-certificate no
+            set net:max-retries 3; set net:timeout 60
+            open -p "$CPANEL_FTP_PORT" -u "$CPANEL_FTP_USER","$CPANEL_FTP_PASSWORD" "ftp://$CPANEL_FTP_HOST"
+            mkdir -p "${snap}"
+            ${mv_cmds}
+            mirror --reverse --delete --parallel=4 --verbose=1 \
+              --exclude-glob 'hub' --exclude-glob 'hub/' --exclude-glob 'cgi-bin/' \
+              --exclude-glob '.well-known/' --exclude-glob 'wh1319644.ispot.cc/' \
+              --exclude-glob '.ftpquota' --exclude-glob '.htpasswd' --exclude-glob 'error_log' \
+              ./out/ ./public_html/
+            bye
+          LFTP
+          echo "Cutover writes complete. Snapshot: ~/${snap}"
+
+      - name: 'ROLLBACK'
+        if: ${{ inputs.action == 'rollback' }}
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+          SNAP: ${{ inputs.snapshot_dir }}
+          APIM_BASE: ${{ secrets.APIM_GATEWAY_URL }}
+        run: |
+          set -euo pipefail
+          case "$SNAP" in
+            public_html_wp_precutover_*) : ;;
+            *) echo "::error::snapshot_dir must be a public_html_wp_precutover_* dir"; exit 1 ;;
+          esac
+          base="${APIM_BASE:-https://apim-ffc-gateway-prod.azure-api.net}"
+          api(){ curl -sS --max-time 45 -H "Ocp-Apim-Subscription-Key: ${APIM_KEY}" -H 'Accept: application/json' "$@"; }
+          snaplist=$(api --get --data-urlencode "dir=/home/${CPANEL_FTP_USER}/${SNAP}" --data-urlencode "show_hidden=1" \
+                       "${base}/cpanel/execute/Fileman/list_files")
+          [ "$(printf '%s' "$snaplist" | jq -r '.status')" = "1" ] || { echo "::error::snapshot ${SNAP} not found"; exit 1; }
+          cur=$(api --get --data-urlencode "dir=/home/${CPANEL_FTP_USER}/public_html" --data-urlencode "show_hidden=1" \
+                  "${base}/cpanel/execute/Fileman/list_files")
+          # current non-keeper entries (the static files) -> delete; snapshot entries -> move back
+          dels=$(printf '%s' "$cur" | jq -r --arg keep "$KEEP" '($keep|split(" ")) as $k | [.data[]?.file|select(. as $f|($k|index($f))|not)]|.[]')
+          restores=$(printf '%s' "$snaplist" | jq -r '[.data[]?.file]|.[]')
+          echo "Would DELETE from public_html (static files):"; printf '%s\n' "$dels" | sed 's/^/  - /'
+          echo "Would RESTORE from ${SNAP}:"; printf '%s\n' "$restores" | sed 's/^/  - /'
+          if [ "$DRY_RUN" = "true" ]; then echo "DRY RUN — nothing written."; exit 0; fi
+          sudo apt-get update -qq && sudo apt-get install -y -qq lftp
+          rm_cmds=$(while IFS= read -r e; do [ -n "$e" ] && printf 'rm -r "public_html/%s"\n' "$e"; done <<< "$dels")
+          mv_cmds=$(while IFS= read -r e; do [ -n "$e" ] && printf 'mv "%s/%s" "public_html/%s"\n' "$SNAP" "$e" "$e"; done <<< "$restores")
+          lftp <<LFTP 2>&1 | tail -200
+            set ftp:ssl-allow yes; set ftp:ssl-force yes; set ftp:ssl-protect-data yes; set ssl:verify-certificate no
+            set net:max-retries 3; set net:timeout 60
+            open -p "$CPANEL_FTP_PORT" -u "$CPANEL_FTP_USER","$CPANEL_FTP_PASSWORD" "ftp://$CPANEL_FTP_HOST"
+            ${rm_cmds}
+            ${mv_cmds}
+            bye
+          LFTP
+          echo "Rollback writes complete. WordPress restored from ${SNAP}."
+
+      - name: 'Verify the live apex (and /hub unchanged)'
+        if: ${{ inputs.dry_run == false }}
+        env:
+          ACTION: ${{ inputs.action }}
+        run: |
+          set -euo pipefail
+          cb="cb=$(date -u +%s)_${RANDOM}"
+          get(){ curl -sSL -m 25 -H 'Cache-Control: no-cache' -w '\n%{http_code}' "https://${APEX}$1?$cb"; }
+          code(){ curl -sSL -m 25 -o /dev/null -w '%{http_code}' -H 'Cache-Control: no-cache' "https://${APEX}$1?$cb"; }
+          fail=0
+          # /hub/ must still serve (status unchanged from the pre-flight baseline)
+          hc=$(code "/hub/")
+          if [ "$hc" = "${HUB_BASELINE}" ] && [ "$hc" != "000" ]; then echo "  ✓ /hub/ -> ${hc} (unchanged — WHMCS intact)";
+          else echo "  ✗ /hub/ -> ${hc} (baseline ${HUB_BASELINE}) — investigate / rollback!"; fail=1; fi
+          r=$(get "/"); c=$(printf '%s' "$r"|tail -n1); b=$(printf '%s' "$r"|sed '$d')
+          if [ "$ACTION" = "cutover" ]; then
+            # apex should now be the static export
+            if [ "$c" = "200" ] && printf '%s' "$b" | grep -qi 'next\|<title>'; then echo "  ✓ / -> 200 static site";
+            else echo "  ✗ / -> ${c} (expected static)"; fail=1; fi
+            wc=$(code "/wp-login.php"); case "$wc" in 301|302|403|404) echo "  ✓ /wp-login.php -> ${wc} (blocked)";; *) echo "  ✗ /wp-login.php -> ${wc}"; fail=1;; esac
+          else
+            [ "$c" = "200" ] && echo "  ✓ / -> 200 (WordPress restored)" || { echo "  ✗ / -> ${c}"; fail=1; }
+          fi
+          {
+            echo "## Apex ${ACTION} on ${APEX}"
+            echo ""
+            echo "- /hub/ (WHMCS): ${hc} (baseline ${HUB_BASELINE})"
+            echo "- snapshot dir: \`${SNAPSHOT_DIR:-${{ inputs.snapshot_dir }}}\`"
+            echo "- result: $( [ "$fail" -eq 0 ] && echo '✅ ok' || echo '⛔ CHECK FAILED — see ROLLBACK' )"
+          } >> "$GITHUB_STEP_SUMMARY"
+          [ "$fail" -eq 0 ] || { echo "::error::Post-${ACTION} verification failed. To revert a cutover, re-run with action=rollback snapshot_dir=${SNAPSHOT_DIR:-<snapshot>}."; exit 1; }
+          echo "✅ ${ACTION} verified."

--- a/.github/workflows/cpanel-apex-cutover.yml
+++ b/.github/workflows/cpanel-apex-cutover.yml
@@ -9,15 +9,18 @@ name: 'cPanel APEX cutover (WordPress -> static, /hub-safe)'
 #     reviewers to a dedicated environment for a second human approval gate;
 #   * a fresh WordPress + WHMCS backup is REQUIRED before a live cutover.
 #
+# STEP 2 of 2. STEP 1 (cpanel-apex-snapshot.yml) must have already created and
+# VERIFIED an on-server WordPress copy in ~/public_html_wp_precutover_<ts>/
+# while the site was still live. This step REFUSES to flip unless you pass that
+# verified snapshot dir as `snapshot_dir` and it still exists — so we never
+# wipe WordPress before its rollback copy is proven to exist.
+#
 # Mechanic (proven /hub-safe by cpanel-cutover-rehearse.yml on staging):
-#   The apex docroot stays ~/public_html. We DON'T move it (WHMCS lives at
-#   ~/public_html/hub as a real dir and must not move). Instead:
-#     1. MOVE the WordPress files aside, server-side, into a timestamped sister
-#        dir ~/public_html_wp_precutover_<ts>/ (FTP rename = instant, no
-#        download) — this is the on-server rollback snapshot. hub/, cgi-bin/,
-#        .well-known/, the parked-domain docroot and system dotfiles are KEPT
-#        in place (never moved, never deleted).
-#     2. Mirror the Next.js static export into the now-clean ~/public_html/.
+#   The apex docroot stays ~/public_html (WHMCS lives at ~/public_html/hub as a
+#   real dir and must not move). The flip just mirrors the Next.js static export
+#   into ~/public_html with --delete, EXCLUDING the keepers (hub/, cgi-bin/,
+#   .well-known/, the parked-domain docroot, system dotfiles). The WordPress
+#   files are removed by --delete; the STEP 1 snapshot is the rollback source.
 #   The static export's own .htaccess hands /hub/ off to WHMCS untouched
 #   (`RewriteRule ^hub($|/) - [L]` + `DirectoryIndex index.html index.php`).
 #
@@ -44,8 +47,8 @@ on:
         default: ''
         type: string
       snapshot_dir:
-        description: 'Rollback only: the public_html_wp_precutover_<ts> dir to restore from'
-        required: false
+        description: 'REQUIRED: the verified public_html_wp_precutover_<ts> dir from STEP 1 (cutover restores from it on rollback; rollback reads it)'
+        required: true
         default: ''
         type: string
       dry_run:
@@ -82,19 +85,23 @@ jobs:
     environment: cpanel-staging
     timeout-minutes: 60
     steps:
-      - name: 'Gate: confirm phrase (required for live writes)'
+      - name: 'Gate: confirm phrase + snapshot required'
         env:
           ACTION: ${{ inputs.action }}
           CONFIRM: ${{ inputs.confirm }}
           DRY_RUN: ${{ inputs.dry_run }}
+          SNAP: ${{ inputs.snapshot_dir }}
         run: |
           set -euo pipefail
-          echo "action=${ACTION} dry_run=${DRY_RUN}"
-          if [ "$DRY_RUN" != "true" ]; then
-            if [ "$CONFIRM" != "CUTOVER freeforcharity.org" ]; then
-              echo "::error::Live write requires confirm='CUTOVER freeforcharity.org' exactly."
-              exit 1
-            fi
+          echo "action=${ACTION} dry_run=${DRY_RUN} snapshot_dir=${SNAP}"
+          # A verified STEP 1 snapshot is mandatory in both directions.
+          case "$SNAP" in
+            public_html_wp_precutover_*) : ;;
+            *) echo "::error::snapshot_dir is required and must be a public_html_wp_precutover_<ts> dir from STEP 1 (cpanel-apex-snapshot.yml)."; exit 1 ;;
+          esac
+          if [ "$DRY_RUN" != "true" ] && [ "$CONFIRM" != "CUTOVER freeforcharity.org" ]; then
+            echo "::error::Live write requires confirm='CUTOVER freeforcharity.org' exactly."
+            exit 1
           fi
 
       - uses: actions/checkout@v6
@@ -184,77 +191,58 @@ jobs:
           echo "HUB_BASELINE=$hb" >> "$GITHUB_ENV"
           echo "/hub/ baseline status: ${hb}"
 
-      - name: 'Plan move-set (entries to snapshot)'
-        if: ${{ inputs.action == 'cutover' }}
+      - name: 'Require a verified STEP 1 snapshot to exist'
         env:
           APIM_BASE: ${{ secrets.APIM_GATEWAY_URL }}
+          SNAP: ${{ inputs.snapshot_dir }}
         run: |
           set -euo pipefail
           base="${APIM_BASE:-https://apim-ffc-gateway-prod.azure-api.net}"
           api(){ curl -sS --max-time 45 -H "Ocp-Apim-Subscription-Key: ${APIM_KEY}" -H 'Accept: application/json' "$@"; }
-          listing=$(api --get --data-urlencode "dir=/home/${CPANEL_FTP_USER}/public_html" \
-                      --data-urlencode "show_hidden=1" "${base}/cpanel/execute/Fileman/list_files")
-          [ "$(printf '%s' "$listing" | jq -r '.status')" = "1" ] || { echo "::error::cannot list public_html"; exit 1; }
-          # Move everything EXCEPT keepers and dotfiles (but DO move WP's .htaccess,
-          # which the static export replaces). Keepers/dotfiles stay in place.
-          moveset=$(printf '%s' "$listing" | jq -r --arg keep "$KEEP" '
-            ($keep|split(" ")) as $k
-            | [ .data[]?.file
-                | select(. as $f | ($k|index($f))|not)
-                | select((startswith(".")|not) or . == ".htaccess") ] | .[]')
-          printf '%s\n' "$moveset" > moveset.txt
-          echo "Will snapshot $(wc -l < moveset.txt) entries:"; sed 's/^/  - /' moveset.txt
-          if ! grep -q . moveset.txt; then echo "::warning::move-set is empty (already cut over?)"; fi
+          # The flip is refused unless STEP 1's WordPress copy actually exists and
+          # is non-trivial — this is the "make sure the copy worked first" gate.
+          snap=$(api --get --data-urlencode "dir=/home/${CPANEL_FTP_USER}/${SNAP}" --data-urlencode "show_hidden=1" \
+                   "${base}/cpanel/execute/Fileman/list_files")
+          [ "$(printf '%s' "$snap" | jq -r '.status')" = "1" ] || { echo "::error::snapshot ${SNAP} not found — run STEP 1 (cpanel-apex-snapshot.yml) first."; exit 1; }
+          n=$(printf '%s' "$snap" | jq -r '[.data[]?.file]|length')
+          haswp=$(printf '%s' "$snap" | jq -r '[.data[]?.file|select(.=="wp-content" or .=="wp-includes" or .=="index.php")]|length')
+          echo "snapshot ${SNAP}: ${n} entries, wp-markers=${haswp}"
+          if [ "${n:-0}" -lt 1 ] || [ "${haswp:-0}" -lt 1 ]; then
+            echo "::error::snapshot ${SNAP} is empty or doesn't look like a WordPress copy — refusing to flip."
+            exit 1
+          fi
+          echo "SNAPSHOT_DIR=${SNAP}" >> "$GITHUB_ENV"
+          echo "✓ verified rollback snapshot present"
 
-      - name: 'CUTOVER'
+      - name: 'CUTOVER (mirror static over WordPress)'
         if: ${{ inputs.action == 'cutover' }}
         env:
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
           set -euo pipefail
-          ts=$(date -u +%Y%m%d%H%M%S)
-          snap="public_html_wp_precutover_${ts}"
-          echo "SNAPSHOT_DIR=${snap}" >> "$GITHUB_ENV"
-          if [ "$DRY_RUN" = "true" ]; then
-            echo "DRY RUN — would:"
-            echo "  1) mkdir ~/${snap}"
-            echo "  2) server-side MOVE each move-set entry: public_html/<e> -> ${snap}/<e>"
-            sed 's/^/       - /' moveset.txt
-            echo "  3) mirror --delete ./out/ -> ./public_html/ (keeping: ${KEEP})"
-            sudo apt-get update -qq && sudo apt-get install -y -qq lftp
-            echo "  --- lftp --dry-run preview of step 3 (no writes) ---"
-            lftp <<LFTP 2>&1 | tail -120
-              set ftp:ssl-allow yes; set ftp:ssl-force yes; set ftp:ssl-protect-data yes; set ssl:verify-certificate no
-              open -p "$CPANEL_FTP_PORT" -u "$CPANEL_FTP_USER","$CPANEL_FTP_PASSWORD" "ftp://$CPANEL_FTP_HOST"
-              mirror --reverse --delete --dry-run --verbose=1 \
-                --exclude-glob 'hub' --exclude-glob 'hub/' --exclude-glob 'cgi-bin/' \
-                --exclude-glob '.well-known/' --exclude-glob 'wh1319644.ispot.cc/' \
-                --exclude-glob '.ftpquota' --exclude-glob '.htpasswd' --exclude-glob 'error_log' \
-                ./out/ ./public_html/
-              bye
-          LFTP
-            echo "DRY RUN complete — nothing was written."
-            exit 0
-          fi
           sudo apt-get update -qq && sudo apt-get install -y -qq lftp
-          # Build the server-side move commands (FTP rename; instant, no download).
-          # Newlines are produced at runtime by printf so the YAML block scalar
-          # stays intact.
-          mv_cmds=$(while IFS= read -r e; do [ -n "$e" ] && printf 'mv "public_html/%s" "%s/%s"\n' "$e" "$snap" "$e"; done < moveset.txt)
+          DRY=""
+          if [ "$DRY_RUN" = "true" ]; then
+            DRY="--dry-run"
+            echo "DRY RUN — lftp --dry-run preview of the overwrite (no writes):"
+          fi
+          # The WordPress files are already copied to ${SNAPSHOT_DIR} (STEP 1).
+          # Mirror the static export into public_html with --delete, keeping the
+          # keepers. WordPress files (not in out/) are removed; rollback restores
+          # them from the snapshot.
           lftp <<LFTP 2>&1 | tail -200
             set ftp:ssl-allow yes; set ftp:ssl-force yes; set ftp:ssl-protect-data yes; set ssl:verify-certificate no
             set net:max-retries 3; set net:timeout 60
             open -p "$CPANEL_FTP_PORT" -u "$CPANEL_FTP_USER","$CPANEL_FTP_PASSWORD" "ftp://$CPANEL_FTP_HOST"
-            mkdir -p "${snap}"
-            ${mv_cmds}
-            mirror --reverse --delete --parallel=4 --verbose=1 \
+            mirror --reverse --delete $DRY --parallel=4 --verbose=1 \
               --exclude-glob 'hub' --exclude-glob 'hub/' --exclude-glob 'cgi-bin/' \
               --exclude-glob '.well-known/' --exclude-glob 'wh1319644.ispot.cc/' \
+              --exclude-glob '.cache/' --exclude-glob '.tmb/' \
               --exclude-glob '.ftpquota' --exclude-glob '.htpasswd' --exclude-glob 'error_log' \
               ./out/ ./public_html/
             bye
           LFTP
-          echo "Cutover writes complete. Snapshot: ~/${snap}"
+          if [ "$DRY_RUN" = "true" ]; then echo "DRY RUN complete — nothing was written."; else echo "Cutover writes complete. Rollback snapshot: ~/${SNAPSHOT_DIR}"; fi
 
       - name: 'ROLLBACK'
         if: ${{ inputs.action == 'rollback' }}

--- a/.github/workflows/cpanel-apex-snapshot.yml
+++ b/.github/workflows/cpanel-apex-snapshot.yml
@@ -1,0 +1,188 @@
+name: 'Apex cutover STEP 1 — backup gate + WP snapshot (non-destructive)'
+
+# Phase 1 of the freeforcharity.org cutover, split out from the flip so the
+# rollback snapshot is created and VERIFIED while WordPress is still live.
+# This step writes only to a NEW sister directory; it never modifies
+# ~/public_html, so the live site is untouched and this is safe to run/re-run.
+#
+# What it does:
+#   1. (live) requires a fresh restorable backup (Softaculous->OneDrive < 30h);
+#   2. copies the WordPress files from ~/public_html into a new timestamped
+#      sister dir ~/public_html_wp_precutover_<ts>/  — a real server-side COPY
+#      (down to the runner over FTPS, back up to the sister dir), so the live
+#      docroot keeps serving; hub/ (WHMCS), cgi-bin/, .well-known/, the
+#      parked-domain docroot and system dotfiles are NOT copied (they stay put
+#      and are not part of a WordPress rollback);
+#   3. verifies the copy: the sister dir's entry set must match the WP entry
+#      set in public_html (count + names) — otherwise it fails.
+#
+# The snapshot dir name it prints is the input you pass to STEP 2
+# (cpanel-apex-cutover.yml), which refuses to flip without a verified snapshot.
+#
+# Creds: GH OIDC -> Azure -> Key Vault (MAIN cPanel FTP creds + read-only
+# gateway subscription key). MAIN FTP is homed at the account root.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Preview only — write nothing (default true)'
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  id-token: write
+  contents: read
+  actions: read
+
+concurrency:
+  group: cpanel-apex-cutover # shares the lock with STEP 2
+  cancel-in-progress: false
+
+env:
+  KEEP: 'hub cgi-bin .well-known .cache .tmb .ftpquota .htpasswd error_log .htpasswds wh1319644.ispot.cc'
+
+jobs:
+  snapshot:
+    name: 'Backup gate + copy WP to sister dir + verify'
+    runs-on: ubuntu-latest
+    environment: cpanel-staging
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: 'Backup-freshness gate (live only)'
+        if: ${{ inputs.dry_run == false }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          ok=$(gh run list --workflow cpanel-softaculous-backup-sync.yml --limit 20 --json conclusion,updatedAt \
+               | jq -r '[.[]|select(.conclusion=="success")]|sort_by(.updatedAt)|last|.updatedAt // empty')
+          if [ -z "$ok" ]; then echo "::error::No successful backup sync found — run it before snapshotting/cutover."; exit 1; fi
+          age=$(( $(date -u +%s) - $(date -u -d "$ok" +%s) ))
+          echo "Last successful backup sync: ${ok} ($((age/3600))h ago)"
+          [ "$age" -le 108000 ] || { echo "::error::Latest restorable backup is >30h old. Run the backup sync first."; exit 1; }
+
+      - name: Azure login (OIDC)
+        uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.WR_ALL_FFC_AZURE_KV_CLIENT_ID }}
+          tenant-id: ${{ secrets.WR_ALL_FFC_AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
+
+      - name: Fetch creds from Key Vault (FTP + gateway key)
+        shell: pwsh
+        env:
+          KV_NAME: kv-ffc-admin-prod-cbm
+        run: |
+          $ErrorActionPreference = 'Stop'
+          . ./.github/scripts/Get-KvSecret.ps1
+          $v = $env:KV_NAME.Trim()
+          $h = Get-KvSecret -VaultName $v -Name 'wr-all-cbm-cpanel-ffc-interserver-ftp-host'
+          $p = Get-KvSecret -VaultName $v -Name 'wr-all-cbm-cpanel-ffc-interserver-ftp-port'
+          $u = Get-KvSecret -VaultName $v -Name 'wr-all-cbm-cpanel-ffc-interserver-ftp-user'
+          $pw= Get-KvSecret -VaultName $v -Name 'wr-all-cbm-cpanel-ffc-interserver-ftp-password'
+          $key=Get-KvSecret -VaultName $v -Name 'read-all-ffc-apim-gateway-subscription-key'
+          foreach ($s in @($h,$u,$pw,$key)) { Write-Host "::add-mask::$s" }
+          "CPANEL_FTP_HOST=$h"  | Out-File $env:GITHUB_ENV -Append -Encoding utf8
+          "CPANEL_FTP_PORT=$p"  | Out-File $env:GITHUB_ENV -Append -Encoding utf8
+          "CPANEL_FTP_USER=$u"  | Out-File $env:GITHUB_ENV -Append -Encoding utf8
+          "CPANEL_FTP_PASSWORD=$pw" | Out-File $env:GITHUB_ENV -Append -Encoding utf8
+          "APIM_KEY=$key"       | Out-File $env:GITHUB_ENV -Append -Encoding utf8
+
+      - name: 'Compute WP copy-set from public_html'
+        env:
+          APIM_BASE: ${{ secrets.APIM_GATEWAY_URL }}
+        run: |
+          set -euo pipefail
+          base="${APIM_BASE:-https://apim-ffc-gateway-prod.azure-api.net}"
+          api(){ curl -sS --max-time 45 -H "Ocp-Apim-Subscription-Key: ${APIM_KEY}" -H 'Accept: application/json' "$@"; }
+          listing=$(api --get --data-urlencode "dir=/home/${CPANEL_FTP_USER}/public_html" --data-urlencode "show_hidden=1" \
+                      "${base}/cpanel/execute/Fileman/list_files")
+          [ "$(printf '%s' "$listing" | jq -r '.status')" = "1" ] || { echo "::error::cannot list public_html"; exit 1; }
+          # WP files = everything except keepers and (system dotfiles, but keep WP's .htaccess).
+          printf '%s' "$listing" | jq -r --arg keep "$KEEP" '
+            ($keep|split(" ")) as $k
+            | [ .data[]?.file
+                | select(. as $f | ($k|index($f))|not)
+                | select((startswith(".")|not) or . == ".htaccess") ] | .[]' > copyset.txt
+          n=$(grep -c . copyset.txt || true)
+          echo "WP copy-set (${n} entries):"; sed 's/^/  - /' copyset.txt
+          [ "$n" -gt 0 ] || { echo "::error::copy-set is empty — is WordPress still in public_html?"; exit 1; }
+          echo "COPYSET_N=$n" >> "$GITHUB_ENV"
+
+      - name: 'Copy WP -> sister dir (down then up), or preview'
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          ts=$(date -u +%Y%m%d%H%M%S)
+          snap="public_html_wp_precutover_${ts}"
+          echo "SNAP=$snap" >> "$GITHUB_ENV"
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "DRY RUN — would create ~/${snap} and COPY these from public_html:"
+            sed 's/^/  - /' copyset.txt
+            echo "(non-destructive: public_html is only READ; the live site is untouched)"
+            exit 0
+          fi
+          sudo apt-get update -qq && sudo apt-get install -y -qq lftp
+          mkdir -p ./wpsnap
+          # 1) download the WP files (everything EXCEPT keepers) to the runner.
+          #    mirror copies dotfiles too, so WP's .htaccess is included; the
+          #    keeper dirs/files are excluded so hub/ (WHMCS) etc. are not pulled.
+          lftp <<LFTP 2>&1 | tail -120
+            set ftp:ssl-allow yes; set ftp:ssl-force yes; set ftp:ssl-protect-data yes; set ssl:verify-certificate no
+            set net:max-retries 3; set net:timeout 60
+            open -p "$CPANEL_FTP_PORT" -u "$CPANEL_FTP_USER","$CPANEL_FTP_PASSWORD" "ftp://$CPANEL_FTP_HOST"
+            mirror --parallel=4 --verbose=0 \
+              --exclude-glob 'hub' --exclude-glob 'hub/' --exclude-glob 'cgi-bin/' \
+              --exclude-glob '.well-known/' --exclude-glob 'wh1319644.ispot.cc/' \
+              --exclude-glob '.cache/' --exclude-glob '.tmb/' \
+              --exclude-glob '.ftpquota' --exclude-glob '.htpasswd' --exclude-glob 'error_log' \
+              public_html ./wpsnap
+            bye
+          LFTP
+          echo "Downloaded WP to runner: $(find ./wpsnap -type f | wc -l) files, $(du -sh ./wpsnap | cut -f1)"
+          # 2) upload to the sister dir (server-side copy completed).
+          lftp <<LFTP 2>&1 | tail -120
+            set ftp:ssl-allow yes; set ftp:ssl-force yes; set ftp:ssl-protect-data yes; set ssl:verify-certificate no
+            set net:max-retries 3; set net:timeout 60
+            open -p "$CPANEL_FTP_PORT" -u "$CPANEL_FTP_USER","$CPANEL_FTP_PASSWORD" "ftp://$CPANEL_FTP_HOST"
+            mkdir -p "${snap}"
+            mirror --reverse --parallel=4 --verbose=0 ./wpsnap/ "./${snap}/"
+            bye
+          LFTP
+          echo "Uploaded snapshot to ~/${snap}"
+
+      - name: 'Verify the snapshot copy'
+        if: ${{ inputs.dry_run == false }}
+        env:
+          APIM_BASE: ${{ secrets.APIM_GATEWAY_URL }}
+        run: |
+          set -euo pipefail
+          base="${APIM_BASE:-https://apim-ffc-gateway-prod.azure-api.net}"
+          api(){ curl -sS --max-time 45 -H "Ocp-Apim-Subscription-Key: ${APIM_KEY}" -H 'Accept: application/json' "$@"; }
+          snaplist=$(api --get --data-urlencode "dir=/home/${CPANEL_FTP_USER}/${SNAP}" --data-urlencode "show_hidden=1" \
+                       "${base}/cpanel/execute/Fileman/list_files")
+          [ "$(printf '%s' "$snaplist" | jq -r '.status')" = "1" ] || { echo "::error::snapshot ${SNAP} not found after copy"; exit 1; }
+          # Use the same (C-locale) sort for both sides so comm pairs correctly.
+          printf '%s' "$snaplist" | jq -r '.data[]?.file' | LC_ALL=C sort > snap_have.txt
+          LC_ALL=C sort copyset.txt > snap_want.txt
+          echo "snapshot ~/${SNAP} top-level entries:"; sed 's/^/  - /' snap_have.txt
+          miss=$(comm -23 snap_want.txt snap_have.txt)
+          if [ -n "$miss" ]; then
+            echo "::error::snapshot is missing expected WP entr(ies):"
+            printf '%s\n' "$miss" | sed 's/^/  - /'
+            exit 1
+          fi
+          {
+            echo "## Apex snapshot complete ✅"
+            echo ""
+            echo "- Snapshot dir: \`${SNAP}\`  (pass this to STEP 2 as \`snapshot_dir\`)"
+            echo "- WP entries copied: ${COPYSET_N}"
+            echo "- public_html (live WordPress) was NOT modified."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "✅ Verified copy. Snapshot dir = ${SNAP}"

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -101,6 +101,11 @@ http://www.fiverr.com/**
 https://www.guidestar.org/**
 https://help.candid.org/**
 
+# Zeffy donation-form/thermometer embeds return 403 to CI crawlers — the
+# embeds render fine in browsers (used on the endowment fund + homepage).
+https://www.zeffy.com/**
+https://zeffy.com/**
+
 # Microsoft privacy statement 403s on bots; the canonical /en-us/ variant is what users get redirected to
 https://privacy.microsoft.com/privacystatement
 https://privacy.microsoft.com/**

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -106,6 +106,10 @@ https://help.candid.org/**
 https://www.zeffy.com/**
 https://zeffy.com/**
 
+# Microsoft Tech Community intermittently 403s CI crawlers (same bot-block as
+# privacy.microsoft.com / microsoft.com/nonprofits, already pinned). Real URL.
+https://techcommunity.microsoft.com/**
+
 # Microsoft privacy statement 403s on bots; the canonical /en-us/ variant is what users get redirected to
 https://privacy.microsoft.com/privacystatement
 https://privacy.microsoft.com/**


### PR DESCRIPTION
## Why

The apex cutover is now **split into two phases** so the rollback copy is created and **proven before** WordPress is ever wiped (per request: "break apart the backup and pre-testing from the actual flip; make sure the copy to the new folder works first"). Mechanic proven `/hub`-safe on staging via `cpanel-cutover-rehearse.yml` (merged in #294).

## STEP 1 — `cpanel-apex-snapshot.yml` (non-destructive)
1. **Backup-freshness gate** — requires a successful Softaculous→OneDrive sync ≤30h.
2. **Copies** the WordPress files from `~/public_html` into a new sister dir `~/public_html_wp_precutover_<ts>/` — a real server-side copy (down to the runner over FTPS, back up to the sister dir). `public_html` is **only read**, so the live site is untouched; `hub/` (WHMCS), `cgi-bin/`, `.well-known/`, the parked-domain docroot and system dotfiles are not copied.
3. **Verifies** the copy — every expected WP entry must be present in the snapshot, or it fails.

Prints the snapshot dir name to feed STEP 2. `dry_run` defaults true.

## STEP 2 — `cpanel-apex-cutover.yml` (the flip + rollback)
- **Refuses to run** unless you pass the verified `snapshot_dir` and it still exists and looks like a WordPress copy (`wp-content`/`wp-includes`/`index.php`) — this is the "copy worked first" gate.
- No longer moves anything: just **mirrors the static export into `public_html` with `--delete`**, keeping the keepers. WP files are removed; the STEP 1 snapshot is the rollback source. The static `.htaccess` hands `/hub/` off to WHMCS untouched.
- `dry_run` default (lftp `--dry-run` add/delete preview), typed `confirm = CUTOVER freeforcharity.org`, `/hub/` status baseline captured pre-flight and re-checked after, `/wp-login.php` blocked check.
- **Rollback** (`action=rollback`): deletes the static files and moves the snapshot WordPress files back.

## Rollback layers
1. **Instant** — the on-server STEP 1 snapshot.
2. **Durable** — the OneDrive Softaculous WP+WHMCS backups (enforced fresh by the gate).

WHMCS and both databases are never touched in either direction.

## Environment / verification
Runs in the proven `cpanel-staging` environment (MAIN-account FTP creds + OIDC). YAML lints clean; `bash -n` passes on every `run:` block. Two unrelated bot-blocked links (Zeffy, MS Tech Community) pinned in `.lycheeignore` to keep the external-link check green.

## Rollout order
STEP 1 (dry-run → live, verify the copy) → STEP 2 dry-run (inspect the `lftp` add/delete plan) → STEP 2 live with the typed confirm.

Refs #139, #29. Refs FreeForCharity/FFC-IN-ClarkeMoyerAdmin#104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)