### PR TITLE
test: complete Jest render + a11y coverage for all components and pages (#19)

### DIFF
--- a/__tests__/app/page-render.test.tsx
+++ b/__tests__/app/page-render.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { render } from '@testing-library/react'
+import { axe } from '../utils/axe'
 
 /**
  * Page render smoke tests.
@@ -97,4 +98,23 @@ describe('Page render smoke tests', () => {
     const { container } = render(<Page />)
     expect(container).not.toBeEmptyDOMElement()
   })
+})
+
+describe('Page accessibility (jest-axe)', () => {
+  // Renders each route's composed page and asserts no axe violations using
+  // the shared fragment config (page-context-only rules disabled, since the
+  // layout's <main>/header/footer are not part of the page component).
+  // Catches cross-component issues a single-component test can't, e.g.
+  // duplicate ids when two sections collide on the same page. Full-page
+  // a11y against the built site is additionally covered in
+  // tests/accessibility.spec.ts (Playwright, real browser).
+  it.each(pages)(
+    '%s has no axe violations',
+    async (_name, Page) => {
+      const { container } = render(<Page />)
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    },
+    30000
+  )
 })

--- a/__tests__/components/all-sections.test.tsx
+++ b/__tests__/components/all-sections.test.tsx
@@ -9,7 +9,7 @@ import { axe } from '../utils/axe'
  * page-section components). The suite asserts the component mounts and
  * produces DOM, then runs the shared fragment-axe config to catch real
  * accessibility regressions. ui/* primitives that require props are
- * covered separately in ui-components.test.tsx.
+ * covered separately in ui/ui-batch-{1,2,3}.test.tsx.
  *
  * Keep this list in sync with the .tsx files under src/components
  * (excluding src/components/ui) when components are added or removed.

--- a/__tests__/components/all-sections.test.tsx
+++ b/__tests__/components/all-sections.test.tsx
@@ -1,0 +1,267 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { axe } from '../utils/axe'
+
+/**
+ * Render + accessibility coverage for every non-ui (section) component.
+ *
+ * Each entry is required lazily and rendered with no props (these are
+ * page-section components). The suite asserts the component mounts and
+ * produces DOM, then runs the shared fragment-axe config to catch real
+ * accessibility regressions. ui/* primitives that require props are
+ * covered separately in ui-components.test.tsx.
+ *
+ * Keep this list in sync with the .tsx files under src/components
+ * (excluding src/components/ui) when components are added or removed.
+ */
+const sectionComponents: [string, string][] = [
+  [
+    '501c3-components/Help-For-Charities-and-Nonprofit',
+    '../../src/components/501c3-components/Help-For-Charities-and-Nonprofit/index',
+  ],
+  [
+    '501c3-components/Ready-to-get-started-and-faqs',
+    '../../src/components/501c3-components/Ready-to-get-started-and-faqs/index',
+  ],
+  [
+    'about-us-components/CallToAction',
+    '../../src/components/about-us-components/CallToAction/index',
+  ],
+  [
+    'about-us-components/Card-section',
+    '../../src/components/about-us-components/Card-section/index',
+  ],
+  ['about-us-components/ParaText', '../../src/components/about-us-components/ParaText/index'],
+  ['about-us-components/content', '../../src/components/about-us-components/content/index'],
+  [
+    'charity-validation-guide-ensuring-mutual-benefit-through-comprehensive-validation-processes-components/Hero',
+    '../../src/components/charity-validation-guide-ensuring-mutual-benefit-through-comprehensive-validation-processes-components/Hero/index',
+  ],
+  [
+    'contact-us-components/Contact-Us',
+    '../../src/components/contact-us-components/Contact-Us/index',
+  ],
+  ['cookie-consent', '../../src/components/cookie-consent/index'],
+  ['domains/Cards-Section', '../../src/components/domains/Cards-Section/index'],
+  ['domains/Curved-Black-Section', '../../src/components/domains/Curved-Black-Section/index'],
+  ['domains/Curved-Blue-Section', '../../src/components/domains/Curved-Blue-Section/index'],
+  ['domains/Dear-Prospective', '../../src/components/domains/Dear-Prospective/index'],
+  ['domains/Get-New-Website', '../../src/components/domains/Get-New-Website/index'],
+  ['domains/Hero', '../../src/components/domains/Hero/index'],
+  ['domains/Order-Your-Domain', '../../src/components/domains/Order-Your-Domain/index'],
+  ['domains/Seperater', '../../src/components/domains/Seperater/index'],
+  ['domains/Setup-Email-Hosting', '../../src/components/domains/Setup-Email-Hosting/index'],
+  ['domains/Verify-Your-Domain', '../../src/components/domains/Verify-Your-Domain/index'],
+  [
+    'donate-components/Free-for-Charity-Donation-Options',
+    '../../src/components/donate-components/Free-for-Charity-Donation-Options/index',
+  ],
+  [
+    'donate-components/General-donation',
+    '../../src/components/donate-components/General-donation/index',
+  ],
+  [
+    'donate-components/measurable-impact',
+    '../../src/components/donate-components/measurable-impact/index',
+  ],
+  [
+    'ffc-volunteer-proving-ground-core-competencies/ContentSection',
+    '../../src/components/ffc-volunteer-proving-ground-core-competencies/ContentSection/index',
+  ],
+  [
+    'ffc-volunteer-proving-ground-core-competencies/Footer',
+    '../../src/components/ffc-volunteer-proving-ground-core-competencies/Footer/index',
+  ],
+  [
+    'ffc-volunteer-proving-ground-core-competencies/Header',
+    '../../src/components/ffc-volunteer-proving-ground-core-competencies/Header/index',
+  ],
+  [
+    'ffc-volunteer-proving-ground-core-competencies/Modules-section',
+    '../../src/components/ffc-volunteer-proving-ground-core-competencies/Modules-section/index',
+  ],
+  ['footer', '../../src/components/footer/index'],
+  [
+    'free-charity-web-hosting/About-FFC-Hosting',
+    '../../src/components/free-charity-web-hosting/About-FFC-Hosting/index',
+  ],
+  [
+    'free-charity-web-hosting/BecomePartOfOurMission',
+    '../../src/components/free-charity-web-hosting/BecomePartOfOurMission/index',
+  ],
+  [
+    'free-charity-web-hosting/ClientTestimonials',
+    '../../src/components/free-charity-web-hosting/ClientTestimonials/index',
+  ],
+  ['free-charity-web-hosting/FAQs', '../../src/components/free-charity-web-hosting/FAQs/index'],
+  ['free-charity-web-hosting/Hero', '../../src/components/free-charity-web-hosting/Hero/index'],
+  [
+    'free-charity-web-hosting/ReadyToGetStarted',
+    '../../src/components/free-charity-web-hosting/ReadyToGetStarted/index',
+  ],
+  [
+    'free-charity-web-hosting/ThreeCards',
+    '../../src/components/free-charity-web-hosting/ThreeCards/index',
+  ],
+  [
+    'free-charity-web-hosting/hosting',
+    '../../src/components/free-charity-web-hosting/hosting/index',
+  ],
+  [
+    'free-for-charity-endowment-fund-components/Empower-Charities',
+    '../../src/components/free-for-charity-endowment-fund-components/Empower-Charities/index',
+  ],
+  [
+    'free-for-charity-endowment-fund-components/Empowering-Charities',
+    '../../src/components/free-for-charity-endowment-fund-components/Empowering-Charities/index',
+  ],
+  [
+    'free-for-charity-endowment-fund-components/Endowment-Features',
+    '../../src/components/free-for-charity-endowment-fund-components/Endowment-Features/index',
+  ],
+  [
+    'free-for-charity-endowment-fund-components/Hero',
+    '../../src/components/free-for-charity-endowment-fund-components/Hero/index',
+  ],
+  [
+    'free-for-charity-endowment-fund-components/Our-Mission',
+    '../../src/components/free-for-charity-endowment-fund-components/Our-Mission/index',
+  ],
+  [
+    'free-for-charity-endowment-fund-components/Support-Our-Mission',
+    '../../src/components/free-for-charity-endowment-fund-components/Support-Our-Mission/index',
+  ],
+  [
+    'free-for-charity-endowment-fund-components/Text-Section',
+    '../../src/components/free-for-charity-endowment-fund-components/Text-Section/index',
+  ],
+  [
+    'free-for-charity-endowment-fund-components/Voices-of-Gratitude',
+    '../../src/components/free-for-charity-endowment-fund-components/Voices-of-Gratitude/index',
+  ],
+  [
+    'free-for-charity-ffc-service-delivery-stages-components/Hero',
+    '../../src/components/free-for-charity-ffc-service-delivery-stages-components/Hero/index',
+  ],
+  [
+    'free-for-charity-ffc-web-developer-training-guide-components/Hero',
+    '../../src/components/free-for-charity-ffc-web-developer-training-guide-components/Hero/index',
+  ],
+  [
+    'free-for-charitys-tools-for-success-components/Card-section',
+    '../../src/components/free-for-charitys-tools-for-success-components/Card-section/index',
+  ],
+  [
+    'free-for-charitys-tools-for-success-components/Educational-Sites',
+    '../../src/components/free-for-charitys-tools-for-success-components/Educational-Sites/index',
+  ],
+  [
+    'free-for-charitys-tools-for-success-components/Five-Cards-Grid-Section',
+    '../../src/components/free-for-charitys-tools-for-success-components/Five-Cards-Grid-Section/index',
+  ],
+  [
+    'free-for-charitys-tools-for-success-components/Rescue-Time',
+    '../../src/components/free-for-charitys-tools-for-success-components/Rescue-Time/index',
+  ],
+  [
+    'free-for-charitys-tools-for-success-components/Six-Grid-Cards',
+    '../../src/components/free-for-charitys-tools-for-success-components/Six-Grid-Cards/index',
+  ],
+  [
+    'free-for-charitys-tools-for-success-components/Tools-For-Businesses',
+    '../../src/components/free-for-charitys-tools-for-success-components/Tools-For-Businesses/index',
+  ],
+  [
+    'free-for-charitys-tools-for-success-components/Two-Cards-With-Heading',
+    '../../src/components/free-for-charitys-tools-for-success-components/Two-Cards-With-Heading/index',
+  ],
+  [
+    'free-for-charitys-tools-for-success-components/Two-Cards',
+    '../../src/components/free-for-charitys-tools-for-success-components/Two-Cards/index',
+  ],
+  [
+    'free-for-charitys-tools-for-success-components/Two-Flex-Cards',
+    '../../src/components/free-for-charitys-tools-for-success-components/Two-Flex-Cards/index',
+  ],
+  [
+    'free-training-programs-components/faq-section',
+    '../../src/components/free-training-programs-components/faq-section',
+  ],
+  ['guidestar-guide/Faqs', '../../src/components/guidestar-guide/Faqs/index'],
+  [
+    'guidestar-guide/Free-for-charity',
+    '../../src/components/guidestar-guide/Free-for-charity/index',
+  ],
+  ['header', '../../src/components/header/index'],
+  [
+    'help-for-charities-components/AccordianSection',
+    '../../src/components/help-for-charities-components/AccordianSection/index',
+  ],
+  [
+    'help-for-charities-components/Charity-Nonprofit-Director-Faq',
+    '../../src/components/help-for-charities-components/Charity-Nonprofit-Director-Faq/index',
+  ],
+  [
+    'help-for-charities-components/Ready-to-Get-Started-Now',
+    '../../src/components/help-for-charities-components/Ready-to-Get-Started-Now/index',
+  ],
+  [
+    'help-for-charities-components/call-section',
+    '../../src/components/help-for-charities-components/call-section/index',
+  ],
+  ['home-page/Endowment-Features', '../../src/components/home-page/Endowment-Features/index'],
+  [
+    'home-page/FrequentlyAskedQuestions',
+    '../../src/components/home-page/FrequentlyAskedQuestions/index',
+  ],
+  ['home-page/Hero', '../../src/components/home-page/Hero/index'],
+  ['home-page/Mission', '../../src/components/home-page/Mission/index'],
+  ['home-page/Our-Programs', '../../src/components/home-page/Our-Programs/index'],
+  ['home-page/Results-2023', '../../src/components/home-page/Results-2023/index'],
+  ['home-page/SupportFreeForCharity', '../../src/components/home-page/SupportFreeForCharity/index'],
+  ['home-page/TheFreeForCharityTeam', '../../src/components/home-page/TheFreeForCharityTeam/index'],
+  ['home-page/VoicesofGratitude', '../../src/components/home-page/VoicesofGratitude/index'],
+  ['home-page/Volunteer-with-Us', '../../src/components/home-page/Volunteer-with-Us/index'],
+  ['home/Contactus', '../../src/components/home/Contactus/index'],
+  ['home/HeroSection', '../../src/components/home/HeroSection/index'],
+  ['home/MissionSection', '../../src/components/home/MissionSection/index'],
+  ['home/Ourblogs', '../../src/components/home/Ourblogs/index'],
+  ['home/SupportFreeforCharity', '../../src/components/home/SupportFreeforCharity/index'],
+  ['home/Testimonials', '../../src/components/home/Testimonials/index'],
+  [
+    'online-impacts-onboarding-guide-components/Ready-To-Get-Started-Now',
+    '../../src/components/online-impacts-onboarding-guide-components/Ready-To-Get-Started-Now/index',
+  ],
+  [
+    'online-impacts-onboarding-guide-components/charity-text',
+    '../../src/components/online-impacts-onboarding-guide-components/charity-text/index',
+  ],
+  ['pre501c3-components/Faqs', '../../src/components/pre501c3-components/Faqs/index'],
+  ['pre501c3-components/charity', '../../src/components/pre501c3-components/charity/index'],
+  ['sentry-init', '../../src/components/sentry-init/index'],
+  ['techstack-components/Hero', '../../src/components/techstack-components/Hero/index'],
+  ['volunteer/Free-For-Charity', '../../src/components/volunteer/Free-For-Charity/index'],
+]
+
+// Side-effect-only components that intentionally render no DOM (they exist
+// to run an effect, e.g. analytics/error-tracking init). They must still
+// mount without throwing, but are exempt from the non-empty-DOM assertion.
+const rendersNull = new Set(['sentry-init'])
+
+describe('Section components — render + a11y', () => {
+  it.each(sectionComponents)(
+    '%s renders and has no axe violations',
+    async (name, reqPath) => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const mod = require(reqPath)
+      const Component = (mod.default ?? mod) as React.ComponentType
+      const { container } = render(<Component />)
+      if (!rendersNull.has(name)) {
+        expect(container).not.toBeEmptyDOMElement()
+      }
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    },
+    30000
+  )
+})

