### PR TITLE
fix(cutover): keep /hub PHP env + add live visual check (browser screenshots)

### DIFF
--- a/.github/workflows/cpanel-apex-cutover.yml
+++ b/.github/workflows/cpanel-apex-cutover.yml
@@ -71,8 +71,10 @@ env:
   DOCROOT: public_html
   # Entries in ~/public_html that must NEVER be moved or deleted by either
   # direction. hub = WHMCS; wh1319644.ispot.cc = a parked-domain docroot;
-  # the rest are cPanel/system. The static export replaces everything else.
-  KEEP: 'hub cgi-bin .well-known .cache .tmb .ftpquota .htpasswd error_log .htpasswds wh1319644.ispot.cc'
+  # .user.ini + php.ini are PHP configs that /hub INHERITS (it has none of its
+  # own), so keep them or WHMCS's PHP env changes; the rest are cPanel/system.
+  # The static export replaces everything else.
+  KEEP: 'hub cgi-bin .well-known .cache .tmb .ftpquota .htpasswd error_log .htpasswds wh1319644.ispot.cc .user.ini php.ini .s3backupstatus .synthquota .ht_wsr.txt'
 
 jobs:
   cutover:
@@ -239,6 +241,8 @@ jobs:
               --exclude-glob '.well-known/' --exclude-glob 'wh1319644.ispot.cc/' \
               --exclude-glob '.cache/' --exclude-glob '.tmb/' \
               --exclude-glob '.ftpquota' --exclude-glob '.htpasswd' --exclude-glob 'error_log' \
+              --exclude-glob '.user.ini' --exclude-glob 'php.ini' \
+              --exclude-glob '.s3backupstatus' --exclude-glob '.synthquota' --exclude-glob '.ht_wsr.txt' \
               ./out/ ./public_html/
             bye
           LFTP


### PR DESCRIPTION
Post-cutover follow-ups (the live apex flip already ran with the keeper fix from this branch).

## 1. Keep `/hub` PHP env (`.user.ini`/`php.ini`)
The flip now preserves `.user.ini`, `php.ini`, and cPanel status dotfiles (`.s3backupstatus`, `.synthquota`, `.ht_wsr.txt`) so WHMCS at `/hub` (which has no PHP config of its own and inherits `public_html`'s) keeps its exact PHP environment. All are also in the STEP 1 snapshot, so rollback is unaffected.

## 2. Live visual check — `scripts/live-visual-check.mjs` + `live-visual-check.yml`
Drives a **real Chromium browser** against the live apex + key routes + the **WHMCS `/hub`**, captures full-page **screenshots** (CI artifacts), asserts page content, and **counts retries per page so flakiness is measured, not assumed**.

Built because `curl`/bare-HTTP probes from datacenter IPs get intermittently rejected (a client-fingerprint/bot-mitigation `415`), which does **not** reflect what real browsers/users see. Verified locally against the live site post-cutover:

```
/           -> 200 (1st try)  "Free For Charity"   (static homepage)
/about-us/  -> 200 (1st try)  "About"
/hub/       -> 200 (1st try)  "WHMCS"               (client portal intact)
```

(`--no-sandbox` + opt-in `IGNORE_HTTPS=1` for sandboxed local Chromium that lacks a CA store; CI keeps cert validation on.)

Refs #139, #29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)