### PR TITLE
refactor: replace duplicate id font-hooks with data-font attributes (#305)

### DIFF
--- a/src/app/charity-and-nonprofit-case-studies/page.tsx
+++ b/src/app/charity-and-nonprofit-case-studies/page.tsx
@@ -40,7 +40,7 @@ const CaseStudiesPage = () => {
       {/* Intro */}
       <section className="py-[60px] bg-[#fcfcfc]">
         <div className="w-[90%] md:w-[80%] max-w-[900px] mx-auto">
-          <div className="space-y-6 mb-12" id="lato-font">
+          <div className="space-y-6 mb-12" data-font="lato-font">
             <p className="text-[18px] font-[500] leading-[28px] text-[#333]">
               A nonprofit organization is the coming together of some groups of people for a purpose
               other than generating profit. And no part of the management income is shared or
@@ -74,7 +74,10 @@ const CaseStudiesPage = () => {
             <h2 className="text-[24px] md:text-[30px] font-[700] leading-[36px] text-[#b35000] mb-4">
               What Case Studies Cover
             </h2>
-            <p className="text-[18px] font-[500] leading-[28px] text-[#333] mb-6" id="lato-font">
+            <p
+              className="text-[18px] font-[500] leading-[28px] text-[#333] mb-6"
+              data-font="lato-font"
+            >
               What is a charity case study? It is a set of skills-based volunteer studies to answer
               the numerous questions people might have, accomplished by looking at real-life
               examples.
@@ -87,7 +90,7 @@ const CaseStudiesPage = () => {
                   className="flex items-center gap-3 p-3 bg-white rounded-[10px] shadow-[0px_2px_12px_0px_rgba(0,0,0,0.05)]"
                 >
                   <div className="w-2 h-2 bg-[#b35000] rounded-full flex-shrink-0" />
-                  <p className="text-[16px] font-[500] text-[#333]" id="lato-font">
+                  <p className="text-[16px] font-[500] text-[#333]" data-font="lato-font">
                     {topic}
                   </p>
                 </div>
@@ -96,7 +99,7 @@ const CaseStudiesPage = () => {
           </div>
 
           {/* Why Case Studies */}
-          <div className="space-y-6" id="lato-font">
+          <div className="space-y-6" data-font="lato-font">
             <p className="text-[18px] font-[500] leading-[28px] text-[#333]">
               You will not want to keep experimenting with the resources of your organization. You
               might end up getting what works but in most cases you might end up wasting your
@@ -124,14 +127,17 @@ const CaseStudiesPage = () => {
           <h2 className="text-[28px] md:text-[36px] font-[700] text-white leading-[40px] mb-4">
             Have a Case Study Request?
           </h2>
-          <p className="text-[18px] text-white font-[500] leading-[28px] mb-6" id="lato-font">
+          <p
+            className="text-[18px] text-white font-[500] leading-[28px] mb-6"
+            data-font="lato-font"
+          >
             Contact us if you have a particular case study request or want to be featured in a case
             study.
           </p>
           <a
             href="/contact-us/"
             className="inline-block px-[30px] py-[10px] text-white border border-[#b35000] rounded-[10px] text-[18px] bg-[#b35000] font-[600] shadow-md hover:shadow-[0px_12px_18px_-6px_#b35000] transition-all duration-300"
-            id="montserrat-font"
+            data-font="montserrat-font"
           >
             Contact Us
           </a>

--- a/src/app/charity-and-nonprofit-service-and-consultant-directory/page.tsx
+++ b/src/app/charity-and-nonprofit-service-and-consultant-directory/page.tsx
@@ -47,7 +47,7 @@ const ServiceDirectoryPage = () => {
             ))}
           </div>
 
-          <div className="space-y-6" id="lato-font">
+          <div className="space-y-6" data-font="lato-font">
             <p className="text-[18px] font-[500] leading-[28px] text-[#333]">
               Every nonprofit organization needs help from time to time and there is no reason why
               they can&apos;t ask for it through the various services and consultants that are out
@@ -98,14 +98,17 @@ const ServiceDirectoryPage = () => {
           <h2 className="text-[28px] md:text-[36px] font-[700] text-white leading-[40px] mb-4">
             Want to Be Listed in the Directory?
           </h2>
-          <p className="text-[18px] text-white font-[500] leading-[28px] mb-6" id="lato-font">
+          <p
+            className="text-[18px] text-white font-[500] leading-[28px] mb-6"
+            data-font="lato-font"
+          >
             For more information about Free for Charity or to obtain information about being added
             to the directory, please contact us.
           </p>
           <a
             href="/contact-us/"
             className="inline-block px-[30px] py-[10px] text-white border border-[#b35000] rounded-[10px] text-[18px] bg-[#b35000] font-[600] shadow-md hover:shadow-[0px_12px_18px_-6px_#b35000] transition-all duration-300"
-            id="montserrat-font"
+            data-font="montserrat-font"
           >
             Contact Us
           </a>

--- a/src/app/charity-and-nonprofit-technology-directory/page.tsx
+++ b/src/app/charity-and-nonprofit-technology-directory/page.tsx
@@ -51,7 +51,7 @@ const TechDirectoryPage = () => {
             Charity Nonprofit Tech Directory
           </h2>
 
-          <div className="space-y-6 mb-12" id="lato-font">
+          <div className="space-y-6 mb-12" data-font="lato-font">
             <p className="text-[18px] font-[500] leading-[28px] text-[#333]">
               The Nonprofit technology directory will focus on the startup charity and will have a
               heavy preference for items that are open source or free. At the end of the day however
@@ -84,7 +84,7 @@ const TechDirectoryPage = () => {
                     <li
                       key={item}
                       className="text-[16px] font-[500] text-[#333] pl-4 border-l-2 border-[#b35000]"
-                      id="lato-font"
+                      data-font="lato-font"
                     >
                       {item}
                     </li>
@@ -102,7 +102,10 @@ const TechDirectoryPage = () => {
           <h2 className="text-[28px] md:text-[36px] font-[700] text-white leading-[40px] mb-4">
             Have Questions?
           </h2>
-          <p className="text-[18px] text-white font-[500] leading-[28px] mb-4" id="lato-font">
+          <p
+            className="text-[18px] text-white font-[500] leading-[28px] mb-4"
+            data-font="lato-font"
+          >
             Have questions about consultation or hosting? Want to know more about nonprofits? Give a
             real person a call:
           </p>
@@ -117,7 +120,7 @@ const TechDirectoryPage = () => {
           <a
             href="/contact-us/"
             className="inline-block px-[30px] py-[10px] text-white border border-[#b35000] rounded-[10px] text-[18px] bg-[#b35000] font-[600] shadow-md hover:shadow-[0px_12px_18px_-6px_#b35000] transition-all duration-300"
-            id="montserrat-font"
+            data-font="montserrat-font"
           >
             Contact Us
           </a>

--- a/src/app/consulting/page.tsx
+++ b/src/app/consulting/page.tsx
@@ -29,7 +29,7 @@ const ConsultingPage = () => {
 
           <p
             className="text-[18px] md:text-[20px] font-[500] leading-[28px] md:leading-[30px] text-[#333] mb-8"
-            id="lato-font"
+            data-font="lato-font"
           >
             Have questions about consultation services? Want to know more about nonprofits? Looking
             to chat? Give a real person a call for free:
@@ -50,13 +50,16 @@ const ConsultingPage = () => {
           <h2 className="text-[28px] md:text-[36px] font-[700] text-white leading-[40px] mb-4">
             Ready to Get Started?
           </h2>
-          <p className="text-[18px] text-white font-[500] leading-[28px] mb-6" id="lato-font">
+          <p
+            className="text-[18px] text-white font-[500] leading-[28px] mb-6"
+            data-font="lato-font"
+          >
             Reach out today and let us help your nonprofit succeed.
           </p>
           <a
             href="/contact-us/"
             className="inline-block px-[30px] py-[10px] text-white border border-[#b35000] rounded-[10px] text-[18px] bg-[#b35000] font-[600] shadow-md hover:shadow-[0px_12px_18px_-6px_#b35000] transition-all duration-300"
-            id="montserrat-font"
+            data-font="montserrat-font"
           >
             Contact Us
           </a>

--- a/src/app/cookie-policy/page.tsx
+++ b/src/app/cookie-policy/page.tsx
@@ -14,7 +14,7 @@ export default function CookiePolicy() {
   return (
     <div className="pt-[140px] pb-[54px]">
       <div className="py-[27px] w-[90%] md:w-[80%] mx-auto">
-        <div id="aria-font">
+        <div data-font="aria-font">
           <h1 className="text-[30px] text-[#333] pb-[10px] leading-[1em] font-[500]">
             <strong>Cookie Policy</strong>
           </h1>

--- a/src/app/ffc-volunteer-proving-ground-core-competencies/page.tsx
+++ b/src/app/ffc-volunteer-proving-ground-core-competencies/page.tsx
@@ -14,7 +14,7 @@ import Footer from '@/components/ffc-volunteer-proving-ground-core-competencies/
 
 const index = () => {
   return (
-    <div className="w-full pt-[150px]" id="segoe-font">
+    <div className="w-full pt-[150px]" data-font="segoe-font">
       <div className="w-full max-w-[90%] md:max-w-[80%] md:p-[2rem] mx-auto">
         <Header />
         <ContentSection />

--- a/src/app/ffcadmin-free-for-charity-cpanel-backup-sop/page.tsx
+++ b/src/app/ffcadmin-free-for-charity-cpanel-backup-sop/page.tsx
@@ -9,7 +9,10 @@ export const metadata: Metadata = {
 
 export default function CpanelBackupSop() {
   return (
-    <div className="lg:min-h-screen w-[90%] md:w-[80%] max-w-[1080px] mx-auto" id="aria-font">
+    <div
+      className="lg:min-h-screen w-[90%] md:w-[80%] max-w-[1080px] mx-auto"
+      data-font="aria-font"
+    >
       <div className="pt-[138px] pb-[60px]">
         <p className="text-[14px] font-[500] text-[#666] uppercase tracking-wider mb-[10px]">
           Internal SOP &mdash; FFC Admin

--- a/src/app/free-for-charity-donation-policy/page.tsx
+++ b/src/app/free-for-charity-donation-policy/page.tsx
@@ -12,7 +12,7 @@ const index = () => {
   return (
     <div className="pt-[140px]">
       <div className="py-[21px] w-[90%] md:w-[80%] mx-auto max-w-[1080px]">
-        <div id="aria-font">
+        <div data-font="aria-font">
           <h1 className="text-[30px] text-[#333] pb-[10px] leading-[30px] font-[500]">
             Free For Charity Donation Policy
           </h1>

--- a/src/app/free-for-charity-ffc-web-developer-training-guide/page.tsx
+++ b/src/app/free-for-charity-ffc-web-developer-training-guide/page.tsx
@@ -12,7 +12,7 @@ export const metadata: Metadata = {
 const index = () => {
   return (
     <div>
-      <div className="" id="segoe-font">
+      <div className="" data-font="segoe-font">
         <Hero />
       </div>
     </div>

--- a/src/app/free-training-programs/page.tsx
+++ b/src/app/free-training-programs/page.tsx
@@ -66,7 +66,7 @@ const FreeTrainingProgramsPage = () => {
 
           <p
             className="text-[18px] font-[500] leading-[28px] text-[#333] text-center mb-8"
-            id="lato-font"
+            data-font="lato-font"
           >
             At Free for Charity the projects you will work on while training and expanding your
             skills will help both Free for Charity directly and the assisted charities that we work
@@ -77,14 +77,14 @@ const FreeTrainingProgramsPage = () => {
             <div className="bg-white rounded-[10px] shadow-[0px_2px_12px_0px_rgba(0,0,0,0.08)] p-6 text-center">
               <div className="text-[40px] mb-2">&#127891;</div>
               <h3 className="text-[18px] font-[700] text-[#1D6E90] mb-2">You Win</h3>
-              <p className="text-[15px] font-[500] text-[#333]" id="lato-font">
+              <p className="text-[15px] font-[500] text-[#333]" data-font="lato-font">
                 Get training and skills in real work needed by for-profit and nonprofits alike.
               </p>
             </div>
             <div className="bg-white rounded-[10px] shadow-[0px_2px_12px_0px_rgba(0,0,0,0.08)] p-6 text-center">
               <div className="text-[40px] mb-2">&#10084;&#65039;</div>
               <h3 className="text-[18px] font-[700] text-[#1D6E90] mb-2">Charities Win</h3>
-              <p className="text-[15px] font-[500] text-[#333]" id="lato-font">
+              <p className="text-[15px] font-[500] text-[#333]" data-font="lato-font">
                 Instead of your work never being seen again after training, your projects are all
                 real-world things needed today.
               </p>
@@ -92,7 +92,7 @@ const FreeTrainingProgramsPage = () => {
             <div className="bg-white rounded-[10px] shadow-[0px_2px_12px_0px_rgba(0,0,0,0.08)] p-6 text-center">
               <div className="text-[40px] mb-2">&#127775;</div>
               <h3 className="text-[18px] font-[700] text-[#1D6E90] mb-2">FFC Wins</h3>
-              <p className="text-[15px] font-[500] text-[#333]" id="lato-font">
+              <p className="text-[15px] font-[500] text-[#333]" data-font="lato-font">
                 Free for Charity captures your skills and motivation to bring efficiencies to the
                 nonprofit industry as a whole.
               </p>
@@ -121,7 +121,7 @@ const FreeTrainingProgramsPage = () => {
                   </span>
                 </div>
                 <p className="text-[16px] font-[600] text-[#555] italic mb-4">{program.subtitle}</p>
-                <div className="space-y-4" id="lato-font">
+                <div className="space-y-4" data-font="lato-font">
                   <p className="text-[16px] font-[500] leading-[26px] text-[#333]">
                     {program.description}
                   </p>
@@ -137,7 +137,7 @@ const FreeTrainingProgramsPage = () => {
                 <a
                   href="/volunteer/"
                   className="inline-block mt-6 px-[24px] py-[8px] text-white border border-[#b35000] rounded-[10px] text-[16px] bg-[#b35000] font-[600] shadow-md hover:shadow-[0px_12px_18px_-6px_#b35000] transition-all duration-300"
-                  id="montserrat-font"
+                  data-font="montserrat-font"
                 >
                   Sign Up Now
                 </a>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -56,37 +56,37 @@ body {
 #header {
   font-family: 'Open Sans', sans-serif !important;
 }
-#aria-font {
+[data-font='aria-font'] {
   font-family: 'Open Sans', sans-serif !important;
 }
-#lato-font {
+[data-font='lato-font'] {
   font-family: 'Lato', sans-serif !important;
 }
-#montserrat-font {
+[data-font='montserrat-font'] {
   font-family: 'Montserrat', sans-serif !important;
 }
-#abeezee {
+[data-font='abeezee'] {
   font-family: 'ABeeZee', sans-serif !important;
 }
-#segoe-font {
+[data-font='segoe-font'] {
   font-family: 'Segoe UI', sans-serif !important;
 }
-#cinzel {
+[data-font='cinzel'] {
   font-family: 'Cinzel', sans-serif !important;
 }
-#fauna-font {
+[data-font='fauna-font'] {
   font-family: 'Fauna One', sans-serif !important;
 }
-#cantata-font {
+[data-font='cantata-font'] {
   font-family: 'Cantata One', sans-serif !important;
 }
-#raleway-font {
+[data-font='raleway-font'] {
   font-family: 'Raleway', sans-serif !important;
 }
-#courier-font {
+[data-font='courier-font'] {
   font-family: 'Courier Prime', sans-serif !important;
 }
-#faustina-font {
+[data-font='faustina-font'] {
   font-family: 'Faustina', sans-serif !important;
 }
 

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -19,7 +19,7 @@ const popularDestinations = [
 export default function NotFound() {
   return (
     <div className="pt-[140px] pb-[80px]">
-      <div className="w-[90%] md:w-[80%] mx-auto max-w-[720px] text-center" id="aria-font">
+      <div className="w-[90%] md:w-[80%] mx-auto max-w-[720px] text-center" data-font="aria-font">
         <p className="text-[14px] font-[500] text-[#666] uppercase tracking-wider mb-[10px]">
           404 &mdash; Page Not Found
         </p>

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -11,7 +11,7 @@ export default function PrivacyPolicy() {
   return (
     <div className="pt-[140px] pb-[54px]">
       <div className="py-[27px] w-[90%] md:w-[80%] mx-auto">
-        <div id="aria-font">
+        <div data-font="aria-font">
           <p className="text-[14px] text-[#666] pb-[10px] leading-[24px] font-[500]"></p>
           <h1 className="text-[30px] text-[#333] pb-[10px] leading-[1em] font-[500]">
             <strong>Privacy Policy</strong>

--- a/src/app/security-acknowledgements/page.tsx
+++ b/src/app/security-acknowledgements/page.tsx
@@ -13,7 +13,7 @@ const index = () => {
   return (
     <div className="pt-[130px] pb-[54px]">
       <div className="py-[27px] w-[90%] md:w-[80%] mx-auto">
-        <div className="border-t-[5px] border-[#0073e6] pt-[25px]" id="lato-font">
+        <div className="border-t-[5px] border-[#0073e6] pt-[25px]" data-font="lato-font">
           <h2 className="text-[30px] leading-[30px] font-[700] text-[#333] mt-[20px] mb-[25px]">
             Security Acknowledgements
           </h2>
@@ -25,7 +25,7 @@ const index = () => {
           </p>
           <div
             className="bg-[#f9f9f9] border-l-[5px] border-[#cccccc] p-[20px] mt-[30px] mb-[30px]"
-            id="lato-font"
+            data-font="lato-font"
           >
             <p className="mb-[10px]  text-[14px] font-[500] leading-[25px] text-[#666]">
               As of now, we have not received any vulnerability reports that qualify for public

--- a/src/app/terms-of-service/page.tsx
+++ b/src/app/terms-of-service/page.tsx
@@ -11,7 +11,7 @@ export default function TermsOfService() {
   return (
     <div className="pt-[130px] pb-[54px]">
       <div className="py-[27px] w-[90%] md:w-[80%] mx-auto">
-        <div id="aria-font">
+        <div data-font="aria-font">
           {/* Effective Date */}
           <p className="text-[14px] text-[#666] pb-[10px] leading-[24px] font-[500]">
             <em>Effective Date: 11-20-2024</em>

--- a/src/app/vulnerability-disclosure-policy/page.tsx
+++ b/src/app/vulnerability-disclosure-policy/page.tsx
@@ -11,7 +11,7 @@ export default function VulnerabilityDisclosurePolicy() {
   return (
     <div className="pt-[130px] pb-[54px]">
       <div className="py-[27px] w-[90%] md:w-[80%] mx-auto">
-        <div id="lato-font">
+        <div data-font="lato-font">
           {/* Main Title */}
           <h2 className="text-[26px] font-bold text-[#333] mt-[40px] mb-[20px]">
             Vulnerability Disclosure Policy for Free For Charity

--- a/src/app/workforce-development/page.tsx
+++ b/src/app/workforce-development/page.tsx
@@ -52,7 +52,10 @@ const WorkforceDevelopmentPage = () => {
               <h3 className="text-[24px] font-[700] text-[#1D6E90] leading-[32px] mb-4">
                 Web Developer / Web Design
               </h3>
-              <p className="text-[16px] font-[500] leading-[26px] text-[#333] mb-6" id="lato-font">
+              <p
+                className="text-[16px] font-[500] leading-[26px] text-[#333] mb-6"
+                data-font="lato-font"
+              >
                 Learn how to create and manage web pages. Use the tools and applications that are
                 used every day by businesses. Learn new skills and practice them by making websites
                 and applications for charities. You will be able to learn:
@@ -62,7 +65,7 @@ const WorkforceDevelopmentPage = () => {
                   <li
                     key={skill}
                     className="flex items-center gap-3 text-[16px] font-[500] text-[#333]"
-                    id="lato-font"
+                    data-font="lato-font"
                   >
                     <div className="w-2 h-2 bg-[#b35000] rounded-full flex-shrink-0" />
                     {skill}
@@ -76,7 +79,10 @@ const WorkforceDevelopmentPage = () => {
               <h3 className="text-[24px] font-[700] text-[#1D6E90] leading-[32px] mb-4">
                 Programming
               </h3>
-              <p className="text-[16px] font-[500] leading-[26px] text-[#333] mb-6" id="lato-font">
+              <p
+                className="text-[16px] font-[500] leading-[26px] text-[#333] mb-6"
+                data-font="lato-font"
+              >
                 Build your resume and hone your skills by programming for nonprofits. Build your
                 programming profile on GitHub. Help produce solutions for problems charities face
                 every day. You will be able to:
@@ -86,7 +92,7 @@ const WorkforceDevelopmentPage = () => {
                   <li
                     key={skill}
                     className="flex items-center gap-3 text-[16px] font-[500] text-[#333]"
-                    id="lato-font"
+                    data-font="lato-font"
                   >
                     <div className="w-2 h-2 bg-[#b35000] rounded-full flex-shrink-0" />
                     {skill}
@@ -96,7 +102,7 @@ const WorkforceDevelopmentPage = () => {
             </div>
           </div>
 
-          <p className="text-[14px] text-[#666] italic mt-8 text-center" id="lato-font">
+          <p className="text-[14px] text-[#666] italic mt-8 text-center" data-font="lato-font">
             NOTE: Workforce Development Programs are only accessible to US citizens who are not dual
             citizens of any other nation.
           </p>
@@ -109,7 +115,10 @@ const WorkforceDevelopmentPage = () => {
           <h3 className="text-[24px] md:text-[30px] font-[600] text-white leading-[36px] mb-4">
             Ready to Get Started?
           </h3>
-          <p className="text-[18px] text-white font-[500] leading-[28px] mb-4" id="lato-font">
+          <p
+            className="text-[18px] text-white font-[500] leading-[28px] mb-4"
+            data-font="lato-font"
+          >
             Give a real person a text:
           </p>
           <p className="text-[20px] text-white font-[600] mb-6">
@@ -121,7 +130,7 @@ const WorkforceDevelopmentPage = () => {
           <a
             href="/volunteer/"
             className="inline-block px-[30px] py-[10px] text-white border border-[#b35000] rounded-[10px] text-[18px] bg-[#b35000] font-[600] shadow-md hover:shadow-[0px_12px_18px_-6px_#b35000] transition-all duration-300"
-            id="montserrat-font"
+            data-font="montserrat-font"
           >
             Volunteer Now
           </a>

--- a/src/components/501c3-components/Help-For-Charities-and-Nonprofit/index.tsx
+++ b/src/components/501c3-components/Help-For-Charities-and-Nonprofit/index.tsx
@@ -9,17 +9,17 @@ const index = () => {
           Free For Charity 501c3 Supported Charity Products and Services
         </h1>
         <div className="mt-[20px] mb-[2.5%]">
-          <p className="text-[18px] font-[500] color-black pb-[1em]" id="lato-font">
+          <p className="text-[18px] font-[500] color-black pb-[1em]" data-font="lato-font">
             Free For Charity is a US based 501c3 charity for charities that provides other US based
             501(c)(3) organizations with free .org domain name registration, professional website
             design tools and templates, as well as ongoing website management and digital
             infrastructure services.
           </p>
-          <p className="text-[18px] font-[500] color-black pb-[1em]" id="lato-font">
+          <p className="text-[18px] font-[500] color-black pb-[1em]" data-font="lato-font">
             Our mission is to empower charities with a strong digital presence, enabling them to
             effectively communicate their cause and engage supporters online.
           </p>
-          <p className="text-[18px] font-[500] color-black" id="lato-font">
+          <p className="text-[18px] font-[500] color-black" data-font="lato-font">
             By offering these essential services always at no cost, we ensure that even small
             non-profits can present themselves professionally in the digital world, enhancing their
             visibility and impact.
@@ -27,17 +27,23 @@ const index = () => {
         </div>
 
         <div className="mb-[70px]">
-          <h1 className="text-[26px] font-[500] color-[#333] text-center pb-[10px]" id="aria-font">
+          <h1
+            className="text-[26px] font-[500] color-[#333] text-center pb-[10px]"
+            data-font="aria-font"
+          >
             Before You Begin Onboarding
           </h1>
-          <h3 className="text-[14px] font-[700] underline text-center text-[#666]" id="aria-font">
+          <h3
+            className="text-[14px] font-[700] underline text-center text-[#666]"
+            data-font="aria-font"
+          >
             Obtain the following information and materials ready to ensure you can complete the
             onboarding steps
           </h3>
 
           <ol
             className="text-[14px] font-[500] text-[#666] list-decimal list-outside space-y-3 pl-5 mb-[1em]"
-            id="aria-font"
+            data-font="aria-font"
           >
             <li>501(c)(3) determination letter from the IRS</li>
             <li>EIN (Employer Identification Number)</li>
@@ -65,12 +71,15 @@ const index = () => {
         </div>
 
         <AccordionItem number="1" title=" External Validation Preparation">
-          <h1 className="font-[700] text-[18px] text-[#4A4A44] pb-[1em] underline" id="lato-font">
+          <h1
+            className="font-[700] text-[18px] text-[#4A4A44] pb-[1em] underline"
+            data-font="lato-font"
+          >
             Before proceeding, ensure your charity agrees to use and sets up:
           </h1>
           <ol
             className="text-[18px] font-[500] text-[#4A4A44] list-decimal list-outside pl-5 pb-[23px]"
-            id="lato-font"
+            data-font="lato-font"
           >
             <li>
               A yourcharityname@outlook.com Email Address
@@ -147,11 +156,11 @@ const index = () => {
         </AccordionItem>
 
         <AccordionItem number="2" title=" Free For Charity Onboarding Form">
-          <h1 className="font-[700] text-[18px] text-[#4A4A44] pb-[1em]" id="lato-font">
+          <h1 className="font-[700] text-[18px] text-[#4A4A44] pb-[1em]" data-font="lato-font">
             Step 1: 501C3 Status Verification via GuideStar (Only approves US Based 501c
             organizations)
           </h1>
-          <h1 className="font-[700] text-[18px] text-[#4A4A44] pb-[1em]" id="lato-font">
+          <h1 className="font-[700] text-[18px] text-[#4A4A44] pb-[1em]" data-font="lato-font">
             What is GuideStar?
           </h1>
           <p className="text-[18px] font-[500] mb-[1em]">
@@ -178,7 +187,7 @@ const index = () => {
             </Link>
             .
           </p>
-          <h1 className="font-[700] text-[18px] text-[#4A4A44] pb-[1em]" id="lato-font">
+          <h1 className="font-[700] text-[18px] text-[#4A4A44] pb-[1em]" data-font="lato-font">
             Step 2: Board Contact Information
           </h1>
           <p className="text-[18px] font-[500] mb-[1em]">
@@ -187,7 +196,7 @@ const index = () => {
             a Vice President / Vice Chair and/or an additional Member-At-Large, but the three key
             roles are non-optional.
           </p>
-          <h1 className="font-[700] text-[18px] text-[#4A4A44] pb-[1em]" id="lato-font">
+          <h1 className="font-[700] text-[18px] text-[#4A4A44] pb-[1em]" data-font="lato-font">
             Step 3: Primary and Technical Contact Information
           </h1>
           <p className="text-[18px] font-[500]">

--- a/src/components/about-us-components/Card-section/index.tsx
+++ b/src/components/about-us-components/Card-section/index.tsx
@@ -15,7 +15,7 @@ const Index = () => {
             </h1>
             <ul
               className="mt-[20px] md:mt-[30px] list-disc text-[16px] md:text-[18px] font-[500] leading-[28px] md:leading-[31px] pb-[10px] pl-[1.5em]"
-              id="lato-font"
+              data-font="lato-font"
             >
               <li>1 on 1 Charity / Nonprofit Consulting</li>
               <li>Free Charity Domain Name</li>

--- a/src/components/about-us-components/ParaText/index.tsx
+++ b/src/components/about-us-components/ParaText/index.tsx
@@ -5,7 +5,7 @@ const index = () => {
     <div className="py-[54px] bg-[#fcfcfc]">
       <div
         className="w-[90%] lg:w-[85%] max-w-[1200px] mx-auto pt-[30px] md:px-[31px] pb-[19px]"
-        id="lato-font"
+        data-font="lato-font"
       >
         <p className="text-[18px] font-[500] leading-[27px] text-center pb-[1em]">
           Free for Charity engages in full cycle training and direct volunteering programs to

--- a/src/components/about-us-components/content/index.tsx
+++ b/src/components/about-us-components/content/index.tsx
@@ -11,7 +11,7 @@ const Page = () => {
 
         <p
           className="text-[18px] md:text-[20px] font-[500] leading-[28px] md:leading-[30px] mt-[30px] md:mt-[50px] text-center w-[95%] md:w-[85%] mx-auto"
-          id="lato-font"
+          data-font="lato-font"
         >
           This charity for charities seeks to replace as many functions as possible&nbsp;that
           current nonprofits pay for&nbsp;to for-profit companies with free or at-cost work from our

--- a/src/components/charity-validation-guide-ensuring-mutual-benefit-through-comprehensive-validation-processes-components/Hero/index.tsx
+++ b/src/components/charity-validation-guide-ensuring-mutual-benefit-through-comprehensive-validation-processes-components/Hero/index.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 
 export default function CharityValidationGuide() {
   return (
-    <div className="pt-40 pb-12 bg-white min-h-screen" id="aria-font">
+    <div className="pt-40 pb-12 bg-white min-h-screen" data-font="aria-font">
       <div className="w-[90%] mx-auto md:max-w-[80%]">
         <h1 className="text-[30px] font-[500] text-[#333] mb-[30px] leading-[30px]">
           Charity Validation Guide: Ensuring Mutual Benefit Through Comprehensive Validation

--- a/src/components/contact-us-components/Contact-Us/index.tsx
+++ b/src/components/contact-us-components/Contact-Us/index.tsx
@@ -11,7 +11,7 @@ const ContactSection = () => {
           </h1>
           <p
             className="text-[18px] font-[500] leading-[27px] text-black text-center"
-            id="lato-font"
+            data-font="lato-font"
           >
             Have questions about consultation or hosting? Want to know more about nonprofits?
             Looking to chat? Give a real person a call:
@@ -26,7 +26,7 @@ const ContactSection = () => {
             <a
               href="mailto:clarkemoyer@freeforcharity.org"
               className="font-[600] text-[#0567B1] text-[18px] break-all "
-              id="lato-font"
+              data-font="lato-font"
             >
               clarkemoyer@freeforcharity.org
             </a>
@@ -37,7 +37,7 @@ const ContactSection = () => {
             <div className="w-full text-center">
               <MdLocationOn className="w-[55px] h-[55px] text-[#1D6E90] mx-auto mb-4" />
               <p className="font-[600] text-[24px] text-black mb-2">Main Address</p>
-              <p className="font-[600] text-[18px] text-[#666666]" id="lato-font">
+              <p className="font-[600] text-[18px] text-[#666666]" data-font="lato-font">
                 4030 Wake Forrest Road STE 349 Raleigh North Carolina 27609
               </p>
             </div>
@@ -45,7 +45,7 @@ const ContactSection = () => {
             <div className="text-center">
               <MdLocationOn className="w-[55px] h-[55px] text-[#1D6E90] mx-auto mb-4" />
               <p className="font-[600] text-[24px] text-black mb-2">PA Office Address</p>
-              <p className="font-[600] text-[18px] text-[#666666]" id="lato-font">
+              <p className="font-[600] text-[18px] text-[#666666]" data-font="lato-font">
                 301 Science Park Road Suite 119 State College PA 16803
               </p>
             </div>
@@ -58,7 +58,7 @@ const ContactSection = () => {
             <a
               href="tel:+15202228104"
               className="font-[600] text-[#0567B1] text-[18px]"
-              id="lato-font"
+              data-font="lato-font"
             >
               (520) 222-8104
             </a>

--- a/src/components/domains/Cards-Section/index.tsx
+++ b/src/components/domains/Cards-Section/index.tsx
@@ -8,7 +8,7 @@ export default function CloudflareSetup() {
       <StepsCard title="Follow the following steps" id="orderstep1">
         <ol
           className="list-decimal list-inside text-left text-[20px] leading-[26px] font-[500]"
-          id="raleway-font"
+          data-font="raleway-font"
         >
           <li>
             Use your organizational outlook.com account
@@ -46,7 +46,7 @@ export default function CloudflareSetup() {
 
       <StepsCard title="Follow the following steps" id="orderstep3">
         {/* Bullet List */}
-        <ul className="list-disc list-inside" id="raleway-font">
+        <ul className="list-disc list-inside" data-font="raleway-font">
           <li>
             Select only a .org domain
             <ol className="list-lower-roman list-inside ml-6">

--- a/src/components/domains/Curved-Black-Section/index.tsx
+++ b/src/components/domains/Curved-Black-Section/index.tsx
@@ -23,7 +23,7 @@ const Index = () => {
           <div className="w-full md:w-[48.5%] text-[15px] leading-[1.6]">
             <ul
               className="list-disc pl-[20px] text-[17px] leading-[26px] font-[500]"
-              id="raleway-font"
+              data-font="raleway-font"
             >
               <li>
                 NOTE: Save the account name and password that you set up as well as the subdomain
@@ -58,7 +58,10 @@ const Index = () => {
         </div>
 
         <div className="py-[27px]">
-          <p className="text-[14px] font-[500] leading-[24px] text-[#666] pt-[25px]" id="aria-font">
+          <p
+            className="text-[14px] font-[500] leading-[24px] text-[#666] pt-[25px]"
+            data-font="aria-font"
+          >
             DOMAIN NAME COUPON CODE Thank you for choosing us to help with your domain name and
             email setup. To get the code please complete the onboarding form for either 501c3 or
             pre-501c3 and you will see the code in the email confirmation that comes after you

--- a/src/components/domains/Curved-Blue-Section/index.tsx
+++ b/src/components/domains/Curved-Blue-Section/index.tsx
@@ -16,7 +16,7 @@ const Index = () => {
         <div className="w-full md:w-[48.5%] md:mr-[32px] text-[15px] leading-[1.6]">
           <ul
             className="list-disc pl-[20px] text-[17px] leading-[26px] font-[500] md:w-[85%] mx-auto "
-            id="raleway-font"
+            data-font="raleway-font"
           >
             <li>
               Go to{' '}

--- a/src/components/domains/Dear-Prospective/index.tsx
+++ b/src/components/domains/Dear-Prospective/index.tsx
@@ -9,7 +9,7 @@ const FFCOnboardingNotice = () => {
         {/* Main Heading */}
         <h2
           className="font-[700] text-[30px] md:text-[35px] leading-[45px] mb-[16px] pb-[10px] text-[#0567B1]"
-          id="cantata-font"
+          data-font="cantata-font"
         >
           Dear Prospective FFC Domain Supported Charity
         </h2>
@@ -17,7 +17,7 @@ const FFCOnboardingNotice = () => {
         {/* Warning Note */}
         <p
           className="font-[500] text-[20px] leading-[30px] mb-[16px] md:w-[65%] mx-auto"
-          id="raleway-font"
+          data-font="raleway-font"
         >
           ** Please read this full page top to bottom before taking any actions as it has several
           follow-on tasks for you as a new domain owner / domain transfer to freeforcharity.org**
@@ -26,7 +26,7 @@ const FFCOnboardingNotice = () => {
         {/* Step 1 */}
         <p
           className="font-[600] text-[20px] md:text-[27px] leading-[35px] w-[85%] mx-auto mt-[30px] pb-[1em]"
-          id="raleway-font"
+          data-font="raleway-font"
         >
           You will have to perform several steps to get full use of your domain once ordered.
         </p>
@@ -34,7 +34,7 @@ const FFCOnboardingNotice = () => {
         {/* Step 2 */}
         <p
           className="font-[600] text-[20px] md:text-[27px] leading-[35px] w-[85%] mx-auto  pb-[1em]"
-          id="raleway-font"
+          data-font="raleway-font"
         >
           The first step is always to complete the FFC on-boarding
         </p>
@@ -43,7 +43,7 @@ const FFCOnboardingNotice = () => {
       <div className="w-[90%] md:w-[80%] mx-auto text-center">
         <h1
           className="text-[22px] sm:text-[24px] md:text-[26px] font-medium text-[#333] pb-[10px]"
-          id="aria-font"
+          data-font="aria-font"
         >
           Ready to Get Started Now?
         </h1>

--- a/src/components/domains/Get-New-Website/index.tsx
+++ b/src/components/domains/Get-New-Website/index.tsx
@@ -9,7 +9,7 @@ const index = () => {
         <div className="w-[90%] md:w-[80%] mx-auto text-center pb-[54px]">
           <h1
             className="text-[22px] sm:text-[24px] md:text-[26px] font-medium text-[#333] pt-[22px]"
-            id="aria-font"
+            data-font="aria-font"
           >
             Ready to Get Started Now?
           </h1>
@@ -32,13 +32,13 @@ const index = () => {
           <div className="pt-[24px] pb-[3px] w-[90%] md:w-[80%] mx-auto max-w-[1080px]">
             <h1
               className="mt-[2px] mb-[12px] pb-[10px] text-[30px] md:text-[35px] font-[700] leading-[46px] text-[#0567B1] text-center"
-              id="cantata-font"
+              data-font="cantata-font"
             >
               STEPS TO GET A NEW WEBSITE DESIGNED AND HOSTED
             </h1>
             <p
               className="mb-[13px] w-[85%] mx-auto font-[500] text-[20px] leading-[30px] text-center"
-              id="raleway-font"
+              data-font="raleway-font"
             >
               New site design has a backlog with Free for Charity but please reach out to get on the
               list for a new free charity website. We try to support 100 Charities a year. If you

--- a/src/components/domains/Hero/index.tsx
+++ b/src/components/domains/Hero/index.tsx
@@ -14,12 +14,12 @@ const Index = () => {
         <div className="w-full md:w-[58.8%] mb-8 md:mb-0">
           <h1
             className="mt-[60px] mb-[20px] font-[700] text-[40px] md:text-[50px] leading-[50px] md:leading-[65px] text-[#1a2e35]"
-            id="cantata-font"
+            data-font="cantata-font"
           >
             Free For Charity <br /> Domains
           </h1>
           <p
-            id="raleway-font"
+            data-font="raleway-font"
             className="text-[18px] md:text-[20px] font-[600] leading-[28px] md:leading-[30px]"
           >
             Welcome to Free For Charity Domains — a project of Free For Charity, providing free

--- a/src/components/domains/Order-Your-Domain/index.tsx
+++ b/src/components/domains/Order-Your-Domain/index.tsx
@@ -58,7 +58,7 @@ const HowToOrderDomain = () => {
         <div className="pb-[3px] w-[80%] max-w-6xl mx-auto mt-[2px] pt-[30px]">
           <h2
             className="text-center mb-[16px] text-[30px] md:text-[35px] text-[#0567B1] font-[700] leading-[46px]"
-            id="cantata-font"
+            data-font="cantata-font"
           >
             HOW TO ORDER YOUR DOMAIN NAME
           </h2>

--- a/src/components/domains/Setup-Email-Hosting/index.tsx
+++ b/src/components/domains/Setup-Email-Hosting/index.tsx
@@ -9,13 +9,13 @@ const index = () => {
         <div className="pt-[24px] pb-[3px]">
           <h1
             className="mt-[2px] mb-[12px] pb-[10px] text-[30px] md:text-[35px] font-[700] leading-[46px] text-[#0567B1] text-center"
-            id="cantata-font"
+            data-font="cantata-font"
           >
             HOW TO SET UP EMAIL HOSTING FOR THE NEW DOMAIN
           </h1>
           <p
             className="mb-[13px] w-[85%] mx-auto font-[500] text-[20px] leading-[30px] text-center"
-            id="raleway-font"
+            data-font="raleway-font"
           >
             Email hosting means that you can have email addresses at your domain name. e.g.
           </p>
@@ -29,7 +29,7 @@ const index = () => {
     border-l-[8px] border-[#0567B1]
     p-[20px] text-center text-[20px] md:text-[22px] font-[600] leading-[31px] text-[#0567B1]
     break-words inline-block"
-          id="raleway-font"
+          data-font="raleway-font"
         >
           yourname@yourdomain.org
         </a>
@@ -40,7 +40,7 @@ const index = () => {
     border-l-[8px] border-[#0567B1]
     p-[20px] text-center text-[20px] md:text-[22px] font-[600] leading-[31px] text-[#0567B1]
     break-words inline-block"
-          id="raleway-font"
+          data-font="raleway-font"
         >
           contactus@yourdomain.org
         </a>
@@ -51,7 +51,7 @@ const index = () => {
     border-l-[8px] border-[#0567B1]
     p-[20px] text-center text-[20px] md:text-[22px] font-[600] leading-[31px] text-[#0567B1]
     break-words inline-block"
-          id="raleway-font"
+          data-font="raleway-font"
         >
           board@yourdomain.org
         </a>
@@ -72,19 +72,19 @@ const index = () => {
 
           <h4
             className="text-[31px] font-[700] leading-[31px] pb-[30px] text-[#0567B1]"
-            id="cantata-font"
+            data-font="cantata-font"
           >
             Step 1
           </h4>
           <p
             className="text-[#333] text-[22px] font-[700] leading-[22px] text-center pb-[10px]"
-            id="raleway-font"
+            data-font="raleway-font"
           >
             Select an email provider
           </p>
 
           {/* Text Content */}
-          <p className="text-[18px] leading-[32px] font-[500]" id="raleway-font">
+          <p className="text-[18px] leading-[32px] font-[500]" data-font="raleway-font">
             Free For Charity recommends Microsoft as your email provider as it is free to charities
             and comes with many additional services at no cost
           </p>
@@ -104,25 +104,25 @@ const index = () => {
 
           <h4
             className="text-[31px] font-[700] leading-[31px] pb-[30px] text-[#0567B1]"
-            id="cantata-font"
+            data-font="cantata-font"
           >
             Step 2
           </h4>
           <p
             className="text-[#333] text-[22px] font-[700] leading-[22px] text-center pb-[10px]"
-            id="raleway-font"
+            data-font="raleway-font"
           >
             Set up a Microsoft 365 Business Premium account
           </p>
 
           {/* Text Content */}
-          <p className="text-[18px] leading-[32px] font-[500] pb-[1em]" id="raleway-font">
+          <p className="text-[18px] leading-[32px] font-[500] pb-[1em]" data-font="raleway-font">
             Follow the following simple steps to set up your Microsoft 365 Business Premium Account
           </p>
           <a
             href="/domains/#setupstep2"
             className="text-[25px] leading-[32px] font-[600] text-[#0460C0]"
-            id="raleway-font"
+            data-font="raleway-font"
           >
             Click here
           </a>

--- a/src/components/domains/Verify-Your-Domain/index.tsx
+++ b/src/components/domains/Verify-Your-Domain/index.tsx
@@ -13,20 +13,20 @@ const index = () => {
         <div className="pt-[24px] pb-[3px] w-[80%] mx-auto">
           <h1
             className="mt-[2px] mb-[12px] pb-[10px] text-[30px] md:text-[35px] font-[700] leading-[46px] text-[#0567B1] text-center"
-            id="cantata-font"
+            data-font="cantata-font"
           >
             HOW TO VERIFY YOUR DOMAIN WITH ICANN
           </h1>
           <p
             className="mb-[13px] w-full lg:w-[85%] mx-auto font-[500] text-[20px] leading-[30px] text-center"
-            id="raleway-font"
+            data-font="raleway-font"
           >
             Please note that you will now own this domain but several emails from the domain
             registrar system will need to be accepted as they verify your account to own the domain.
           </p>
           <p
             className="mt-[30px] font-[600] text-[27px] leading-[35px] text-center"
-            id="raleway-font"
+            data-font="raleway-font"
           >
             What to do then?
           </p>
@@ -50,10 +50,13 @@ const index = () => {
 
             {/* Text */}
             <div className="text-center md:text-left">
-              <h4 className="text-[31px] font-[700] leading-[31px] pb-[10px]" id="cantata-font">
+              <h4
+                className="text-[31px] font-[700] leading-[31px] pb-[10px]"
+                data-font="cantata-font"
+              >
                 Step 1
               </h4>
-              <p className="text-[23px] font-[500] leading-[30px]" id="raleway-font">
+              <p className="text-[23px] font-[500] leading-[30px]" data-font="raleway-font">
                 Check for emails about verification to the email address you used to register this
                 domain
               </p>
@@ -62,7 +65,7 @@ const index = () => {
         </div>
 
         {/* Bottom note */}
-        <p className="font-[500] text-[20px] leading-[30px] text-center" id="raleway-font">
+        <p className="font-[500] text-[20px] leading-[30px] text-center" data-font="raleway-font">
           There are three main things to keep in mind.
         </p>
       </div>
@@ -102,16 +105,22 @@ const index = () => {
 
             {/* Text */}
             <div className="text-center md:text-left">
-              <h4 className="text-[31px] font-[700] leading-[31px] pb-[10px]" id="cantata-font">
+              <h4
+                className="text-[31px] font-[700] leading-[31px] pb-[10px]"
+                data-font="cantata-font"
+              >
                 Step 2
               </h4>
-              <p className="text-[23px] font-[500] leading-[30px] pb-[1em]" id="raleway-font">
+              <p
+                className="text-[23px] font-[500] leading-[30px] pb-[1em]"
+                data-font="raleway-font"
+              >
                 You can manage your domain anytime by accessing our system with the account you
                 created at checkout.
               </p>
               <a
                 href={hubUrl()}
-                id="raleway-font"
+                data-font="raleway-font"
                 className="italic text-[23px] font-[500] leading-[46px] break-all"
               >
                 https://freeforcharity.org/hub
@@ -127,14 +136,14 @@ const index = () => {
           <div className="mt-[2px] mb-[12px]">
             <h2
               className="pb-[10px] text-[#333] text-[35px] font-[700] leading-[46px] text-center"
-              id="cantata-font"
+              data-font="cantata-font"
             >
               Have any Question
             </h2>
           </div>
           <p
             className="w-full md:w-[85%] mx-auto text-[27px] font-[600] leading-[35px] text-center"
-            id="raleway-font"
+            data-font="raleway-font"
           >
             If at anytime 72 hours after your order has been placed you have any questions about
             these verifications please contact
@@ -145,7 +154,7 @@ const index = () => {
         <div className="w-full lg:w-auto md:pl-[15px] flex flex-col items-center lg:items-start">
           <h2
             className="pb-[10px] mt-2 mb-[12px] text-[35px] font-[700] leading-[46px] text-center lg:text-left"
-            id="cantata-font"
+            data-font="cantata-font"
           >
             Contact <br /> Clarke Moyer
           </h2>
@@ -155,7 +164,7 @@ const index = () => {
             <a
               href="tel:+15202228104"
               className="pl-[15px] text-[28px] font-[500] leading-[42px] text-[#0567B1]"
-              id="raleway-font"
+              data-font="raleway-font"
             >
               520-222-8104
             </a>
@@ -165,7 +174,7 @@ const index = () => {
             <a
               href="mailto:clarkemoyer@freeforcharity.org"
               className="text-center pl-[15px] text-[28px] font-[500] leading-[42px] text-[#0567B1] break-all  inline-block"
-              id="raleway-font"
+              data-font="raleway-font"
             >
               clarkemoyer@freeforcharity.org
             </a>

--- a/src/components/donate-components/Free-for-Charity-Donation-Options/index.tsx
+++ b/src/components/donate-components/Free-for-Charity-Donation-Options/index.tsx
@@ -10,21 +10,27 @@ const index = () => {
           <h1 className="text-[30px] md:text-[40px] font-[700] leading-[44px] text-[#b35000] mb-[20px]">
             Free for Charity Donation Options
           </h1>
-          <p className="text-[18px] font-[500] text-black pb-[1em]" id="lato-font">
+          <p className="text-[18px] font-[500] text-black pb-[1em]" data-font="lato-font">
             Here at free for charity we make it easy to donate and help the cause of great free
             training programs and free services for charities.
           </p>
-          <p className="text-[18px] font-[700] text-black mb-[50px]" id="lato-font">
+          <p className="text-[18px] font-[700] text-black mb-[50px]" data-font="lato-font">
             We have the following options:
           </p>
         </div>
 
         {/* Callout Box */}
         <div className="bg-[#2D7F87] py-[20px] md:py-[40px] md:px-[60px]  px-[30px] flex flex-col items-center justify-center text-center">
-          <h1 className="text-[26px] font-[500] leading-[26px] text-white pb-[10px]" id="aria-font">
+          <h1
+            className="text-[26px] font-[500] leading-[26px] text-white pb-[10px]"
+            data-font="aria-font"
+          >
             Free For Charity Domains Endowment Fund
           </h1>
-          <p className="text-[14px] font-[500] leading-[24px] text-white pb-[1em]" id="aria-font">
+          <p
+            className="text-[14px] font-[500] leading-[24px] text-white pb-[1em]"
+            data-font="aria-font"
+          >
             Free For Charity is creating an endowment fund to support our program that buys and
             manages domains names and email accounts for charities in need. Consider supporting to
             the largest fundraising campaign in Free For Charity history.

--- a/src/components/donate-components/General-donation/index.tsx
+++ b/src/components/donate-components/General-donation/index.tsx
@@ -7,7 +7,7 @@ const index = () => {
       <div className="w-[90%] md:w-[80%] mx-auto pb-[80px]">
         <h1
           className="text-center pt-[40px] pb-[45px] text-[#333] leading-[30px] text-[30px] font-[500]"
-          id="aria-font"
+          data-font="aria-font"
         >
           General Donations
         </h1>

--- a/src/components/donate-components/measurable-impact/index.tsx
+++ b/src/components/donate-components/measurable-impact/index.tsx
@@ -15,7 +15,7 @@ const Index = () => {
             </h1>
             <p
               className="text-[18px] font-[500] leading-[27px] mb-[5.82%] mt-[20px]"
-              id="lato-font"
+              data-font="lato-font"
             >
               Every organizations success ultimately falls down to how much support the organization
               received for its causes. Here at Free for Charity it is our mission to provide world
@@ -24,12 +24,15 @@ const Index = () => {
             <h1 className="text-[28px] font-[700] leading-[31px] text-[#b35000]">
               We cannot do the work we do without your support.
             </h1>
-            <p className="text-[18px] font-[500] leading-[27px] pb-[1em] mt-[20px]" id="lato-font">
+            <p
+              className="text-[18px] font-[500] leading-[27px] pb-[1em] mt-[20px]"
+              data-font="lato-font"
+            >
               From the day to day costs of running servers, websites, and paying for software to
               support our training programs; Free for Charity can always put to good use your
               donation. Consider your options to donate today.
             </p>
-            <p className="text-[18px] font-[500] leading-[27px] mb-[5.82%]" id="lato-font">
+            <p className="text-[18px] font-[500] leading-[27px] mb-[5.82%]" data-font="lato-font">
               In addition to financial support, Free for Charity also needs community support
               through{' '}
               <a href="/volunteer/" className="text-[#0567B1]">
@@ -46,11 +49,14 @@ const Index = () => {
           <div className="bg-[#2D7F87] flex flex-col justify-center items-center text-center py-[20px] md:py-[40px] md:px-[60px] px-[30px] w-full h-full">
             <h1
               className="text-[26px] font-[500] leading-[26px] text-white pb-[10px]"
-              id="aria-font"
+              data-font="aria-font"
             >
               Thank you for supporting our mission to help charities in need!
             </h1>
-            <p className="text-[14px] font-[500] leading-[24px] text-white pb-[1em]" id="aria-font">
+            <p
+              className="text-[14px] font-[500] leading-[24px] text-white pb-[1em]"
+              data-font="aria-font"
+            >
               Click the button below to make a donation at PayPal and support Free For Charity. Your
               contribution will make a meaningful impact in helping us provide world-class training
               programs and support charities throughout the United States. From covering the costs

--- a/src/components/ffc-volunteer-proving-ground-core-competencies/Header/index.tsx
+++ b/src/components/ffc-volunteer-proving-ground-core-competencies/Header/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 const index = () => {
   return (
-    <div className="mb-[3rem]" id="segoe-font">
+    <div className="mb-[3rem]" data-font="segoe-font">
       <h1 className="text-[30px] md:text-[36px] font-[700] leading-[36px] text-center pb-[10px]">
         FFC Volunteer Proving Ground: Core Competencies
       </h1>

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -51,7 +51,7 @@ const Footer: React.FC = () => {
               className="group relative my-4 flex w-full max-w-[230px] items-center justify-between
                 border-2 border-[#5BA3D9] bg-black px-5 py-2.5 text-[#5BA3D9]
                 transition-all duration-300 hover:border-transparent"
-              id="aria-font"
+              data-font="aria-font"
             >
               <span className="text-[17px] font-medium leading-tight sm:text-[18px] md:text-[20px] transition-transform duration-300 group-hover:-translate-x-1">
                 Direct GuideStar Profile Link
@@ -73,7 +73,7 @@ const Footer: React.FC = () => {
         <div className="space-y-6 px-4 sm:px-0">
           <h3 className="text-[28px] text-white">Quick Links</h3>
 
-          <ul className="space-y-2 text-sm" id="lato-font">
+          <ul className="space-y-2 text-sm" data-font="lato-font">
             {[
               { name: 'Home', href: '/' },
               { name: 'About Us', href: '/about-us' },
@@ -110,7 +110,7 @@ const Footer: React.FC = () => {
 
           <div className="space-y-3">
             <h4 className="text-[28px] text-white">Free For Charity Policy</h4>
-            <ul className="space-y-1 text-sm" id="lato-font">
+            <ul className="space-y-1 text-sm" data-font="lato-font">
               {[
                 {
                   name: 'Donation Policy',
@@ -166,7 +166,7 @@ const Footer: React.FC = () => {
                 <a
                   href="mailto:clarkemoyer@freeforcharity.org"
                   className="font-[500] text-[15px] hover:text-cyan-400 transition-colors break-all"
-                  id="aria-font"
+                  data-font="aria-font"
                 >
                   clarkemoyer@freeforcharity.org
                 </a>
@@ -180,7 +180,7 @@ const Footer: React.FC = () => {
                 <a
                   href="tel:+15202228104"
                   className="font-[500] text-[16px] hover:text-cyan-400 transition-colors"
-                  id="aria-font"
+                  data-font="aria-font"
                 >
                   (520) 222-8104
                 </a>
@@ -197,7 +197,7 @@ const Footer: React.FC = () => {
               <MapPin className="w-10 h-10 text-orange-500 flex-shrink-0 mt-0.5" />
               <div>
                 <p className="font-[500] text-[22px]">Main Address</p>
-                <p className="font-[500] text-[16px]" id="aria-font">
+                <p className="font-[500] text-[16px]" data-font="aria-font">
                   4030 Wake Forrest Road
                   <br />
                   Suite 349 Raleigh North
@@ -217,7 +217,7 @@ const Footer: React.FC = () => {
               <MapPin className="w-10 h-10 text-orange-500 flex-shrink-0 mt-0.5" />
               <div>
                 <p className="font-[500] text-[22px]">PA Office Address</p>
-                <p className="font-[500] text-[16px]" id="aria-font">
+                <p className="font-[500] text-[16px]" data-font="aria-font">
                   301 Science Park Road Suite
                   <br />
                   119 State College PA 16803
@@ -246,7 +246,7 @@ const Footer: React.FC = () => {
       {/* Bottom Bar */}
       <div
         className="mt-12 py-6 px-4 border-t border-gray-800 text-center text-[18px] font-[500] w-full"
-        id="aria-font"
+        data-font="aria-font"
       >
         <p>
           © {currentYear} All Rights Are Reserved by Free For Charity a US 501c3 Non Profit | A

--- a/src/components/free-charity-web-hosting/About-FFC-Hosting/index.tsx
+++ b/src/components/free-charity-web-hosting/About-FFC-Hosting/index.tsx
@@ -17,11 +17,11 @@ const index = () => {
         <div className="w-full md:w-[58.8%]">
           <h1
             className="mb-[12px] mt-[2px] pb-[10px] font-[700] text-[31px] leading-[31px] text-black text-center"
-            id="cantata-font"
+            data-font="cantata-font"
           >
             About FFC Hosting
           </h1>
-          <p className="text-[18px] font-[500] leading-[29px] text-center" id="raleway-font">
+          <p className="text-[18px] font-[500] leading-[29px] text-center" data-font="raleway-font">
             FFCHosting is a project of Free For Charity. After seeing how small nonprofits were
             often unaware of the resources available to them as it related to technology and
             observing how charities were preyed upon while in the up to 18 months leading up to IRS

--- a/src/components/free-charity-web-hosting/BecomePartOfOurMission/index.tsx
+++ b/src/components/free-charity-web-hosting/BecomePartOfOurMission/index.tsx
@@ -8,7 +8,7 @@ const index = () => {
       <div className="w-[90%] lg:w-[80%] mx-auto pt-[27px]">
         <h1
           className="mt-[2px] mb-[12px] pb-[10px] text-[31px] font-[700] leading-[31px] text-[#0567B1] text-center"
-          id="cantata-font"
+          data-font="cantata-font"
         >
           Become a part of our Mission
         </h1>

--- a/src/components/free-charity-web-hosting/ClientTestimonials/index.tsx
+++ b/src/components/free-charity-web-hosting/ClientTestimonials/index.tsx
@@ -38,7 +38,7 @@ export default function TestimonialSlider() {
       <div className="w-[90%] md:w-[85%] max-w-[1300px] mx-auto text-center">
         <h1
           className="mt-[2px] mb-[42px] pb-[10px] text-[31px] font-[700] leading-[31px] text-[#0567B1] text-center"
-          id="cantata-font"
+          data-font="cantata-font"
         >
           Client Testimonials
         </h1>
@@ -80,7 +80,7 @@ export default function TestimonialSlider() {
                 >
                   <p
                     className="text-[16px] leading-[25px] sm:text-[17px] sm:leading-[27px] font-[400] w-full"
-                    id="raleway-font"
+                    data-font="raleway-font"
                   >
                     {testimonial.quote}
                   </p>
@@ -88,13 +88,13 @@ export default function TestimonialSlider() {
                   <div className="mt-5">
                     <h4
                       className="text-[22px] leading-[22px] font-[500] pb-[10px]"
-                      id="raleway-font"
+                      data-font="raleway-font"
                     >
                       {testimonial.author}
                     </h4>
                     <p
                       className="text-[14px] font-[500] leading-[14px] text-[#fff]"
-                      id="raleway-font"
+                      data-font="raleway-font"
                     >
                       {testimonial.role}
                     </p>

--- a/src/components/free-charity-web-hosting/FAQs/index.tsx
+++ b/src/components/free-charity-web-hosting/FAQs/index.tsx
@@ -47,7 +47,7 @@ const AccordionItem: React.FC<AccordionItemProps> = ({
                 ? 'text-[22px] text-[#0567B1]'
                 : 'text-[18px] text-black'
           }`}
-          id="cantata-font"
+          data-font="cantata-font"
         >
           {title}
         </span>
@@ -73,7 +73,7 @@ const AccordionItem: React.FC<AccordionItemProps> = ({
           className={`px-4 pb-4 pt-2 font-[500] transition-colors duration-300 ${
             small ? 'text-[16px] leading-[26px]' : 'text-[18px] leading-[29px]'
           }`}
-          id="raleway-font"
+          data-font="raleway-font"
         >
           {children}
         </div>
@@ -104,7 +104,7 @@ const AccordionLayout = () => {
         <div className="py-[24px]">
           <h1
             className="mt-[2px] mb-[12px] pb-[10px] text-[31px] font-[700] leading-[31px] text-[#0567B1] text-center"
-            id="cantata-font"
+            data-font="cantata-font"
           >
             FAQS
           </h1>

--- a/src/components/free-charity-web-hosting/Hero/index.tsx
+++ b/src/components/free-charity-web-hosting/Hero/index.tsx
@@ -14,13 +14,13 @@ const Index = () => {
         <div className="w-full md:w-[38.2%] mb-8 md:mb-0 md:mr-[39px]">
           <h1
             className="md:mt-[60px] mb-[20px] font-[700] text-[40px] md:text-[50px] leading-[50px] md:leading-[65px] text-[#1a2e35]"
-            id="cantata-font"
+            data-font="cantata-font"
           >
             Free For Charity <br />
             Hosting
           </h1>
           <p
-            id="raleway-font"
+            data-font="raleway-font"
             className="text-[18px] md:text-[20px] font-[600] leading-[28px] md:leading-[30px]"
           >
             Welcome to Free For Charity Hosting, a project of Free For Charity providing free

--- a/src/components/free-charity-web-hosting/ReadyToGetStarted/index.tsx
+++ b/src/components/free-charity-web-hosting/ReadyToGetStarted/index.tsx
@@ -8,7 +8,7 @@ const index = () => {
       <div className="w-[90%] md:w-[80%] mx-auto text-center">
         <h1
           className="text-[22px] sm:text-[24px] md:text-[26px] font-medium text-[#333] pb-[10px]"
-          id="aria-font"
+          data-font="aria-font"
         >
           Ready to Get Started Now?
         </h1>

--- a/src/components/free-charity-web-hosting/ThreeCards/index.tsx
+++ b/src/components/free-charity-web-hosting/ThreeCards/index.tsx
@@ -21,7 +21,7 @@ const DonateSection: React.FC = () => {
           </div>
           <h1
             className="text-[31px] leading-[31px] font-bold text-white text-center"
-            id="cantata-font"
+            data-font="cantata-font"
           >
             <a href="/donate/">Donate Now</a>
           </h1>
@@ -31,11 +31,14 @@ const DonateSection: React.FC = () => {
         <div className="w-full rounded-[10px] overflow-hidden pt-[30px] pr-[20px] pb-[30px] pl-[20px] shadow-[0px_2px_18px_0px_rgba(0,0,0,0.3)] flex flex-col items-center">
           <h1
             className="text-[31px] leading-[31px] font-bold text-[#0567B1] text-center pb-[10px]"
-            id="cantata-font"
+            data-font="cantata-font"
           >
             Help us in our cause
           </h1>
-          <p className="text-[18px] leading-[32px] font-medium text-center" id="raleway-font">
+          <p
+            className="text-[18px] leading-[32px] font-medium text-center"
+            data-font="raleway-font"
+          >
             If you don’t need a domain name today but want to support us please share this page or
             donate directly so we can provide more and more services to non-profits
           </p>
@@ -54,7 +57,7 @@ const DonateSection: React.FC = () => {
           </div>
           <h1
             className="text-[31px] leading-[31px] font-bold text-white text-center"
-            id="cantata-font"
+            data-font="cantata-font"
           >
             <a href="/volunteer/">Be a Volunteer</a>
           </h1>

--- a/src/components/free-charity-web-hosting/hosting/index.tsx
+++ b/src/components/free-charity-web-hosting/hosting/index.tsx
@@ -13,11 +13,11 @@ const HeroSection = () => {
         <div className="w-full md:w-[47%] mx-auto mb-8 md:mb-0 text-center">
           <h1
             className="mt-[48px] mb-[12px] text-white text-[31px] font-[700] leading-[37px] pb-[10px]"
-            id="cantata-font"
+            data-font="cantata-font"
           >
             Free For Charity <br /> Hosting
           </h1>
-          <p className="text-white text-[18px] font-[600] leading-[29px]" id="raleway-font">
+          <p className="text-white text-[18px] font-[600] leading-[29px]" data-font="raleway-font">
             FFC HOSTING IS THE FIRST US BASED 501C3 NONPROFIT ‘CHARITY FOR CHARITIES’ providing free
             domains and hosting services to other Non-Profit Organizations
           </p>

--- a/src/components/free-for-charity-endowment-fund-components/Empower-Charities/index.tsx
+++ b/src/components/free-for-charity-endowment-fund-components/Empower-Charities/index.tsx
@@ -45,7 +45,10 @@ const DonationSection: FC = () => {
     <div className="bg-[#003566] py-[54px]">
       <div className="w-[90%] md:w-[80%] mx-auto py-[27px]">
         <div className="mb-[10px]">
-          <h3 className="text-[32px] font-[500] leading-[42px] pb-[10px] text-white" id="cinzel">
+          <h3
+            className="text-[32px] font-[500] leading-[42px] pb-[10px] text-white"
+            data-font="cinzel"
+          >
             Empower Charities with Your Generosity
           </h3>
         </div>

--- a/src/components/free-for-charity-endowment-fund-components/Empowering-Charities/index.tsx
+++ b/src/components/free-for-charity-endowment-fund-components/Empowering-Charities/index.tsx
@@ -9,7 +9,7 @@ const Index = () => {
       <section className="py-[54px] w-[90%] md:w-[80%] mx-auto">
         <h1
           className="pt-[27px] mb-[10px] text-[32px] sm:text-[42px] md:text-[50px] text-[#111111] text-center font-[500] leading-[42px] sm:leading-[52px] md:leading-[60px] pb-[37px]"
-          id="cinzel"
+          data-font="cinzel"
         >
           Empowering Charities Through Endowment
         </h1>
@@ -32,7 +32,7 @@ const Index = () => {
           <div className="w-full md:w-[57.8%] text-center md:text-left">
             <p
               className="text-[15px] sm:text-[16px] text-[#000000a3] font-[500] leading-[26px] sm:leading-[28px]"
-              id="fauna-font"
+              data-font="fauna-font"
             >
               Our Free For Charity Domain Program has already supported over 200 charitable
               organizations, providing them with essential digital tools to enhance their outreach

--- a/src/components/free-for-charity-endowment-fund-components/Endowment-Features/index.tsx
+++ b/src/components/free-for-charity-endowment-fund-components/Endowment-Features/index.tsx
@@ -25,7 +25,7 @@ const Index = () => {
           <div className="w-full md:w-[47.25%]">
             <h1
               className="mb-[20px] text-[32px] sm:text-[40px] md:text-[50px] text-[#111111] font-[500] leading-[42px] sm:leading-[50px] md:leading-[60px] text-center md:text-left"
-              id="cinzel"
+              data-font="cinzel"
             >
               Endowment Features
             </h1>
@@ -35,12 +35,15 @@ const Index = () => {
               <div className="flex flex-col sm:flex-row items-center sm:items-start text-center sm:text-left">
                 <FaInfoCircle className="text-[#003566] text-[36px] sm:text-[40px] flex-shrink-0 mb-[10px] sm:mb-0" />
                 <div className="sm:pl-[15px]">
-                  <h2 className="text-[18px] text-[#111111] pb-[10px] font-[500]" id="cinzel">
+                  <h2
+                    className="text-[18px] text-[#111111] pb-[10px] font-[500]"
+                    data-font="cinzel"
+                  >
                     Sustainable Funding
                   </h2>
                   <p
                     className="text-[15px] sm:text-[16px] text-[#000000a3] font-[500] leading-[26px] sm:leading-[28px]"
-                    id="fauna-font"
+                    data-font="fauna-font"
                   >
                     The Endowment ensures that only the investment gains are used, providing a
                     sustainable funding source for the Free For Charity Domain Program.
@@ -52,12 +55,15 @@ const Index = () => {
               <div className="flex flex-col sm:flex-row items-center sm:items-start text-center sm:text-left">
                 <FaChartPie className="text-[#003566] text-[40px] sm:text-[44px] flex-shrink-0 mb-[10px] sm:mb-0" />
                 <div className="sm:pl-[15px]">
-                  <h2 className="text-[18px] text-[#111111] pb-[10px] font-[500]" id="cinzel">
+                  <h2
+                    className="text-[18px] text-[#111111] pb-[10px] font-[500]"
+                    data-font="cinzel"
+                  >
                     Long-Term Impact
                   </h2>
                   <p
                     className="text-[15px] sm:text-[16px] text-[#000000a3] font-[500] leading-[26px] sm:leading-[28px]"
-                    id="fauna-font"
+                    data-font="fauna-font"
                   >
                     By supporting the Endowment, you contribute to a lasting legacy that will
                     continuously support charities in need of digital resources.
@@ -69,12 +75,15 @@ const Index = () => {
               <div className="flex flex-col sm:flex-row items-center sm:items-start text-center sm:text-left">
                 <FaCreditCard className="text-[#003566] text-[44px] sm:text-[50px] flex-shrink-0 mb-[10px] sm:mb-0" />
                 <div className="sm:pl-[15px]">
-                  <h2 className="text-[18px] text-[#111111] pb-[10px] font-[500]" id="cinzel">
+                  <h2
+                    className="text-[18px] text-[#111111] pb-[10px] font-[500]"
+                    data-font="cinzel"
+                  >
                     Goal of $1,000,000
                   </h2>
                   <p
                     className="text-[15px] sm:text-[16px] text-[#000000a3] font-[500] leading-[26px] sm:leading-[28px]"
-                    id="fauna-font"
+                    data-font="fauna-font"
                   >
                     Our target is to raise $1,000,000 to secure the future of the program, ensuring
                     ongoing support for countless charities.

--- a/src/components/free-for-charity-endowment-fund-components/Hero/index.tsx
+++ b/src/components/free-for-charity-endowment-fund-components/Hero/index.tsx
@@ -12,7 +12,7 @@ const Index = () => {
           <div className="text-center md:text-left md:mr-[35px]">
             <h1
               className="text-[42px] sm:text-[54px] md:text-[72px] font-[500] leading-[50px] sm:leading-[65px] md:leading-[83px] text-white"
-              id="cinzel"
+              data-font="cinzel"
             >
               Empower Charities with Free Domains
             </h1>
@@ -23,7 +23,7 @@ const Index = () => {
             <Link
               href="/free-for-charity-endowment-fund/"
               className="whitespace-nowrap px-[20px] sm:px-[24px] py-[10px] sm:py-[12px] hover:bg-gray-100 transition shadow-lg text-[#003566] !border-0 rounded-full text-[14px] font-[700] leading-[24px] bg-white"
-              id="fauna-font"
+              data-font="fauna-font"
             >
               Support the Endowment
             </Link>

--- a/src/components/free-for-charity-endowment-fund-components/Our-Mission/index.tsx
+++ b/src/components/free-for-charity-endowment-fund-components/Our-Mission/index.tsx
@@ -8,7 +8,7 @@ const Index = () => {
       <section className="py-[54px] w-[90%] md:w-[80%] mx-auto">
         <h1
           className="pt-[27px] mb-[10px] text-[32px] sm:text-[40px] md:text-[50px] text-[#111111] text-center font-[500] leading-[42px] sm:leading-[50px] md:leading-[60px] pb-[37px]"
-          id="cinzel"
+          data-font="cinzel"
         >
           Our Mission: Empowering Charities
         </h1>
@@ -18,7 +18,7 @@ const Index = () => {
           <div className="w-full md:w-[47.25%] md:mr-[60px]">
             <p
               className="text-[15px] sm:text-[16px] text-[#000000a3] font-[500] leading-[26px] sm:leading-[28px] text-center md:text-left"
-              id="fauna-font"
+              data-font="fauna-font"
             >
               The Free For Charity Domain Program is dedicated to providing essential digital tools
               to charities at no cost. By offering free domain names and setting up Microsoft 365

--- a/src/components/free-for-charity-endowment-fund-components/Support-Our-Mission/index.tsx
+++ b/src/components/free-for-charity-endowment-fund-components/Support-Our-Mission/index.tsx
@@ -33,21 +33,21 @@ const SupportMissionSection: React.FC<SupportMissionSectionProps> = ({
         <h1
           className="text-[32px] font-[500] text-gray-900 mb-[10px] pb-[10px] sm:leading-[60px]
           sm:text-[50px] leading-[40px]"
-          id="cinzel"
+          data-font="cinzel"
         >
           {title}
         </h1>
         <p
           className="sm:text-[16px] font-[500] text-[#000000a3] mb-6 sm:leading-[28px]
           text-[14px] leading-[24px]"
-          id="fauna-font"
+          data-font="fauna-font"
         >
           {description1}
         </p>
         <p
           className="sm:text-[16px] font-[500] text-[#000000a3] mb-6 sm:leading-[28px]
           text-[14px] leading-[24px]"
-          id="fauna-font"
+          data-font="fauna-font"
         >
           {description2}
         </p>

--- a/src/components/free-for-charity-endowment-fund-components/Text-Section/index.tsx
+++ b/src/components/free-for-charity-endowment-fund-components/Text-Section/index.tsx
@@ -5,7 +5,7 @@ const index = () => {
     <div className="py-[54px]">
       <h1
         className="w-[90%] md:w-[80%] mx-auto text-[25px] md:text-[30px] font-[500] leading-[30px] text-[#333] py-[27px]"
-        id="aria-font"
+        data-font="aria-font"
       >
         NOTE: This page is under development but the endowment is real! Please reach out to the
         founder Clarke Moyer at 520-222-8104 if you have any questions.

--- a/src/components/free-for-charity-endowment-fund-components/Voices-of-Gratitude/index.tsx
+++ b/src/components/free-for-charity-endowment-fund-components/Voices-of-Gratitude/index.tsx
@@ -5,7 +5,7 @@ const index = () => {
     <div className="py-[54px] w-[90%] md:w-[80%] mx-auto">
       <h1
         className="text-[30px] md:text-[50px] font-[500] text-[#111] mb-[10px] pb-[10px] py-[27px] leading-[60px]"
-        id="cinzel"
+        data-font="cinzel"
       >
         Voices of Gratitude
       </h1>
@@ -24,14 +24,14 @@ const index = () => {
           <div>
             <p
               className="text-[#0e0c19] text-[18px] mb-[10px] leading-[32px] font-[700]"
-              id="fauna-font"
+              data-font="fauna-font"
             >
               “Thanks to Free For Charity, our organization now has a professional online presence,
               which has significantly increased our visibility and donor engagement.”
             </p>
             <p
               className="text-[#000000a3] text-[16px] mb-[10px] leading-[32px] font-[500]"
-              id="fauna-font"
+              data-font="fauna-font"
             >
               — FFC Supporter
             </p>
@@ -50,14 +50,14 @@ const index = () => {
           <div>
             <p
               className="text-[#0e0c19] text-[18px] mb-[10px] leading-[32px] font-[700]"
-              id="fauna-font"
+              data-font="fauna-font"
             >
               “The free domain and email setup provided by Free For Charity have been invaluable in
               helping us streamline our communications and expand our reach.”
             </p>
             <p
               className="text-[#000000a3] text-[16px] mb-[10px] leading-[32px] font-[500]"
-              id="fauna-font"
+              data-font="fauna-font"
             >
               — FFC Supporter
             </p>
@@ -76,14 +76,14 @@ const index = () => {
           <div>
             <p
               className="text-[#0e0c19] text-[18px] mb-[10px] leading-[32px] font-[700]"
-              id="fauna-font"
+              data-font="fauna-font"
             >
               “We are grateful for the support from Free For Charity. Their services have allowed us
               to focus more on our core mission and less on administrative tasks.”
             </p>
             <p
               className="text-[#000000a3] text-[16px] mb-[10px] leading-[32px] font-[500]"
-              id="fauna-font"
+              data-font="fauna-font"
             >
               — FFC Supporter
             </p>

--- a/src/components/free-for-charity-ffc-service-delivery-stages-components/Hero/index.tsx
+++ b/src/components/free-for-charity-ffc-service-delivery-stages-components/Hero/index.tsx
@@ -3,11 +3,11 @@ import React from 'react'
 const index = () => {
   return (
     <div className="pt-[135px] pb-[50px]">
-      <div className="py-[24px] w-[90%] md:w-[80%] max-w-[1080px] mx-auto" id="aria-font">
+      <div className="py-[24px] w-[90%] md:w-[80%] max-w-[1080px] mx-auto" data-font="aria-font">
         {/* header  */}
         <div
           className="bg-[#1f2937] text-white p-8 text-center shadow-lg shadow-black/20"
-          id="aria-font"
+          data-font="aria-font"
         >
           <h1 className="text-[36px] font-[700] leading-[36px] mb-[8px] pb-[10px]">
             Free For Charity (FFC)
@@ -211,7 +211,7 @@ const index = () => {
                   </ul>
                   <pre
                     className="bg-[#111827] text-white p-[1rem] rounded-md my-4 text-[14px] leading-[24px] font-[500] whitespace-pre-wrap break-words"
-                    id="courier-font"
+                    data-font="courier-font"
                   >
                     <code>
                       {`// ** Fixes admin portal CloudFlare re-direct issue ** //

--- a/src/components/free-for-charitys-tools-for-success-components/Educational-Sites/index.tsx
+++ b/src/components/free-for-charitys-tools-for-success-components/Educational-Sites/index.tsx
@@ -40,7 +40,7 @@ const EducationalSitesSection = () => {
         {/* Heading */}
         <h2
           className="text-[40px] font-[700] text-white text-center leading-[44px] mb-4 [font-variant:small-caps] tracking-[1px]"
-          id="lato-font"
+          data-font="lato-font"
         >
           Educational Sites for
           <span className="text-[#b35000]"> Everyone</span>
@@ -68,7 +68,7 @@ const EducationalSitesSection = () => {
               <div className="flex-1">
                 <h3
                   className="text-[24px] font-[700] text-white leading-[31px] pb-[10px]"
-                  id="faustina-font"
+                  data-font="faustina-font"
                 >
                   {card.title}
                 </h3>
@@ -87,7 +87,7 @@ const EducationalSitesSection = () => {
                     shadow-md leading-[31px] font-[600]
                     hover:shadow-[0px_12px_18px_-6px_#b35000]
                   "
-                  id="montserrat-font"
+                  data-font="montserrat-font"
                 >
                   <span className="transition-all duration-300 group-hover:translate-x-1">
                     Check Here!

--- a/src/components/free-for-charitys-tools-for-success-components/Rescue-Time/index.tsx
+++ b/src/components/free-for-charitys-tools-for-success-components/Rescue-Time/index.tsx
@@ -48,7 +48,7 @@ const Index = () => {
               Credit Karma (free add supported)
             </h3>
 
-            <div className="text-white text-[18px] leading-[24px] font-[500]" id="lato-font">
+            <div className="text-white text-[18px] leading-[24px] font-[500]" data-font="lato-font">
               Credit Karma actually gives you a FREE credit score and report from transunion. When I
               say free I mean it. At no time does it even ask you for a credit card so it is
               impossible to charge you. It uses the same model as Mint.com for income and serves you
@@ -70,7 +70,7 @@ const Index = () => {
                 shadow-md leading-[31px] font-[600]
                 hover:shadow-[0px_12px_18px_-6px_#b35000]
               "
-              id="montserrat-font"
+              data-font="montserrat-font"
             >
               <span className="transition-all duration-300 group-hover:translate-x-1">
                 Get Started
@@ -116,7 +116,7 @@ const Index = () => {
               Rescue Time (free with a paid premium version)
             </h3>
 
-            <div className="text-white text-[18px] leading-[24px] font-[500]" id="lato-font">
+            <div className="text-white text-[18px] leading-[24px] font-[500]" data-font="lato-font">
               Rescue Time is another FREE tool that really tells you about yourself and how you
               spend your time. It is amazing once you get it set up. The only downside is that you
               may not be able to install this on your work computer. NOTE: I use the paid version on
@@ -137,7 +137,7 @@ const Index = () => {
                 shadow-md leading-[31px] font-[600]
                 hover:shadow-[0px_12px_18px_-6px_#b35000]
               "
-              id="montserrat-font"
+              data-font="montserrat-font"
             >
               <span className="transition-all duration-300 group-hover:translate-x-1">
                 Get Started

--- a/src/components/free-for-charitys-tools-for-success-components/Tools-For-Businesses/index.tsx
+++ b/src/components/free-for-charitys-tools-for-success-components/Tools-For-Businesses/index.tsx
@@ -9,7 +9,7 @@ const index = () => {
           <div className="w-[80%] mx-auto pt-[27px] pb-[35px] ">
             <h1
               className="mb-[11px] pb-[10px] text-[40px] font-[700] leading-[44px] text-center text-[#333] tracking-[1px]"
-              id="faustina-font"
+              data-font="faustina-font"
             >
               Tools for <span className="text-[#b35000]">Businesses</span>
             </h1>

--- a/src/components/free-for-charitys-tools-for-success-components/Two-Cards-With-Heading/index.tsx
+++ b/src/components/free-for-charitys-tools-for-success-components/Two-Cards-With-Heading/index.tsx
@@ -9,7 +9,7 @@ const index = () => {
           <div className="w-[80%] mx-auto pt-[27px] pb-[35px] ">
             <h1
               className="mb-[11px] pb-[10px] text-[40px] font-[700] leading-[44px] text-center text-[#333] tracking-[1px]"
-              id="faustina-font"
+              data-font="faustina-font"
             >
               Tools for <span className="text-[#b35000]">Non-Profits</span>
             </h1>

--- a/src/components/free-for-charitys-tools-for-success-components/Two-Flex-Cards/index.tsx
+++ b/src/components/free-for-charitys-tools-for-success-components/Two-Flex-Cards/index.tsx
@@ -53,7 +53,10 @@ const Index = () => {
               Volunteer Match (Free basic account paid upgrades)
             </h3>
 
-            <div className="text-[18px] leading-[24px] font-[500] text-[#666]" id="lato-font">
+            <div
+              className="text-[18px] leading-[24px] font-[500] text-[#666]"
+              data-font="lato-font"
+            >
               The best volunteer sourcing tool. Links with linkedin.com, your website, and many
               other sources creating a job board for your charities needs. Create a profile and post
               offers for all your needs.
@@ -65,7 +68,7 @@ const Index = () => {
               target="_blank"
               rel="noopener noreferrer"
               className="relative group inline-flex items-center justify-center gap-2 mt-[25px] px-[30px] py-[6px] text-white border border-[#b35000] rounded-[10px] text-[18px] bg-[#b35000] transition-all duration-300 ease-in-out shadow-md leading-[31px] font-[600] hover:shadow-[0px_12px_18px_-6px_#b35000]"
-              id="montserrat-font"
+              data-font="montserrat-font"
             >
               <span className="transition-all duration-300 group-hover:translate-x-1">
                 Get Started
@@ -95,7 +98,10 @@ const Index = () => {
               FreeForCharity (No costs for anything we directly provide … really)
             </h3>
 
-            <div className="text-[18px] leading-[24px] font-[500] text-[#666]" id="lato-font">
+            <div
+              className="text-[18px] leading-[24px] font-[500] text-[#666]"
+              data-font="lato-font"
+            >
               My personal charity focused on bridging the gaps between the big players in the
               charity for charities section. Focus is on IT Project Management support and other
               business level support. Free For Charity leverages and simplifies the plethora of
@@ -106,7 +112,7 @@ const Index = () => {
             <Link
               href="/"
               className="relative group inline-flex items-center justify-center gap-2 mt-[25px] px-[30px] py-[6px] border border-[#b35000] rounded-[10px] text-[18px] bg-[#b35000] transition-all duration-300 ease-in-out text-white shadow-md leading-[31px] font-[600] hover:shadow-[0px_12px_18px_-6px_#b35000]"
-              id="montserrat-font"
+              data-font="montserrat-font"
             >
               <span className="transition-all duration-300 group-hover:translate-x-1">
                 Get Started

--- a/src/components/free-training-programs-components/faq-section.tsx
+++ b/src/components/free-training-programs-components/faq-section.tsx
@@ -38,7 +38,7 @@ const FaqSection = () => {
         ))}
 
         <div className="text-center mt-8">
-          <p className="text-[18px] font-[600] text-[#b35000]" id="lato-font">
+          <p className="text-[18px] font-[600] text-[#b35000]" data-font="lato-font">
             Sign up today and start learning these new skills while helping charities.
           </p>
         </div>

--- a/src/components/guidestar-guide/Faqs/index.tsx
+++ b/src/components/guidestar-guide/Faqs/index.tsx
@@ -9,7 +9,10 @@ const index = () => {
     <div className="w-full">
       <div className="w-[90%] mx-auto py-[40px] ">
         <div className="pt-[26px] w-full max-w-[90%] sm:max-w-[90%] mx-auto">
-          <h1 className="text-[25px] md:text-[30px] font-[500] text-[#333] pb-[1em]" id="aria-font">
+          <h1
+            className="text-[25px] md:text-[30px] font-[500] text-[#333] pb-[1em]"
+            data-font="aria-font"
+          >
             1. Achieving Gold or Platinum Seal of Transparency
           </h1>
           <AccordianBold number="1" title=" Claim Your Nonprofit Profile">
@@ -223,10 +226,13 @@ const index = () => {
         </div>
 
         <div className="pt-[26px] max-w-[90%] sm:max-w-[90%] mx-auto">
-          <h1 className="text-[25px] md:text-[30px] font-[500] text-[#333] pb-[1em]" id="aria-font">
+          <h1
+            className="text-[25px] md:text-[30px] font-[500] text-[#333] pb-[1em]"
+            data-font="aria-font"
+          >
             2. Preparing to share your profile with Free For Charity
           </h1>
-          <p className="text-[14px] font-[500] text-[#666] mb-[30px]" id="aria-font">
+          <p className="text-[14px] font-[500] text-[#666] mb-[30px]" data-font="aria-font">
             Once you have published your report you will then be given a link to share your profile
             as well as some option for posting this badge to your website that we will need later.
           </p>
@@ -239,7 +245,7 @@ const index = () => {
           />
         </div>
 
-        <div className="pt-[26px] w-[90%] mx-auto text-[14px]" id="aria-font">
+        <div className="pt-[26px] w-[90%] mx-auto text-[14px]" data-font="aria-font">
           <p className="font-[700] text-[#666] pb-[1em]">
             Here is an example of the links to copy into the FFC onboarding form:
           </p>

--- a/src/components/guidestar-guide/Free-for-charity/index.tsx
+++ b/src/components/guidestar-guide/Free-for-charity/index.tsx
@@ -12,7 +12,7 @@ const Index = () => {
         {/* GuideStar Instruction Text */}
         <p
           className="text-[14px] text-[#666] font-semibold leading-relaxed mb-8"
-          id="aria-font"
+          data-font="aria-font"
           aria-describedby="GuideStar is required for onboarding verification"
         >
           GuideStar is the main tool for helping you gather the information to complete our

--- a/src/components/help-for-charities-components/AccordianSection/index.tsx
+++ b/src/components/help-for-charities-components/AccordianSection/index.tsx
@@ -8,7 +8,7 @@ const index = () => {
         <h1 className="text-[#b35000] text-[28px] font-[700] mb-[15px] mt-[40px]">
           Empower Your Charity with Cutting-Edge Technology
         </h1>
-        <p className="text-[18px] font-[500] color-black text-left" id="lato-font">
+        <p className="text-[18px] font-[500] color-black text-left" data-font="lato-font">
           At Free For Charity, we believe that every non-profit deserves a powerful digital
           presence. That’s why we offer a comprehensive, modern tech stack to 501(c)(3)
           organizations – completely free of charge. When you partner with us, you’re not just
@@ -19,7 +19,7 @@ const index = () => {
         <h1 className="text-[#b35000] text-[28px] font-[700] mb-[15px]">
           Our Tech Stack: Your Gateway to Digital Excellence
         </h1>
-        <p className="text-[18px] font-[500] color-black text-left" id="lato-font">
+        <p className="text-[18px] font-[500] color-black text-left" data-font="lato-font">
           By choosing Free For Charity, you’re agreeing to adopt our carefully curated tech stack:
         </p>
       </div>

--- a/src/components/help-for-charities-components/Charity-Nonprofit-Director-Faq/index.tsx
+++ b/src/components/help-for-charities-components/Charity-Nonprofit-Director-Faq/index.tsx
@@ -14,12 +14,15 @@ const CharityFAQ: React.FC = () => {
           <h1 className="font-bold text-[28px] text-[#b35000] mb-4">
             We can’t test them without helping your charity or non profit.
           </h1>
-          <p className="text-[18px] font-medium text-black" id="lato-font">
+          <p className="text-[18px] font-medium text-black" data-font="lato-font">
             Our main goal is to train people in the skills of effective business and technology
             management. We accomplish this goal of providing help for charities by producing
             in-house projects like:
           </p>
-          <ul className="list-disc pl-5 text-[18px] font-medium text-black mt-4" id="lato-font">
+          <ul
+            className="list-disc pl-5 text-[18px] font-medium text-black mt-4"
+            data-font="lato-font"
+          >
             <li>
               Research papers, case studies, and use cases from other industries and nonprofits.
             </li>

--- a/src/components/help-for-charities-components/Ready-to-Get-Started-Now/index.tsx
+++ b/src/components/help-for-charities-components/Ready-to-Get-Started-Now/index.tsx
@@ -8,7 +8,7 @@ const index: React.FC = () => {
       <div className="w-[90%] md:w-[80%] mx-auto text-center">
         <h1
           className="text-[22px] sm:text-[24px] md:text-[26px] font-medium text-[#333] mb-6"
-          id="aria-font"
+          data-font="aria-font"
         >
           Ready to Get Started Now?
         </h1>

--- a/src/components/help-for-charities-components/call-section/index.tsx
+++ b/src/components/help-for-charities-components/call-section/index.tsx
@@ -6,11 +6,11 @@ const index = () => {
     <div className="w-full max-w-[100%] py-[54px] ">
       <div className="w-[80%] max-w-[90%] mx-auto py-[2%] flex flex-col items-center justify-center text-center">
         <div>
-          <h1 className="text-[22px] font-[500] text-black" id="lato-font">
+          <h1 className="text-[22px] font-[500] text-black" data-font="lato-font">
             Have questions about consultation or hosting? Want to know more about nonprofits?
             Looking to chat? Give a real person a call:
           </h1>
-          <p className="text-[22px] font-[500] text-black" id="lato-font">
+          <p className="text-[22px] font-[500] text-black" data-font="lato-font">
             Clarke Moyer{' '}
             <Link className="text-[#b35000]" href="tel:+15202228104">
               (520) 222-8104

--- a/src/components/home-page/Endowment-Features/index.tsx
+++ b/src/components/home-page/Endowment-Features/index.tsx
@@ -8,7 +8,7 @@ const Home: React.FC = () => {
         <div>
           <h2
             className="font-[400] text-[40px] lg:text-[48px] leading-[100%] tracking-[0] text-center mx-auto mb-[30px]"
-            id="faustina-font"
+            data-font="faustina-font"
           >
             Free For Charity Endowment Features
           </h2>

--- a/src/components/home-page/FrequentlyAskedQuestions/index.tsx
+++ b/src/components/home-page/FrequentlyAskedQuestions/index.tsx
@@ -7,7 +7,7 @@ const index = () => {
       <div className="w-[90%] mx-auto lg:px-[20px]">
         <h2
           className="font-[400] text-[40px] lg:text-[48px]  tracking-[0] text-center mx-auto mb-[50px]"
-          id="faustina-font"
+          data-font="faustina-font"
         >
           Frequently Asked Questions
         </h2>

--- a/src/components/home-page/Hero/index.tsx
+++ b/src/components/home-page/Hero/index.tsx
@@ -27,20 +27,20 @@ const CharityHeroBackground = () => {
         <div className="w-full lg:w-[565px]">
           <h1
             className="text-[50px] lg:text-[60px] font-[500] text-[#FFFFFF] leading-[120%] mb-[20px]"
-            id="faustina-font"
+            data-font="faustina-font"
           >
             Welcome to <br /> Free For Charity
           </h1>
           <p
             className="text-[24px] font-[400] leading-[120%] text-[#FFFFFF] mb-[20px]"
-            id="lato-font"
+            data-font="lato-font"
           >
             Connecting Students, Professionals, & Businesses with Charities in Need
           </p>
           <a
             href="#volunteer"
             className="top-[378px] w-[300px] lg:w-[351px] h-[54px] opacity-100 rounded-[27px] px-[32px] py-[18px] flex items-center justify-center gap-[10px] bg-[#FFFFFF] text-[#113563] text-[20px] font-[400] leading-[100%] mb-[10px] whitespace-nowrap"
-            id="lato-font"
+            data-font="lato-font"
           >
             Volunteer
           </a>
@@ -48,14 +48,14 @@ const CharityHeroBackground = () => {
             <a
               href="#donate"
               className="top-[442px] w-[130px] lg:w-[173px] h-[54px] opacity-100 rounded-[27px] px-[32px] py-[18px] flex items-center justify-center gap-[10px] bg-[#FFFFFF] text-[#113563] text-[20px] font-[400] leading-[100%] whitespace-nowrap"
-              id="lato-font"
+              data-font="lato-font"
             >
               Donate
             </a>
             <a
               href="#programs"
               className="top-[442px] w-[173px] h-[54px] opacity-100 rounded-[27px] px-[32px] py-[18px] flex items-center justify-center gap-[10px] bg-[#FFFFFF] text-[#113563] text-[20px] font-[400] leading-[100%] whitespace-nowrap"
-              id="lato-font"
+              data-font="lato-font"
             >
               Help for Charities
             </a>

--- a/src/components/home-page/Mission/index.tsx
+++ b/src/components/home-page/Mission/index.tsx
@@ -7,20 +7,20 @@ const index = () => {
       <div className="w-[90%] mx-auto py-[27px] mb-[60px] max-w-[1280px]">
         <h2
           className="font-[400] text-[40px] lg:text-[48px] leading-[100%] tracking-[0] text-center w-full lg:w-[906px] mx-auto mb-[50px]"
-          id="faustina-font"
+          data-font="faustina-font"
         >
           Free For Charity has a simple mission with broad implications
         </h2>
         <p
           className="font-[700] text-[25px] leading-[150%] tracking-[0] text-center mb-[30px]"
-          id="lato-font"
+          data-font="lato-font"
         >
           Reduce costs and increase revenues for nonprofits; putting that money back into their
           charitable mission where it belongs.
         </p>
         <p
           className="font-[500] text-[25px] leading-[150%] tracking-[0] text-center"
-          id="lato-font"
+          data-font="lato-font"
         >
           This charity for charities seeks to replace as many functions as possible that current
           nonprofits pay for to for-profit companies with free or at cost work from our campus, on

--- a/src/components/home-page/Our-Programs/index.tsx
+++ b/src/components/home-page/Our-Programs/index.tsx
@@ -9,7 +9,7 @@ const index = () => {
       <div className="w-[90%] lg:px-[20px] mx-auto">
         <h2
           className="font-[400] text-[40px] lg:text-[48px]  tracking-[0] text-center mx-auto mb-[50px]"
-          id="faustina-font"
+          data-font="faustina-font"
         >
           Help for Charities
         </h2>
@@ -21,11 +21,11 @@ const index = () => {
                 <Image src={assetPath('/Svgs/FFC-Domains.svg')} alt="FFC-Domains" fill></Image>
               </div>
             </div>
-            <h3 className="text-[36px] font-[400] " id="lato-font">
+            <h3 className="text-[36px] font-[400] " data-font="lato-font">
               FFC Domains
             </h3>
           </div>
-          <p className="text-[25px] font-[400] " id="lato-font">
+          <p className="text-[25px] font-[400] " data-font="lato-font">
             Provides free .org domain names, Microsoft 365 with Outlook email, & Microsoft Teams to
             501c3 charities.
           </p>
@@ -77,11 +77,11 @@ const index = () => {
                 <Image src={assetPath('/Svgs/FFC-Hosting.svg')} alt="FFC-Domains" fill></Image>
               </div>
             </div>
-            <h3 className="text-[36px] font-[400]  " id="lato-font">
+            <h3 className="text-[36px] font-[400]  " data-font="lato-font">
               FFC Hosting
             </h3>
           </div>
-          <p className="text-[25px] font-[400]  " id="lato-font">
+          <p className="text-[25px] font-[400]  " data-font="lato-font">
             Free static site hosting for nonprofit organizations using Microsoft GitHub Pages, with
             websites built using GitHub Copilot AI:
           </p>
@@ -143,11 +143,11 @@ const index = () => {
                 <Image src={assetPath('/Svgs/FFC-Consulting.svg')} alt="FFC-Domains" fill></Image>
               </div>
             </div>
-            <h3 className="text-[36px] font-[400]  " id="lato-font">
+            <h3 className="text-[36px] font-[400]  " data-font="lato-font">
               FFC Consulting
             </h3>
           </div>
-          <p className="text-[25px] font-[400]  " id="lato-font">
+          <p className="text-[25px] font-[400]  " data-font="lato-font">
             FFC Consulting is about helping charities get the most out of their digital
             infrastructure including from other charities for charities like ours or from partners.
             We introduce charities to each major service that supports the charity mission of our
@@ -195,7 +195,7 @@ const index = () => {
         </div>
 
         <div className="lg:w-[90%] mx-auto text-center pb-[54px] pt-[20px]">
-          <h3 className="text-[36px] font-[400] pt-[22px] pb-[30px]" id="lato-font">
+          <h3 className="text-[36px] font-[400] pt-[22px] pb-[30px]" data-font="lato-font">
             Ready to Get Started Now?
           </h3>
 
@@ -203,14 +203,14 @@ const index = () => {
             <a
               href="/501c3/"
               className="rounded-[20px] border-[5px] border-[#2A6682] flex items-center justify-center text-black font-[400] text-[25px] px-[28px] py-[16px]"
-              id="lato-font"
+              data-font="lato-font"
             >
               501 (c)3 Charities Click Here To Get Started!
             </a>
             <a
               href="/pre501c3/"
               className="rounded-[20px] border-[5px] border-[#2A6682] flex items-center justify-center text-black font-[400] text-[25px] px-[28px] py-[16px]"
-              id="lato-font"
+              data-font="lato-font"
             >
               Pre-501 (c)3 Charities Click Here To Get Started!
             </a>

--- a/src/components/home-page/Results-2023/index.tsx
+++ b/src/components/home-page/Results-2023/index.tsx
@@ -7,7 +7,7 @@ const index = () => {
       <div className="w-[90%] mx-auto py-[52px] lg:px-[20px]">
         <h2
           className="mt-[2px] pb-[10px] text-[30px] md:text-[48px] font-[400] leading-[46px]  text-center mb-[40px]"
-          id="faustina-font"
+          data-font="faustina-font"
         >
           Results - 2023
         </h2>

--- a/src/components/home-page/SupportFreeForCharity/index.tsx
+++ b/src/components/home-page/SupportFreeForCharity/index.tsx
@@ -32,7 +32,7 @@ const Index = () => {
       <div className="w-[90%] mx-auto py-[27px] mb-[60px] px-[20px] max-w-[1280px]">
         <h2
           className="font-[400] text-[40px] lg:text-[48px] leading-[100%] tracking-[0] text-center mx-auto mb-[60px]"
-          id="faustina-font"
+          data-font="faustina-font"
         >
           Support Free For Charity
         </h2>
@@ -42,7 +42,7 @@ const Index = () => {
           <div className="flex flex-col w-full lg:w-[50%]">
             <p
               className="mb-[20px] font-[400] text-[25px] leading-[150%] tracking-[0] text-center lg:text-left"
-              id="lato-font"
+              data-font="lato-font"
             >
               By donating you help drive our mission and allow us to support more charities with our
               Domain, Website, and other services.

--- a/src/components/home-page/TheFreeForCharityTeam/index.tsx
+++ b/src/components/home-page/TheFreeForCharityTeam/index.tsx
@@ -7,7 +7,7 @@ const TheFreeForCharityTeam = () => {
     <section id="team" className="py-[50px]">
       <h2
         className="font-[400] text-[40px] lg:text-[48px] tracking-[0] text-center mx-auto mb-[50px]"
-        id="faustina-font"
+        data-font="faustina-font"
       >
         The Free For Charity Team
       </h2>

--- a/src/components/home-page/VoicesofGratitude/index.tsx
+++ b/src/components/home-page/VoicesofGratitude/index.tsx
@@ -31,7 +31,7 @@ export default function TestimonialSlider() {
       <div className="py-[30px]">
         <h2
           className="font-[400] text-[40px] lg:text-[48px]  tracking-[0] text-center mx-auto mb-[50px]"
-          id="faustina-font"
+          data-font="faustina-font"
         >
           Voices of Gratitude
         </h2>
@@ -56,7 +56,10 @@ export default function TestimonialSlider() {
                         }`}
                         style={{ minHeight: '200px' }}
                       >
-                        <p className="text-center font-[400] text-[28px] mb-3" id="fauna-font">
+                        <p
+                          className="text-center font-[400] text-[28px] mb-3"
+                          data-font="fauna-font"
+                        >
                           {testimonial.author}
                         </p>
                         <div className="flex justify-center mb-3">
@@ -72,7 +75,7 @@ export default function TestimonialSlider() {
                           ))}
                         </div>
 
-                        <p className="text-center text-[21px] font-[400]" id="fauna-font">
+                        <p className="text-center text-[21px] font-[400]" data-font="fauna-font">
                           &ldquo;{testimonial.quote}&rdquo;
                         </p>
                       </div>

--- a/src/components/home-page/Volunteer-with-Us/index.tsx
+++ b/src/components/home-page/Volunteer-with-Us/index.tsx
@@ -8,13 +8,13 @@ const index = () => {
       <div className="w-[90%] mx-auto lg:px-[20px]">
         <h2
           className="mt-[2px] mb-[42px] pb-[10px] text-[30px] md:text-[48px] font-[400] leading-[46px] text-center text-white"
-          id="faustina-font"
+          data-font="faustina-font"
         >
           Volunteer with Us
         </h2>
         <p
           className="mb-[13px] w-[85%] mx-auto font-[500] text-[20px] leading-[30px] text-center text-white"
-          id="lato-font"
+          data-font="lato-font"
         >
           Your time and skills can create a lasting impact. Whether youre assisting with outreach,
           providing technical expertise, or supporting our programs, your contributions are
@@ -27,7 +27,7 @@ const index = () => {
           className="w-[216px] h-[62px] top-[261px] left-[611px] rounded-[27px] 
              flex items-center justify-center px-[32px] py-[18px] gap-[10px] 
              text-[#113563] mx-auto mt-[30px] bg-white text-[20px] font-[400] font-sans text-center"
-          id="lato-font"
+          data-font="lato-font"
         >
           Volunteer
         </a>

--- a/src/components/home/Contactus/index.tsx
+++ b/src/components/home/Contactus/index.tsx
@@ -31,7 +31,7 @@ const ContactUsSection: React.FC = () => {
             <a
               href={`mailto:${contact.email}`}
               className="font-[600] text-[#0567B1] text-[18px]"
-              id="lato-font"
+              data-font="lato-font"
             >
               {contact.email}
             </a>
@@ -41,7 +41,7 @@ const ContactUsSection: React.FC = () => {
           <div className="w-full max-w-[550px]">
             <MdLocationOn className="w-[55px] h-[55px] text-[#1D6E90] mx-auto mb-4" />
             <p className="font-[600] text-[24px] text-black mb-2">Main Address</p>
-            <p className="font-[600] text-[18px] text-[#666666]" id="lato-font">
+            <p className="font-[600] text-[18px] text-[#666666]" data-font="lato-font">
               {contact.mainAddress}
             </p>
           </div>
@@ -53,7 +53,7 @@ const ContactUsSection: React.FC = () => {
             <a
               href={`tel:${contact.phone.replace(/[^0-9]/g, '')}`}
               className="font-[600] text-[#0567B1] text-[18px]"
-              id="lato-font"
+              data-font="lato-font"
             >
               {contact.phone}
             </a>
@@ -64,7 +64,7 @@ const ContactUsSection: React.FC = () => {
         <div className="w-full max-w-[550px] mx-auto">
           <MdLocationOn className="w-[55px] h-[55px] text-[#1D6E90] mx-auto mb-4" />
           <p className="font-[600] text-[24px] text-black mb-2">PA Office Address</p>
-          <p className="font-[600] text-[18px] text-[#666666]" id="lato-font">
+          <p className="font-[600] text-[18px] text-[#666666]" data-font="lato-font">
             {contact.paAddress}
           </p>
         </div>

--- a/src/components/home/HeroSection/index.tsx
+++ b/src/components/home/HeroSection/index.tsx
@@ -12,7 +12,7 @@ const Hero: React.FC = () => {
             Welcome to Free For Charity
           </h1>
           <p
-            id="lato-font"
+            data-font="lato-font"
             className="font-medium text-black text-[20px] leading-[30px] sm:text-[28px] sm:leading-[40px] md:text-[35px] md:leading-[49px] mt-4"
           >
             Connecting Students, Professionals, & Businesses with Charities in Need

--- a/src/components/home/MissionSection/index.tsx
+++ b/src/components/home/MissionSection/index.tsx
@@ -11,7 +11,7 @@ const Mission: React.FC = () => {
 
         <p
           className="font-bold text-[16px] sm:text-[17px] md:text-[18px] leading-[26px] sm:leading-[27px] my-3 text-black px-2 sm:px-0"
-          id="lato-font"
+          data-font="lato-font"
         >
           Reduce costs and increase revenues for nonprofits; putting that money back into their
           charitable mission where it belongs.
@@ -19,7 +19,7 @@ const Mission: React.FC = () => {
 
         <p
           className="font-medium text-[16px] sm:text-[17px] md:text-[18px] leading-[26px] sm:leading-[27px] text-black px-2 sm:px-0"
-          id="lato-font"
+          data-font="lato-font"
         >
           This charity for charities seeks to replace as many functions as possible that current
           nonprofits pay for to for-profit companies with free or at cost work from our campus, on

--- a/src/components/home/SupportFreeforCharity/index.tsx
+++ b/src/components/home/SupportFreeforCharity/index.tsx
@@ -17,7 +17,7 @@ const SupportFreeForCharity: React.FC = () => {
             </h1>
             <p
               className="w-full max-w-[650px] font-[500] text-[18px] leading-[27px] text-black"
-              id="montserrat-font"
+              data-font="montserrat-font"
             >
               By donating you help drive our mission and allow us to support more charities with our
               Domain, Website, and other services.
@@ -35,7 +35,7 @@ const SupportFreeForCharity: React.FC = () => {
           <div>
             <h1
               className="text-center mb-10 font-[600] text-[18px] leading-[27px] text-black px-1"
-              id="montserrat-font"
+              data-font="montserrat-font"
             >
               LOOKING TO GET FREE SKILLS TRAINING AND HELP CHARITIES AT THE SAME TIME? START A
               TRAINING PROGRAM.
@@ -52,7 +52,7 @@ const SupportFreeForCharity: React.FC = () => {
           <div>
             <h1
               className="text-center mb-10 font-[600] text-[18px] leading-[27px] text-black px-1"
-              id="montserrat-font"
+              data-font="montserrat-font"
             >
               CHARITY IN NEED OF HELP? GET FREE SUPPORT WITH YOUR ONLINE AND OFFLINE CRITICAL
               PROJECTS.
@@ -69,7 +69,7 @@ const SupportFreeForCharity: React.FC = () => {
           <div>
             <h1
               className="text-center mb-10 font-[600] text-[18px] leading-[27px] text-black px-1"
-              id="montserrat-font"
+              data-font="montserrat-font"
             >
               ARE YOU A BUSINESS OR INDIVIDUAL LOOKING TO DONATE OR PARTNER WITH FREE FOR CHARITY?
             </h1>

--- a/src/components/home/Testimonials/index.tsx
+++ b/src/components/home/Testimonials/index.tsx
@@ -98,19 +98,22 @@ const TestimonialSlider: React.FC = () => {
 
                   <h3
                     className="text-[22px] font-bold mb-[10px] text-[#333] leading-6 italic"
-                    id="aria-font"
+                    data-font="aria-font"
                   >
                     {t.heading}
                   </h3>
                   <p
                     className="text-[17px] font-medium text-black italic px-0 sm:px-4 md:px-8"
-                    id="aria-font"
+                    data-font="aria-font"
                   >
                     {t.text}
                   </p>
 
                   {t.name && (
-                    <p className="text-[14px] font-medium my-2 text-[#666666]" id="aria-font">
+                    <p
+                      className="text-[14px] font-medium my-2 text-[#666666]"
+                      data-font="aria-font"
+                    >
                       {t.name}
                     </p>
                   )}
@@ -121,7 +124,7 @@ const TestimonialSlider: React.FC = () => {
                       target="_blank"
                       rel="noopener noreferrer"
                     >
-                      <p className="text-[14px] font-medium text-[#0567B1]" id="aria-font">
+                      <p className="text-[14px] font-medium text-[#0567B1]" data-font="aria-font">
                         {t.location}
                       </p>
                     </a>

--- a/src/components/online-impacts-onboarding-guide-components/Ready-To-Get-Started-Now/index.tsx
+++ b/src/components/online-impacts-onboarding-guide-components/Ready-To-Get-Started-Now/index.tsx
@@ -9,7 +9,7 @@ const index = () => {
     <div className="bg-white">
       <div className="w-full max-w-[90%] mx-auto">
         <div className="flex items-center flex-col text-center pb-[40px]">
-          <h1 className="text-[26px] font-[500] text-[#333] pb-[10px]" id="aria-font">
+          <h1 className="text-[26px] font-[500] text-[#333] pb-[10px]" data-font="aria-font">
             Ready to Get Started Now?
           </h1>
           <TransparentBtn
@@ -22,7 +22,7 @@ const index = () => {
           number="3"
           title=" Free For Charity Domain Name and Microsoft 365 Email Hosting Request"
         >
-          <p className="text-[18px] font-[500] text-[#4a4a4a] mb-[1em]" id="lato-font">
+          <p className="text-[18px] font-[500] text-[#4a4a4a] mb-[1em]" data-font="lato-font">
             Free For Charity Provides free .org domain names to US 501c3 organizations. Once your
             onboarding forms are accepted you will receive an email from the system with the
             discount code to request a new domain name or to transfer your current domain name to us

--- a/src/components/online-impacts-onboarding-guide-components/charity-text/index.tsx
+++ b/src/components/online-impacts-onboarding-guide-components/charity-text/index.tsx
@@ -11,15 +11,15 @@ const index = () => {
           title="Free For Charity 501c3 Supported Charity Products and Services for Former Online Impacts Supported Charities"
           description=""
         />
-        <h1 className="text-[26px] font-[500] text-[#333] my-[20px]" id="lato-font">
+        <h1 className="text-[26px] font-[500] text-[#333] my-[20px]" data-font="lato-font">
           Lets get started on your transfer today
         </h1>
-        <p className="text-[18px] font-[500] pb-[1em]" id="lato-font">
+        <p className="text-[18px] font-[500] pb-[1em]" data-font="lato-font">
           Great News. As an Online Impacts supported charity you already are likely using many of
           the products and features needed to convert over to Free For Charity to support your .org
           Domain Name, WordPress hosting, and more!
         </p>
-        <p className="text-[18px] font-[500]" id="lato-font">
+        <p className="text-[18px] font-[500]" data-font="lato-font">
           Depending on when you signed up or were transferred to Online Impacts you are already
           likey using a registered .org domain name, Cloudflare for DNS and DDoS Protection, Web
           Hosting with interserver.net, a Softaculous managed WordPress Website, WPMUDEV Plugins for
@@ -28,7 +28,7 @@ const index = () => {
         </p>
         <h1
           className="text-[23px] sm:text-[26px] font-[500] text-[#333] my-[20px] leading-[1.4]"
-          id="lato-font"
+          data-font="lato-font"
         >
           We are here to help. If you run into any issues or have questions about the changes,
           please reach out directly to:
@@ -36,14 +36,14 @@ const index = () => {
 
         <h1
           className="text-[23px] sm:text-[26px] font-[500] text-[#333] my-[20px] leading-[1.4]"
-          id="lato-font"
+          data-font="lato-font"
         >
           Clarke Moyer the founder of Free For Charity at clarkemoyer@freeforcharity.org or text me
           at 520-222-8104
         </h1>
         <h1
           className="text-[23px] sm:text-[26px] font-[500] text-[#333] my-[20px] leading-[1.4]"
-          id="lato-font"
+          data-font="lato-font"
         >
           Pardhasaradhi Namburi the founder of Online Impacts at pardhu@onlineimpacts.org
         </h1>
@@ -54,16 +54,16 @@ const index = () => {
         />
 
         <div className="w-full h-[1px] bg-[#2D7F87] mt-[30px] mb-[50px]"></div>
-        <h1 className="text-[26px] font-[500] text-[#333] mt-[20px]" id="lato-font">
+        <h1 className="text-[26px] font-[500] text-[#333] mt-[20px]" data-font="lato-font">
           Before You Begin Onboarding
         </h1>
-        <p className="text-[18px] font-[600] text-[#666]" id="abeezee">
+        <p className="text-[18px] font-[600] text-[#666]" data-font="abeezee">
           Obtain the following information and materials ready to ensure you can complete the
           onboarding steps:
         </p>
         <ol
           className="text-[18px] mb-[50px] font-[600] text-[#666] list-decimal list-inside "
-          id="abeezee"
+          data-font="abeezee"
         >
           <li>501(c)(3) determination letter from the IRS</li>
           <li>EIN (Employer Identification Number)</li>
@@ -159,7 +159,7 @@ const index = () => {
 
         <AccordionItem number="2" title="Free For Charity Onboarding Form">
           {/* Step 1 */}
-          <h1 className="text-[18px] font-[700] text-[#4a4a4a] mb-[1em]" id="lato-font">
+          <h1 className="text-[18px] font-[700] text-[#4a4a4a] mb-[1em]" data-font="lato-font">
             Step 1: 501(c)(3) Status Verification via GuideStar
           </h1>
 

--- a/src/components/techstack-components/Hero/index.tsx
+++ b/src/components/techstack-components/Hero/index.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 const UnderstandingHosting: React.FC = () => {
   return (
     <div className="min-h-screen w-full pt-[160px] pb-[70px]">
-      <div className="w-full max-w-[90%] md:max-w-[80%] mx-auto" id="aria-font">
+      <div className="w-full max-w-[90%] md:max-w-[80%] mx-auto" data-font="aria-font">
         <h1 className="font-[400] text-[30px] text-[#333] leading-[30px] pb-[10px]">
           Understanding Your Free For Charity WordPress Website Hosting: A Layered Approach
         </h1>

--- a/src/components/ui/Accordian.tsx
+++ b/src/components/ui/Accordian.tsx
@@ -61,7 +61,7 @@ const AccordionItem: React.FC<AccordionItemProps> = ({ number, title, children }
         <div
           ref={contentRef}
           className="px-4 pb-4 pt-2 text-gray-700 text-[18px] font-[500] transition-colors duration-300"
-          id="lato-font"
+          data-font="lato-font"
         >
           {children}
         </div>

--- a/src/components/ui/AccordianBold.tsx
+++ b/src/components/ui/AccordianBold.tsx
@@ -37,7 +37,7 @@ const AccordionItem: React.FC<AccordionItemProps> = ({ number, title, children }
           className={`font-[500] text-[20px] md:text-[26px] flex-1 pr-3 transition-colors duration-300 ${
             isOpen ? 'text-[#333]' : 'text-[#666]'
           }`}
-          id="aria-font"
+          data-font="aria-font"
         >
           {number}.{title}
         </span>
@@ -62,7 +62,7 @@ const AccordionItem: React.FC<AccordionItemProps> = ({ number, title, children }
         <div
           ref={contentRef}
           className="px-4 pb-4 pt-2 text-gray-700 text-[14px] font-[500] transition-colors duration-300"
-          id="aria-font"
+          data-font="aria-font"
         >
           {children}
         </div>

--- a/src/components/ui/BecomePartOfOurMissionCard.tsx
+++ b/src/components/ui/BecomePartOfOurMissionCard.tsx
@@ -30,13 +30,13 @@ const BecomePartOfOurMissionCard: React.FC<BecomePartOfOurMissionCardProps> = ({
       }}
     >
       <div className="mb-[13px]">
-        <h1 className="pb-[10px] text-[31px] font-[700] leading-[31px]" id="cantata-font">
+        <h1 className="pb-[10px] text-[31px] font-[700] leading-[31px]" data-font="cantata-font">
           {heading}
         </h1>
-        <p className="text-[18px] font-[500] leading-[32px]" id="raleway-font">
+        <p className="text-[18px] font-[500] leading-[32px]" data-font="raleway-font">
           {description1}
         </p>
-        <p className="text-[18px] font-[500] leading-[32px]" id="raleway-font">
+        <p className="text-[18px] font-[500] leading-[32px]" data-font="raleway-font">
           {description2}
         </p>
       </div>
@@ -54,7 +54,7 @@ const BecomePartOfOurMissionCard: React.FC<BecomePartOfOurMissionCardProps> = ({
     transition-all duration-300 ease-in-out
     hover:border-transparent hover:scale-x-110
   "
-        id="aria-font"
+        data-font="aria-font"
       >
         <span className="z-10">{buttonText}</span>
 

--- a/src/components/ui/BlogCard.tsx
+++ b/src/components/ui/BlogCard.tsx
@@ -56,11 +56,11 @@ const InfoCard: React.FC<InfoCardProps> = ({ imageUrl, heading, date, descriptio
           )}
         </h3>
         {date && (
-          <p id="aria-font" className="text-[14px] font-[600] text-[#b35000] my-2">
+          <p data-font="aria-font" className="text-[14px] font-[600] text-[#b35000] my-2">
             {date}
           </p>
         )}
-        <p id="lato-font" className="text-[#666666] font-[500] text-[18px] leading-relaxed">
+        <p data-font="lato-font" className="text-[#666666] font-[500] text-[18px] leading-relaxed">
           {description}
         </p>
       </div>

--- a/src/components/ui/Bluebtn.tsx
+++ b/src/components/ui/Bluebtn.tsx
@@ -27,7 +27,7 @@ const BlueBtn: React.FC<BlueBtnProps> = ({ children = 'Learn More', href, ...pro
         text-[18px] font-semibold bg-[#1D6E90]
         flex items-center justify-center
       "
-      id="montserrat-font"
+      data-font="montserrat-font"
       onClick={handleClick} // handle link click
       {...props}
     >

--- a/src/components/ui/CallToActionCard.tsx
+++ b/src/components/ui/CallToActionCard.tsx
@@ -63,7 +63,10 @@ const IconTextCard: React.FC<IconTextCardProps> = ({ icon, iconLabel = 'icon', t
       </div>
 
       {/* Text */}
-      <h3 className="text-[30px] font-bold leading-[30px] text-center text-gray-900" id="lato-font">
+      <h3
+        className="text-[30px] font-bold leading-[30px] text-center text-gray-900"
+        data-font="lato-font"
+      >
         {text}
       </h3>
     </a>

--- a/src/components/ui/Charity-Nonprofit-Director-Faq.tsx
+++ b/src/components/ui/Charity-Nonprofit-Director-Faq.tsx
@@ -14,12 +14,15 @@ const CharityFAQ: React.FC = () => {
           <h1 className="font-bold text-[28px] text-[#b35000] mb-4">
             We can’t test them without helping your charity or non profit.
           </h1>
-          <p className="text-[18px] font-medium text-black" id="lato-font">
+          <p className="text-[18px] font-medium text-black" data-font="lato-font">
             Our main goal is to train people in the skills of effective business and technology
             management. We accomplish this goal of providing help for charities by producing
             in-house projects like:
           </p>
-          <ul className="list-disc pl-5 text-[18px] font-medium text-black mt-4" id="lato-font">
+          <ul
+            className="list-disc pl-5 text-[18px] font-medium text-black mt-4"
+            data-font="lato-font"
+          >
             <li>
               Research papers, case studies, and use cases from other industries and nonprofits.
             </li>

--- a/src/components/ui/Contact-data-card.tsx
+++ b/src/components/ui/Contact-data-card.tsx
@@ -22,7 +22,7 @@ const AddressCard: React.FC<AddressCardProps> = ({ imageSrc, heading, descriptio
       {/* Description - supports line breaks */}
       <p
         className="text-[18px] font-[600] leading-[24px] text-[#666] whitespace-pre-line"
-        id="lato-font"
+        data-font="lato-font"
       >
         {description}
       </p>

--- a/src/components/ui/Domain-Card.tsx
+++ b/src/components/ui/Domain-Card.tsx
@@ -36,7 +36,7 @@ export default function StepCard({
       </div>
 
       {/* Text Content */}
-      <p className="text-[20px] leading-[28px] font-[500]" id="raleway-font">
+      <p className="text-[20px] leading-[28px] font-[500]" data-font="raleway-font">
         {text}
       </p>
     </div>

--- a/src/components/ui/EducationalSitesCard.tsx
+++ b/src/components/ui/EducationalSitesCard.tsx
@@ -41,7 +41,7 @@ const EducationalSitesCard: React.FC<EducationalSitesCardProps> = ({
             shadow-md leading-[31px] font-[600]
             hover:shadow-[0px_12px_18px_-6px_#b35000] w-fit
           "
-          id="montserrat-font"
+          data-font="montserrat-font"
         >
           <span className="transition-all duration-300 group-hover:translate-x-1">Check Here!</span>
           <IoIosArrowForward

--- a/src/components/ui/Frequently-Asked-Questions.tsx
+++ b/src/components/ui/Frequently-Asked-Questions.tsx
@@ -23,7 +23,7 @@ const FrequentlyAskedQuestions: React.FC<AccordionItemProps> = ({ title, childre
   const toggle = () => setIsOpen(!isOpen)
 
   return (
-    <div className="mb-5 overflow-hidden" id="lato-font">
+    <div className="mb-5 overflow-hidden" data-font="lato-font">
       {/* Header */}
       <button
         onClick={toggle}
@@ -31,7 +31,7 @@ const FrequentlyAskedQuestions: React.FC<AccordionItemProps> = ({ title, childre
         aria-expanded={isOpen}
       >
         {/* Text takes remaining space */}
-        <span className={`font-[400] text-[20px] md:text-[32px] flex-1 pr-3`} id="lato-font">
+        <span className={`font-[400] text-[20px] md:text-[32px] flex-1 pr-3`} data-font="lato-font">
           {title}
         </span>
 
@@ -63,7 +63,7 @@ const FrequentlyAskedQuestions: React.FC<AccordionItemProps> = ({ title, childre
         <div
           ref={contentRef}
           className="px-4 pb-4 pt-2 transition-colors duration-300 text-[#555555] text-[20px] md:text-[25px] font-[400]"
-          id="lato-font"
+          data-font="lato-font"
         >
           {children}
         </div>

--- a/src/components/ui/General-Donation-Card.tsx
+++ b/src/components/ui/General-Donation-Card.tsx
@@ -21,7 +21,7 @@ const GeneralDonationCard: React.FC<GeneralDonationCardProps> = ({
       href={href}
       {...(isExternal ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
       className="block mx-auto bg-white p-6 rounded-[10px] overflow-hidden pt-[50px] pr-[20px] pb-[50px] pl-[20px] shadow-[0px_2px_18px_0px_rgba(0,0,0,0.3)]"
-      id="lato-font"
+      data-font="lato-font"
     >
       {/* Title */}
       <h1 className="text-[30px] font-[700] leading-[30px] text-center pb-[10px]">{title}</h1>

--- a/src/components/ui/HeroSection.tsx
+++ b/src/components/ui/HeroSection.tsx
@@ -36,7 +36,7 @@ const HeroSection: React.FC<HeroSectionProps> = ({
             </h1>
             <p
               className="font-[500] w-full mt-[11px]"
-              id="lato-font"
+              data-font="lato-font"
               style={{
                 fontSize: fontSize ? `${fontSize}px` : '22px',
                 lineHeight: lineHeight ? `${lineHeight}px` : '31px',

--- a/src/components/ui/OrangeFaqItem.tsx
+++ b/src/components/ui/OrangeFaqItem.tsx
@@ -25,7 +25,7 @@ const AccordionItem: React.FC<AccordionItemProps> = ({ title, children }) => {
   return (
     <div
       className="shadow-[0px_16px_16px_0px_#11253E0F] mb-5 p-2 border-[5px] border-[#F58629] rounded-[10px] overflow-hidden"
-      id="lato-font"
+      data-font="lato-font"
     >
       {/* Header */}
       <button
@@ -60,7 +60,7 @@ const AccordionItem: React.FC<AccordionItemProps> = ({ title, children }) => {
         <div
           ref={contentRef}
           className="px-4 pb-4 pt-2 text-[22px] lg:text-[25px] font-[400]"
-          id="lato-font"
+          data-font="lato-font"
         >
           {children}
         </div>

--- a/src/components/ui/ProgressBar.tsx
+++ b/src/components/ui/ProgressBar.tsx
@@ -20,7 +20,7 @@ const ProgressBar: React.FC<ProgressBarProps> = ({ title, percentage }) => {
   return (
     <div className="w-full">
       {/* Title */}
-      <p className="text-[14px] font-[700] text-[#111111] mb-1" id="fauna-font">
+      <p className="text-[14px] font-[700] text-[#111111] mb-1" data-font="fauna-font">
         {title}
       </p>
 

--- a/src/components/ui/ProvingGroundSection.tsx
+++ b/src/components/ui/ProvingGroundSection.tsx
@@ -7,7 +7,7 @@ interface ProvingGroundSectionProps {
 
 const ProvingGroundSection: React.FC<ProvingGroundSectionProps> = ({ title, children }) => {
   return (
-    <section className="w-full mx-auto py-[2em] md:px-[2em]" id="segoe-font">
+    <section className="w-full mx-auto py-[2em] md:px-[2em]" data-font="segoe-font">
       {/* Title with Bottom Border */}
       <h1 className="text-[25px] md:text-[30px] font-[600] text-[#111827] leading-[30px] border-b-[2px] w-full border-[#3B82F6] inline-block mb-[1.5rem] pb-[0.5rem]">
         {title}

--- a/src/components/ui/ResultCard.tsx
+++ b/src/components/ui/ResultCard.tsx
@@ -13,10 +13,10 @@ const ResultCard: React.FC<ResultCardProps> = ({ title, description }) => {
 
   return (
     <div className="w-full h-[300px] px-[20px] flex items-center justify-center flex-col border-[5px] border-[#F58629] rounded-[20px] shadow-[0px_16px_16px_0px_#11253E0F]">
-      <h1 className="text-[64px] font-[400]" id="faustina-font">
+      <h1 className="text-[64px] font-[400]" data-font="faustina-font">
         {!isNaN(numericValue) ? <AnimatedNumber value={numericValue} /> : title}
       </h1>
-      <p className="text-center text-[25px] font-[400]" id="lato-font">
+      <p className="text-center text-[25px] font-[400]" data-font="lato-font">
         {description}
       </p>
     </div>

--- a/src/components/ui/SlidingCard.tsx
+++ b/src/components/ui/SlidingCard.tsx
@@ -81,7 +81,7 @@ export default function SlidingCard({
             {subtitle}
           </h3>
 
-          <div className="text-[#333] text-[18px] leading-[24px] font-[500]" id="lato-font">
+          <div className="text-[#333] text-[18px] leading-[24px] font-[500]" data-font="lato-font">
             {description}
           </div>
 
@@ -91,7 +91,7 @@ export default function SlidingCard({
             target="_blank"
             rel="noopener noreferrer"
             className="relative group inline-flex items-center justify-center gap-2 mt-[25px] px-[30px] py-[6px] text-white border border-[#b35000] rounded-[10px] text-[18px] bg-[#b35000] transition-all duration-300 ease-in-out shadow-md leading-[31px] font-[600] hover:shadow-[0px_12px_18px_-6px_#b35000]"
-            id="montserrat-font"
+            data-font="montserrat-font"
           >
             <span className="transition-all duration-300 group-hover:translate-x-1">
               {buttonText}

--- a/src/components/ui/StepCard.tsx
+++ b/src/components/ui/StepCard.tsx
@@ -56,18 +56,18 @@ const StepCard: React.FC<{ step: Step }> = ({ step }) => {
           </div>
         </div>
 
-        <h4 className="text-[31px] font-bold leading-[31px] pb-[10px]" id="cantata-font">
+        <h4 className="text-[31px] font-bold leading-[31px] pb-[10px]" data-font="cantata-font">
           {step.title}
         </h4>
 
-        <p className="text-[25px] font-bold leading-[33px] pb-[1em]" id="raleway-font">
+        <p className="text-[25px] font-bold leading-[33px] pb-[1em]" data-font="raleway-font">
           {step.description}
         </p>
 
         <a
           href={step.linkUrl}
           className="text-[30px] font-bold text-white leading-[33px]"
-          id="raleway-font"
+          data-font="raleway-font"
         >
           {step.linkText}
         </a>

--- a/src/components/ui/StepContentCard.tsx
+++ b/src/components/ui/StepContentCard.tsx
@@ -18,7 +18,7 @@ export default function StepsCard({ title, children, className, id }: StepsCardP
       {/* Title */}
       <h2
         className="text-center text-[30px] md:text-[35px] font-[700] leading-[46px] text-[#0567B1] mb-[10px] mt-[3px]"
-        id="cantata-font"
+        data-font="cantata-font"
       >
         {title}
       </h2>

--- a/src/components/ui/SustainableFundingCard.tsx
+++ b/src/components/ui/SustainableFundingCard.tsx
@@ -31,13 +31,13 @@ export const SustainableFundingCard: React.FC<SustainableFundingCardProps> = ({
       <div className="p-4 text-center">
         <h3
           className="text-[24px] lg:text-[28px] font-[400] text-[#000000] leading-[100%] mb-3"
-          id="lato-font"
+          data-font="lato-font"
         >
           {title}
         </h3>
         <p
           className="text-[16px] sm:text-[18px] font-[400] text-[#000000] leading-[140%]"
-          id="lato-font"
+          data-font="lato-font"
         >
           {text}
         </p>

--- a/src/components/ui/TeamMemberCard.tsx
+++ b/src/components/ui/TeamMemberCard.tsx
@@ -32,10 +32,10 @@ export default function TeamMemberCard({
 
       {/* Text Content */}
       <div className="text-center space-y-2">
-        <h3 className="text-[32px] font-[400]" id="lato-font">
+        <h3 className="text-[32px] font-[400]" data-font="lato-font">
           {name}
         </h3>
-        <p className="text-[25px] font-[400]" id="lato-font">
+        <p className="text-[25px] font-[400]" data-font="lato-font">
           {title}
         </p>
       </div>

--- a/src/components/ui/ToolCard.tsx
+++ b/src/components/ui/ToolCard.tsx
@@ -61,7 +61,7 @@ export default function ToolCard({ logo, title, description, link }: ToolCardPro
         {description && (
           <p
             className="mb-[22px] text-[18px] leading-[24px] font-[500] text-[#666] text-center"
-            id="lato-font"
+            data-font="lato-font"
           >
             {description}
           </p>
@@ -72,7 +72,7 @@ export default function ToolCard({ logo, title, description, link }: ToolCardPro
           target="_blank"
           rel="noopener noreferrer"
           className="relative group inline-flex items-center justify-center gap-2 px-[30px] py-[6px] text-white border border-[#b35000] rounded-[10px] text-[18px] bg-[#b35000] transition-all duration-300 ease-in-out shadow-md leading-[31px] font-[600] hover:shadow-[0px_12px_18px_-6px_#b35000]"
-          id="montserrat-font"
+          data-font="montserrat-font"
         >
           <span className="transition-all duration-300 group-hover:translate-x-1">Get Started</span>
           <IoIosArrowForward className="opacity-0 translate-x-[-8px] group-hover:opacity-100 group-hover:translate-x-0 transition-all duration-300 ease-in-out w-[20px] h-[20px]" />

--- a/src/components/ui/Transparentbtn.tsx
+++ b/src/components/ui/Transparentbtn.tsx
@@ -20,7 +20,7 @@ const Transparentbtn: React.FC<TransparentbtnProps> = ({ text, href, color = '#0
           hover:border-transparent hover:bg-gray-200 mx-auto md:mx-0 max-w-fit
         `}
         style={{ borderColor: color, color }}
-        id="aria-font"
+        data-font="aria-font"
       >
         <span className="text-[17px] font-medium leading-tight sm:text-[18px] md:text-[20px] transition-transform duration-300 group-hover:-translate-x-1">
           {text}

--- a/src/components/ui/help-for-charity.tsx
+++ b/src/components/ui/help-for-charity.tsx
@@ -23,7 +23,10 @@ const InfoSection: React.FC<SectionProps> = ({
             {title}
           </h1>
         )}
-        <p className={`text-[18px] font-[500] text-black text-${descriptionAlign}`} id="lato-font">
+        <p
+          className={`text-[18px] font-[500] text-black text-${descriptionAlign}`}
+          data-font="lato-font"
+        >
           {description}
         </p>
       </div>

--- a/src/components/ui/trainingcard.tsx
+++ b/src/components/ui/trainingcard.tsx
@@ -22,7 +22,7 @@ const TrainingCard: React.FC<TrainingCardProps> = ({ src, heading, text }) => {
       <h3 className="font-semibold text-2xl leading-tight text-black mb-3">{heading}</h3>
 
       {/* Text */}
-      <p className="font-[600] text-[18px] leading-[24px] text-[#666]" id="lato-font">
+      <p className="font-[600] text-[18px] leading-[24px] text-[#666]" data-font="lato-font">
         {text}
       </p>
     </div>

--- a/src/components/volunteer/Free-For-Charity/index.tsx
+++ b/src/components/volunteer/Free-For-Charity/index.tsx
@@ -11,28 +11,37 @@ const Index = () => {
           <h1 className="text-[30px] md:text-[40px] font-[700] leading-[44px] text-[#b35000] mb-[20px]">
             Free for Charity Volunteer Options
           </h1>
-          <p className="text-[18px] font-[500] text-black pb-[1em]" id="lato-font">
+          <p className="text-[18px] font-[500] text-black pb-[1em]" data-font="lato-font">
             Free for Charity is always looking for motivated and skilled people from around the US
             to help guide and participate in our training programs and direct support to charities.
           </p>
-          <p className="text-[18px] font-[700] text-black mb-[50px]" id="lato-font">
+          <p className="text-[18px] font-[700] text-black mb-[50px]" data-font="lato-font">
             You can help in the following ways:
           </p>
         </div>
 
         {/* Callout Box */}
         <div className="bg-[#2D7F87] py-[20px] md:py-[40px] md:px-[60px]  px-[30px] flex flex-col items-center justify-center text-center">
-          <h1 className="text-[26px] font-[500] leading-[26px] text-white pb-[10px]" id="aria-font">
+          <h1
+            className="text-[26px] font-[500] leading-[26px] text-white pb-[10px]"
+            data-font="aria-font"
+          >
             IMPORTANT: A Prerequisite for All Applicants
           </h1>
-          <p className="text-[14px] font-[500] leading-[24px] text-white pb-[1em]" id="aria-font">
+          <p
+            className="text-[14px] font-[500] leading-[24px] text-white pb-[1em]"
+            data-font="aria-font"
+          >
             To ensure the highest standards of security and competence for the non-profits we serve,
             all prospective volunteers must first complete our{' '}
             <span className="font-[700]">Core Competencies Training Program.</span> This mandatory
             first step is our “proving ground” and ensures you have the foundational skills needed
             to succeed.
           </p>
-          <p className="text-[14px] font-[500] leading-[24px] text-white pb-[20px]" id="aria-font">
+          <p
+            className="text-[14px] font-[500] leading-[24px] text-white pb-[20px]"
+            data-font="aria-font"
+          >
             After you have successfully completed the training and received your certificate, you
             may then apply for one of the specific roles listed below.
           </p>
@@ -52,7 +61,10 @@ const Index = () => {
             You can create a measurable impact to the success of charities nation wide with your
             donation or volunteer hours.
           </h1>
-          <p className="text-[18px] font-[500] leading-[27px] mb-[5.82%] mt-[20px]" id="lato-font">
+          <p
+            className="text-[18px] font-[500] leading-[27px] mb-[5.82%] mt-[20px]"
+            data-font="lato-font"
+          >
             Every organizations success ultimately falls down to how much support the organization
             received for its causes. Here at Free for Charity it is our mission to provide world
             class training programs that at the same time help charities throughout the United
@@ -61,12 +73,15 @@ const Index = () => {
           <h1 className="text-[28px] font-[700] leading-[31px] text-[#b35000]">
             We cannot do the work we do without your support.
           </h1>
-          <p className="text-[18px] font-[500] leading-[27px] pb-[1em] mt-[20px]" id="lato-font">
+          <p
+            className="text-[18px] font-[500] leading-[27px] pb-[1em] mt-[20px]"
+            data-font="lato-font"
+          >
             From the day to day costs of running servers, websites, and paying for software to
             support our training programs; Free for Charity can always put to good use your
             donation. Consider your options to donate today.
           </p>
-          <p className="text-[18px] font-[500] leading-[27px] mb-[5.82%]" id="lato-font">
+          <p className="text-[18px] font-[500] leading-[27px] mb-[5.82%]" data-font="lato-font">
             In addition to financial support, Free for Charity also needs community support through{' '}
             <a href="/volunteer/" className="text-[#0567B1]">
               skilled volunteers
@@ -81,7 +96,7 @@ const Index = () => {
           <a
             href="https://www.idealist.org/en/nonprofit/356bfc8e2ae64f83beea4a4e677e99d7-free-for-charity-state-college#opportunities"
             className="inline-block px-6 py-3 text-[16px] font-bold text-white bg-[#0056B3] rounded-md text-center no-underline transition-colors duration-300 ease-in-out hover:bg-[#004494]"
-            id="aria-font"
+            data-font="aria-font"
             target="_blank"
             rel="noopener noreferrer"
           >


### PR DESCRIPTION
## Summary

Fixes **#305**. Many elements applied a font via a hardcoded `id` used purely as a CSS hook (`id="lato-font"`, `id="aria-font"`, `id="raleway-font"`, …). Because the same id repeated across dozens of elements — often several times on a single rendered page — this was **invalid HTML** (`id` must be unique per document).

## Change
- Converts **all 11 font-hook ids** (`lato-font`, `aria-font`, `montserrat-font`, `abeezee`, `segoe-font`, `cinzel`, `fauna-font`, `cantata-font`, `raleway-font`, `courier-font`, `faustina-font`) — **304 occurrences across 111 files** — from `id="…"` to repeatable `data-font="…"` attributes.
- Switches the matching `src/app/globals.css` rules from `#id` selectors to `[data-font='…']` attribute selectors.

### Why `data-font` rather than a class
`data-*` attributes are valid to repeat, so this is a clean 1:1 rename regardless of whether an element already has a `className` (and where) — no risky className-merge across 300+ varied/multiline call sites. Every rule already uses `!important` and each element carries exactly one `data-font` value, so **font rendering is unchanged**.

### Left untouched
Legitimate unique ids — `id="header"` (single use) and in-page anchor targets like `id="team"`, `id="section3"` — are not modified.

## Verification
- `npm run build` ✅ (static export, 39 pages)
- `npm run lint` ✅ (0 errors)
- `npm run test` ✅ — **359 passing**, including the render + jest-axe suites added in #304 that exercise every component and page
- Confirmed **0** remaining font-hook `id=` occurrences

Fixes #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014W4FydyhP3fnKxSYJMG5eP)_