--- a/__tests__/components/ui/ui-batch-1.test.tsx
+++ b/__tests__/components/ui/ui-batch-1.test.tsx
@@ -1,0 +1,132 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { axe } from '../../utils/axe'
+
+import Accordian from '@/components/ui/Accordian'
+import AccordianBold from '@/components/ui/AccordianBold'
+import AnimatedNumber from '@/components/ui/AnimatedNumber'
+import BecomePartOfOurMissionCard from '@/components/ui/BecomePartOfOurMissionCard'
+import BlogCard from '@/components/ui/BlogCard'
+import Bluebtn from '@/components/ui/Bluebtn'
+import CallToActionCard from '@/components/ui/CallToActionCard'
+import CharityNonprofitDirectorFaq from '@/components/ui/Charity-Nonprofit-Director-Faq'
+import ContactDataCard from '@/components/ui/Contact-data-card'
+
+describe('Accordian', () => {
+  it('renders and has no a11y violations', async () => {
+    const { container } = render(
+      <Accordian number="1" title="What is Free For Charity?">
+        We provide free websites for nonprofits.
+      </Accordian>
+    )
+    expect(container).not.toBeEmptyDOMElement()
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  }, 30000)
+})
+
+describe('AccordianBold', () => {
+  it('renders and has no a11y violations', async () => {
+    const { container } = render(
+      <AccordianBold number="1" title="How do we qualify?">
+        Your organization must be a registered 501(c)(3).
+      </AccordianBold>
+    )
+    expect(container).not.toBeEmptyDOMElement()
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  }, 30000)
+})
+
+describe('AnimatedNumber', () => {
+  it('renders and has no a11y violations', async () => {
+    const { container } = render(<AnimatedNumber value={1500} />)
+    expect(container).not.toBeEmptyDOMElement()
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  }, 30000)
+})
+
+describe('BecomePartOfOurMissionCard', () => {
+  it('renders and has no a11y violations', async () => {
+    const { container } = render(
+      <BecomePartOfOurMissionCard
+        bgImage="/images/mission-bg.jpg"
+        heading="Become Part Of Our Mission"
+        description1="Help us provide free websites to nonprofits."
+        description2="Join our community of volunteers today."
+        buttonText="Get Involved"
+        buttonLink="/get-involved"
+      />
+    )
+    expect(container).not.toBeEmptyDOMElement()
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  }, 30000)
+})
+
+describe('BlogCard', () => {
+  it('renders and has no a11y violations', async () => {
+    const { container } = render(
+      <BlogCard
+        imageUrl="/images/blog-post.jpg"
+        heading="How Nonprofits Save Money With FFC"
+        date="June 26, 2026"
+        description="A look at the services Free For Charity offers to nonprofits."
+        href="/blog/save-money"
+      />
+    )
+    expect(container).not.toBeEmptyDOMElement()
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  }, 30000)
+})
+
+describe('Bluebtn', () => {
+  it('renders and has no a11y violations', async () => {
+    const { container } = render(<Bluebtn href="/learn-more">Learn More</Bluebtn>)
+    expect(container).not.toBeEmptyDOMElement()
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  }, 30000)
+})
+
+describe('CallToActionCard', () => {
+  it('renders and has no a11y violations', async () => {
+    const { container } = render(
+      <CallToActionCard
+        icon={<span>icon</span>}
+        iconLabel="Free websites"
+        text="Free Websites For Nonprofits"
+        href="/services"
+      />
+    )
+    expect(container).not.toBeEmptyDOMElement()
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  }, 30000)
+})
+
+describe('Charity-Nonprofit-Director-Faq', () => {
+  it('renders and has no a11y violations', async () => {
+    const { container } = render(<CharityNonprofitDirectorFaq />)
+    expect(container).not.toBeEmptyDOMElement()
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  }, 30000)
+})
+
+describe('Contact-data-card', () => {
+  it('renders and has no a11y violations', async () => {
+    const { container } = render(
+      <ContactDataCard
+        imageSrc="/images/location-pin.svg"
+        heading="Main Address"
+        description={'4030 Wake Forest Road STE 349 Raleigh\nNorth Carolina 27609'}
+      />
+    )
+    expect(container).not.toBeEmptyDOMElement()
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  }, 30000)
+})

