### PR TITLE
fix(cutover): gateway list_files uses cPanel-home-relative dirs

### DIFF
--- a/.github/workflows/cpanel-apex-cutover.yml
+++ b/.github/workflows/cpanel-apex-cutover.yml
@@ -181,7 +181,7 @@ jobs:
           base="${APIM_BASE:-https://apim-ffc-gateway-prod.azure-api.net}"
           api(){ curl -sS --max-time 45 -H "Ocp-Apim-Subscription-Key: ${APIM_KEY}" -H 'Accept: application/json' "$@"; }
           # WHMCS must be a real dir with configuration.php — abort if not.
-          whmcs=$(api --get --data-urlencode "dir=/home/${CPANEL_FTP_USER}/public_html/hub" \
+          whmcs=$(api --get --data-urlencode "dir=public_html/hub" \
                     --data-urlencode "only_these_files=configuration.php" --data-urlencode "types=file" \
                     "${base}/cpanel/execute/Fileman/list_files" | jq -r '[.data[]?.file]|length')
           if [ "${whmcs:-0}" -lt 1 ]; then echo "::error::WHMCS configuration.php not found at public_html/hub — aborting."; exit 1; fi
@@ -201,7 +201,7 @@ jobs:
           api(){ curl -sS --max-time 45 -H "Ocp-Apim-Subscription-Key: ${APIM_KEY}" -H 'Accept: application/json' "$@"; }
           # The flip is refused unless STEP 1's WordPress copy actually exists and
           # is non-trivial — this is the "make sure the copy worked first" gate.
-          snap=$(api --get --data-urlencode "dir=/home/${CPANEL_FTP_USER}/${SNAP}" --data-urlencode "show_hidden=1" \
+          snap=$(api --get --data-urlencode "dir=${SNAP}" --data-urlencode "show_hidden=1" \
                    "${base}/cpanel/execute/Fileman/list_files")
           [ "$(printf '%s' "$snap" | jq -r '.status')" = "1" ] || { echo "::error::snapshot ${SNAP} not found — run STEP 1 (cpanel-apex-snapshot.yml) first."; exit 1; }
           n=$(printf '%s' "$snap" | jq -r '[.data[]?.file]|length')
@@ -258,10 +258,10 @@ jobs:
           esac
           base="${APIM_BASE:-https://apim-ffc-gateway-prod.azure-api.net}"
           api(){ curl -sS --max-time 45 -H "Ocp-Apim-Subscription-Key: ${APIM_KEY}" -H 'Accept: application/json' "$@"; }
-          snaplist=$(api --get --data-urlencode "dir=/home/${CPANEL_FTP_USER}/${SNAP}" --data-urlencode "show_hidden=1" \
+          snaplist=$(api --get --data-urlencode "dir=${SNAP}" --data-urlencode "show_hidden=1" \
                        "${base}/cpanel/execute/Fileman/list_files")
           [ "$(printf '%s' "$snaplist" | jq -r '.status')" = "1" ] || { echo "::error::snapshot ${SNAP} not found"; exit 1; }
-          cur=$(api --get --data-urlencode "dir=/home/${CPANEL_FTP_USER}/public_html" --data-urlencode "show_hidden=1" \
+          cur=$(api --get --data-urlencode "dir=public_html" --data-urlencode "show_hidden=1" \
                   "${base}/cpanel/execute/Fileman/list_files")
           # current non-keeper entries (the static files) -> delete; snapshot entries -> move back
           dels=$(printf '%s' "$cur" | jq -r --arg keep "$KEEP" '($keep|split(" ")) as $k | [.data[]?.file|select(. as $f|($k|index($f))|not)]|.[]')

--- a/.github/workflows/cpanel-apex-snapshot.yml
+++ b/.github/workflows/cpanel-apex-snapshot.yml
@@ -100,7 +100,7 @@ jobs:
           set -euo pipefail
           base="${APIM_BASE:-https://apim-ffc-gateway-prod.azure-api.net}"
           api(){ curl -sS --max-time 45 -H "Ocp-Apim-Subscription-Key: ${APIM_KEY}" -H 'Accept: application/json' "$@"; }
-          listing=$(api --get --data-urlencode "dir=/home/${CPANEL_FTP_USER}/public_html" --data-urlencode "show_hidden=1" \
+          listing=$(api --get --data-urlencode "dir=public_html" --data-urlencode "show_hidden=1" \
                       "${base}/cpanel/execute/Fileman/list_files")
           [ "$(printf '%s' "$listing" | jq -r '.status')" = "1" ] || { echo "::error::cannot list public_html"; exit 1; }
           # WP files = everything except keepers and (system dotfiles, but keep WP's .htaccess).
@@ -165,7 +165,7 @@ jobs:
           set -euo pipefail
           base="${APIM_BASE:-https://apim-ffc-gateway-prod.azure-api.net}"
           api(){ curl -sS --max-time 45 -H "Ocp-Apim-Subscription-Key: ${APIM_KEY}" -H 'Accept: application/json' "$@"; }
-          snaplist=$(api --get --data-urlencode "dir=/home/${CPANEL_FTP_USER}/${SNAP}" --data-urlencode "show_hidden=1" \
+          snaplist=$(api --get --data-urlencode "dir=${SNAP}" --data-urlencode "show_hidden=1" \
                        "${base}/cpanel/execute/Fileman/list_files")
           [ "$(printf '%s' "$snaplist" | jq -r '.status')" = "1" ] || { echo "::error::snapshot ${SNAP} not found after copy"; exit 1; }
           # Use the same (C-locale) sort for both sides so comm pairs correctly.


### PR DESCRIPTION
## Why

After #299 merged, the live STEP 1 dry-run failed with `cannot list public_html`: the gateway calls used `/home/${CPANEL_FTP_USER}/...`, but the MAIN FTP user is **`githubSFTP@freeforcharity.org`** (an account homed at the cPanel root), not the cPanel account name `freeforc`. So the path resolved to `/home/freeforc/home/githubSFTP@…/public_html` → "directory does not exist".

## Fix

The gateway runs as the cPanel user and resolves **relative** paths against `/home/freeforc`, so the `Fileman/list_files` calls now use `dir=public_html`, `dir=public_html/hub`, `dir=${SNAP}` (lftp already used home-relative paths). No `CPANEL_FTP_USER` in gateway paths.

## Verified live (from the branch)
- STEP 1 dry-run ✅ — copy-set = 28 WordPress entries.
- STEP 1 live ✅ — copied 36,163 files / 2.0 GB into `public_html_wp_precutover_20260622193234`; verify step passed; re-confirmed via the gateway (`wp-content`, `wp-includes`, `index.php`, **`wp-config.php`** present). Live apex + `/hub/` stayed `200` (untouched).

Refs #139, #29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L5dsyzhYdTmrpkgTXar6pa)_