### PR TITLE
fix(ci): resolve link-rot report — pin whmcs.community bot-block false positive

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -110,6 +110,12 @@ https://zeffy.com/**
 # privacy.microsoft.com / microsoft.com/nonprofits, already pinned). Real URL.
 https://techcommunity.microsoft.com/**
 
+# WHMCS Community forum sits behind Cloudflare bot protection that 403s
+# GitHub Actions runner IPs while staying reachable in browsers (verified
+# 200 with a normal UA). Linked from the web-developer training guide.
+https://whmcs.community/
+https://whmcs.community/**
+
 # Microsoft privacy statement 403s on bots; the canonical /en-us/ variant is what users get redirected to
 https://privacy.microsoft.com/privacystatement
 https://privacy.microsoft.com/**


### PR DESCRIPTION
## Summary

Resolves the weekly Lychee link-rot report in #283. I reviewed every entry from the [flagged workflow run](https://github.com/FreeForCharity/FFC-IN-freeforcharity.org/actions/runs/27539121317) and found **no genuinely broken links** — only one outstanding bot-block false positive.

### What the run actually reported
- **2 errors (403 Forbidden):**
  - `https://help.candid.org/s/article/How-to-Earn-a-Platinum-Seal-of-Transparency` — **already excluded** in `.lycheeignore` (`https://help.candid.org/**`, added after this issue was filed). No action needed.
  - `https://whmcs.community/` — **the one remaining cause.** Verified it returns **HTTP 200** with a normal browser user agent; the 403 is Cloudflare bot protection rejecting GitHub Actions runner IPs, identical to hosts already pinned (guidestar.org, techcommunity.microsoft.com, g2.com, zeffy.com, …).
- **22 "broken" entries:** all were `3xx` redirects resolving to a final `200`. The workflow accepts these (`--accept 200,206,301,302,307,308`), so they never failed CI and no source link is dead.

### Change
Pin `https://whmcs.community/` in `.lycheeignore` under the existing bot-block section, following the issue's own step 3 ("Add persistent false-positives to `.lycheeignore`") and the file's established two-line (`/` + `/**`) convention.

```
# WHMCS Community forum sits behind Cloudflare bot protection that 403s
# GitHub Actions runner IPs while staying reachable in browsers (verified
# 200 with a normal UA). Linked from the web-developer training guide.
https://whmcs.community/
https://whmcs.community/**
```

### Verification
- `curl` to `https://whmcs.community/` → `200` with a browser UA (live, not dead).
- Source confirmed: the link lives in `src/components/free-for-charity-ffc-web-developer-training-guide-components/Hero/index.tsx:209` and is correct as written.
- Config-only change (no source/TypeScript touched), so lint/build/test outputs are unaffected.

Fixes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014W4FydyhP3fnKxSYJMG5eP)_