--- a/__tests__/components/ui/ui-batch-2.test.tsx
+++ b/__tests__/components/ui/ui-batch-2.test.tsx
@@ -1,0 +1,149 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { axe } from '../../utils/axe'
+
+import DomainCard from '@/components/ui/Domain-Card'
+import EducationalSitesCard from '@/components/ui/EducationalSitesCard'
+import FrequentlyAskedQuestions from '@/components/ui/Frequently-Asked-Questions'
+import GeneralDonationCard from '@/components/ui/General-Donation-Card'
+import HeroSection from '@/components/ui/HeroSection'
+import ModuleCard from '@/components/ui/Module-card'
+import OrangeFaqItem from '@/components/ui/OrangeFaqItem'
+import ProgressBar from '@/components/ui/ProgressBar'
+import ProvingGroundSection from '@/components/ui/ProvingGroundSection'
+import ResultCard from '@/components/ui/ResultCard'
+
+describe('UI batch 2 components', () => {
+  describe('Domain-Card (StepCard)', () => {
+    it('renders and has no accessibility violations', async () => {
+      const { container } = render(
+        <DomainCard
+          imageSrc="/Images/step.webp"
+          imageAlt="Domain setup step icon"
+          text="Register your nonprofit domain for free."
+        />
+      )
+      expect(container).not.toBeEmptyDOMElement()
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    }, 30000)
+  })
+
+  describe('EducationalSitesCard', () => {
+    it('renders and has no accessibility violations', async () => {
+      const { container } = render(
+        <EducationalSitesCard
+          imageSrc="/Images/educational-site.webp"
+          title="Great resource for small nonprofits"
+          link="https://example.org"
+        />
+      )
+      expect(container).not.toBeEmptyDOMElement()
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    }, 30000)
+  })
+
+  describe('Frequently-Asked-Questions', () => {
+    it('renders and has no accessibility violations', async () => {
+      const { container } = render(
+        <FrequentlyAskedQuestions title="How do I qualify for a free website?">
+          <p>Your organization must be a registered 501(c)(3) nonprofit.</p>
+        </FrequentlyAskedQuestions>
+      )
+      expect(container).not.toBeEmptyDOMElement()
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    }, 30000)
+  })
+
+  describe('General-Donation-Card', () => {
+    it('renders and has no accessibility violations', async () => {
+      const { container } = render(
+        <GeneralDonationCard
+          title="Donate Today"
+          description="Support nonprofits with your contribution."
+          img="/Images/donate.webp"
+          href="https://example.org/donate"
+        />
+      )
+      expect(container).not.toBeEmptyDOMElement()
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    }, 30000)
+  })
+
+  describe('HeroSection', () => {
+    it('renders and has no accessibility violations', async () => {
+      const { container } = render(
+        <HeroSection
+          heading="Free For Charity"
+          paragraph="Free websites and domain management for nonprofits."
+          heroImg="/Images/hero.webp"
+        />
+      )
+      expect(container).not.toBeEmptyDOMElement()
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    }, 30000)
+  })
+
+  describe('Module-card', () => {
+    it('renders and has no accessibility violations', async () => {
+      const { container } = render(
+        <ModuleCard title="Getting Started" id="module-getting-started">
+          <p>Learn how to set up your nonprofit website.</p>
+        </ModuleCard>
+      )
+      expect(container).not.toBeEmptyDOMElement()
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    }, 30000)
+  })
+
+  describe('OrangeFaqItem (AccordionItem)', () => {
+    it('renders and has no accessibility violations', async () => {
+      const { container } = render(
+        <OrangeFaqItem title="What does Free For Charity offer?">
+          <p>We provide free websites and domain management.</p>
+        </OrangeFaqItem>
+      )
+      expect(container).not.toBeEmptyDOMElement()
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    }, 30000)
+  })
+
+  describe('ProgressBar', () => {
+    it('renders and has no accessibility violations', async () => {
+      const { container } = render(<ProgressBar title="Fundraising Goal" percentage={75} />)
+      expect(container).not.toBeEmptyDOMElement()
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    }, 30000)
+  })
+
+  describe('ProvingGroundSection', () => {
+    it('renders and has no accessibility violations', async () => {
+      const { container } = render(
+        <ProvingGroundSection title="Our Proving Ground">
+          <p>See how we have helped nonprofits succeed.</p>
+        </ProvingGroundSection>
+      )
+      expect(container).not.toBeEmptyDOMElement()
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    }, 30000)
+  })
+
+  describe('ResultCard', () => {
+    it('renders and has no accessibility violations', async () => {
+      const { container } = render(
+        <ResultCard title="500" description="Nonprofits served and counting." />
+      )
+      expect(container).not.toBeEmptyDOMElement()
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    }, 30000)
+  })
+})

--- a/__tests__/components/ui/ui-batch-3.test.tsx
+++ b/__tests__/components/ui/ui-batch-3.test.tsx
@@ -1,0 +1,161 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { axe } from '../../utils/axe'
+
+import SlidingCard from '@/components/ui/SlidingCard'
+import StepCard from '@/components/ui/StepCard'
+import StepContentCard from '@/components/ui/StepContentCard'
+import { SustainableFundingCard } from '@/components/ui/SustainableFundingCard'
+import TeamMemberCard from '@/components/ui/TeamMemberCard'
+import ToolCard from '@/components/ui/ToolCard'
+import Transparentbtn from '@/components/ui/Transparentbtn'
+import InfoSection from '@/components/ui/help-for-charity'
+import TrainingCard from '@/components/ui/trainingcard'
+
+describe('SlidingCard', () => {
+  it('renders and has no a11y violations', async () => {
+    const { container } = render(
+      <SlidingCard
+        subtitle="Build your nonprofit website"
+        description={<p>We provide free websites for 501(c)(3) organizations.</p>}
+        buttonText="Learn more"
+        buttonLink="https://example.org"
+        imageSrc="/Images/example.webp"
+      />
+    )
+    expect(container).not.toBeEmptyDOMElement()
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  }, 30000)
+})
+
+describe('StepCard', () => {
+  it('renders and has no a11y violations', async () => {
+    const { container } = render(
+      <StepCard
+        step={{
+          number: 1,
+          title: 'Apply',
+          description: 'Submit your application for a free website.',
+          linkText: 'Get started',
+          innerbg: 'bg-blue-500',
+          outerbg: 'bg-white',
+          linkUrl: 'https://example.org',
+        }}
+      />
+    )
+    expect(container).not.toBeEmptyDOMElement()
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  }, 30000)
+})
+
+describe('StepContentCard', () => {
+  it('renders and has no a11y violations', async () => {
+    const { container } = render(
+      <StepContentCard title="How it works" id="how-it-works">
+        <p>Follow these steps to get your free website.</p>
+      </StepContentCard>
+    )
+    expect(container).not.toBeEmptyDOMElement()
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  }, 30000)
+})
+
+describe('SustainableFundingCard', () => {
+  it('renders and has no a11y violations', async () => {
+    const { container } = render(
+      <SustainableFundingCard
+        imageUrl="/Images/funding.webp"
+        title="Sustainable funding"
+        text="Keep your nonprofit running with sustainable funding strategies."
+      />
+    )
+    expect(container).not.toBeEmptyDOMElement()
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  }, 30000)
+})
+
+describe('TeamMemberCard', () => {
+  it('renders and has no a11y violations', async () => {
+    const { container } = render(
+      <TeamMemberCard
+        imageUrl="/Images/member.webp"
+        name="Jane Doe"
+        title="Executive Director"
+        linkedinUrl="https://linkedin.com/in/janedoe"
+      />
+    )
+    expect(container).not.toBeEmptyDOMElement()
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  }, 30000)
+})
+
+describe('ToolCard', () => {
+  it('renders and has no a11y violations', async () => {
+    const { container } = render(
+      <ToolCard
+        logo="/Images/logo.webp"
+        title="Google Workspace"
+        description="Free productivity tools for your nonprofit."
+        link="https://example.org"
+      />
+    )
+    expect(container).not.toBeEmptyDOMElement()
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  }, 30000)
+})
+
+describe('Transparentbtn', () => {
+  it('renders and has no a11y violations', async () => {
+    const { container } = render(<Transparentbtn text="Donate now" href="https://example.org" />)
+    expect(container).not.toBeEmptyDOMElement()
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  }, 30000)
+})
+
+describe('InfoSection (help-for-charity)', () => {
+  it('renders with a non-empty title and has no a11y violations', async () => {
+    const { container } = render(
+      <InfoSection
+        title="How we help charities"
+        description="Free For Charity provides free websites and domain management."
+      />
+    )
+    expect(container).not.toBeEmptyDOMElement()
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  }, 30000)
+
+  it('renders with an empty title without an empty-heading violation', async () => {
+    const { container } = render(
+      <InfoSection
+        title=""
+        description="Free For Charity provides free websites and domain management."
+      />
+    )
+    expect(container).not.toBeEmptyDOMElement()
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  }, 30000)
+})
+
+describe('TrainingCard', () => {
+  it('renders and has no a11y violations', async () => {
+    const { container } = render(
+      <TrainingCard
+        src="/Images/training.webp"
+        heading="Onboarding training"
+        text="Learn how to manage your nonprofit website."
+      />
+    )
+    expect(container).not.toBeEmptyDOMElement()
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  }, 30000)
+})

--- a/__tests__/utils/axe.ts
+++ b/__tests__/utils/axe.ts
@@ -1,0 +1,26 @@
+import { configureAxe } from 'jest-axe'
+
+/**
+ * Shared axe runner for component-level (fragment) accessibility tests.
+ *
+ * Components are rendered in isolation, outside the page <main>/landmark
+ * structure that src/app/layout.tsx provides. A few axe rules only make
+ * sense for a complete document and produce false positives against an
+ * isolated fragment:
+ *   - region / landmark-one-main: a fragment has no page landmarks.
+ *   - page-has-heading-one: a section legitimately starts at <h2>.
+ *   - heading-order: a section's first heading need not be <h1> in context.
+ *
+ * Everything else (alt text, form labels, ARIA validity, empty headings,
+ * duplicate ids, color where computable, etc.) stays enabled, so real
+ * accessibility regressions still fail the test. Full-page a11y is also
+ * covered against the built site in tests/accessibility.spec.ts (Playwright).
+ */
+export const axe = configureAxe({
+  rules: {
+    region: { enabled: false },
+    'landmark-one-main': { enabled: false },
+    'page-has-heading-one': { enabled: false },
+    'heading-order': { enabled: false },
+  },
+})

--- a/src/components/ui/help-for-charity.tsx
+++ b/src/components/ui/help-for-charity.tsx
@@ -18,9 +18,11 @@ const InfoSection: React.FC<SectionProps> = ({
   return (
     <div style={{ backgroundColor: bg }}>
       <div className="py-[0px]">
-        <h1 className={`text-[#b35000] text-[28px] font-[700] mb-[15px] text-${titleAlign}`}>
-          {title}
-        </h1>
+        {title && (
+          <h1 className={`text-[#b35000] text-[28px] font-[700] mb-[15px] text-${titleAlign}`}>
+            {title}
+          </h1>
+        )}
         <p className={`text-[18px] font-[500] text-black text-${descriptionAlign}`} id="lato-font">
           {description}
         </p>

--- a/src/components/ui/help-for-charity.tsx
+++ b/src/components/ui/help-for-charity.tsx
@@ -18,7 +18,7 @@ const InfoSection: React.FC<SectionProps> = ({
   return (
     <div style={{ backgroundColor: bg }}>
       <div className="py-[0px]">
-        {title && (
+        {title.trim() && (
           <h1 className={`text-[#b35000] text-[28px] font-[700] mb-[15px] text-${titleAlign}`}>
             {title}
           </h1>


### PR DESCRIPTION
## Summary

Completes the Jest unit-testing work for **#19** — render + accessibility coverage for **every** component and **every** page.

### What's added
| Suite | Covers |
|---|---|
| `__tests__/components/all-sections.test.tsx` | All **85** non-`ui` (section) components — render + jest-axe |
| `__tests__/components/ui/ui-batch-{1,2,3}.test.tsx` | All **28** `ui` primitives — render + jest-axe, each with representative props |
| `__tests__/app/page-render.test.tsx` | Adds a **jest-axe pass over all 35 route pages** (on top of the render smoke tests) |
| `__tests__/utils/axe.ts` | Shared jest-axe config (see below) |

### Results
- **Jest: 359 passing** (20 suites), up from 210.
- **Statement coverage ~84%** (was well under threshold before).
- Lint clean (0 errors), build green.

### Shared axe config
Components are rendered in isolation, outside the layout's `<main>`/landmark structure. `__tests__/utils/axe.ts` disables the few **page-context-only** rules that false-positive on a fragment (`region`, `landmark-one-main`, `page-has-heading-one`, `heading-order`) while keeping every real rule enabled (alt text, labels, ARIA validity, empty headings, duplicate ids, …). Full-page a11y against the *built* site remains covered by `tests/accessibility.spec.ts` (Playwright, real browser).

### Real accessibility fix found
- **`src/components/ui/help-for-charity.tsx`** rendered an empty `<h1>` when passed an empty `title` (used that way on the pre-501c3 page), tripping axe's `empty-heading` rule. The heading is now only rendered when a title is provided.

### Notes
- A global `IntersectionObserver`/`ResizeObserver` mock (added in the previous PR) is what lets these animation-driven components render under jsdom.
- The 85-component section suite is parametrized and self-documenting so it stays in sync as components are added.

Refs #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014W4FydyhP3fnKxSYJMG5eP)_