### PR TITLE
perf: convert raw &lt;img&gt; to next/Image (CLS + lazy-loading)

### DIFF
--- a/__tests__/components/free-charity-web-hosting/About-FFC-Hosting/index.test.tsx
+++ b/__tests__/components/free-charity-web-hosting/About-FFC-Hosting/index.test.tsx
@@ -21,7 +21,7 @@ describe('AboutFFCHosting Component', () => {
 
   it('renders the image with correct alt text', () => {
     render(<AboutFFCHosting />)
-    const image = screen.getByAltText('Example')
+    const image = screen.getByAltText('Free For Charity hosting dashboard')
     expect(image).toBeInTheDocument()
     expect(image).toHaveAttribute('src', '/Images/About-FFC-Hosting.webp')
   })

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -7,6 +7,7 @@ import { hubUrl } from '@/lib/config'
 
 import { FaFacebookF, FaLinkedinIn, FaGithub } from 'react-icons/fa'
 import { FaXTwitter } from 'react-icons/fa6'
+import Image from 'next/image'
 import { assetPath } from '@/lib/assetPath'
 
 const Footer: React.FC = () => {
@@ -38,10 +39,12 @@ const Footer: React.FC = () => {
               target="_blank"
               rel="noopener noreferrer"
             >
-              <img
+              <Image
                 src={assetPath('/Svgs/footerImage.svg')}
                 alt="GuideStar Platinum Seal of Transparency"
                 aria-label="GuideStar Platinum Seal of Transparency"
+                width={108}
+                height={108}
               />
             </a>
             <Link

--- a/src/components/free-charity-web-hosting/About-FFC-Hosting/index.tsx
+++ b/src/components/free-charity-web-hosting/About-FFC-Hosting/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import Image from 'next/image'
 import { assetPath } from '@/lib/assetPath'
 
 const index = () => {
@@ -7,9 +8,11 @@ const index = () => {
       <div className="pb-[3px] pt-[27px] w-[90%] lg:w-[80%] mx-auto flex flex-col md:flex-row gap-[40px] md:gap-[0px]">
         <div className="w-full md:w-[38.2%] mr-[32px]">
           <div className="rounded-[15px] overflow-hidden shadow-[0px_2px_18px_0px_rgba(0,0,0,0.3)] w-full">
-            <img
+            <Image
               src={assetPath('/Images/About-FFC-Hosting.webp')}
-              alt="Example"
+              alt="Free For Charity hosting dashboard"
+              width={1200}
+              height={810}
               className="w-full h-auto object-cover"
             />
           </div>

--- a/src/components/free-for-charity-endowment-fund-components/Hero/index.tsx
+++ b/src/components/free-for-charity-endowment-fund-components/Hero/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Link from 'next/link'
+import Image from 'next/image'
 import { assetPath } from '@/lib/assetPath'
 
 const Index = () => {
@@ -32,10 +33,12 @@ const Index = () => {
 
         {/* Image Section */}
         <div className="flex justify-center md:justify-start pt-[50px] md:pt-[64px]">
-          <img
+          <Image
             src={assetPath('/Images/hero-img.webp')}
             alt="Person signing donation agreement"
-            className="w-full max-w-[512px] rounded-[6px] shadow-2xl object-cover"
+            width={512}
+            height={512}
+            className="w-full max-w-[512px] h-auto rounded-[6px] shadow-2xl object-cover"
           />
         </div>
       </section>

--- a/src/components/guidestar-guide/Faqs/index.tsx
+++ b/src/components/guidestar-guide/Faqs/index.tsx
@@ -279,6 +279,7 @@ const index = () => {
               target="_blank"
               rel="noopener noreferrer"
             >
+              {/* eslint-disable-next-line @next/next/no-img-element -- external dynamic GuideStar badge served from their host; not a local optimizable asset */}
               <img
                 src="https://widgets.guidestar.org/TransparencySeal/9326392"
                 alt="GuideStar Transparency Seal"

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -7,6 +7,7 @@ import { FiMenu, FiChevronDown } from 'react-icons/fi'
 import { LiaSearchSolid } from 'react-icons/lia'
 import { RxCross2 } from 'react-icons/rx'
 import { motion, AnimatePresence } from 'framer-motion'
+import Image from 'next/image'
 import { assetPath } from '@/lib/assetPath'
 
 interface DropdownItem {
@@ -155,10 +156,12 @@ const Header: React.FC = () => {
               className={`transition-all duration-300 ${isScrolled ? 'w-[110px]' : 'w-[150px]'}`}
             >
               <Link href="/" onClick={handleLinkClick} className="block">
-                <img
+                <Image
                   src={assetPath('/Images/ffc-logo-banner.webp')}
                   alt="Free For Charity"
-                  className={`transition-all duration-300 ${isScrolled ? 'h-7' : 'h-11'}`}
+                  width={686}
+                  height={234}
+                  className={`w-auto transition-all duration-300 ${isScrolled ? 'h-7' : 'h-11'}`}
                 />
               </Link>
             </div>

--- a/src/components/ui/General-Donation-Card.tsx
+++ b/src/components/ui/General-Donation-Card.tsx
@@ -33,6 +33,7 @@ const GeneralDonationCard: React.FC<GeneralDonationCardProps> = ({
 
       {/* Image */}
       <div className="flex justify-center">
+        {/* eslint-disable-next-line @next/next/no-img-element -- dynamic donation logo; intrinsic aspect ratio varies per image (w-auto), so next/Image's fixed dimensions would distort it */}
         <img src={assetPath(img)} alt="Donation image" className="h-12 w-auto object-contain" />
       </div>
     </Link>

--- a/src/components/ui/trainingcard.tsx
+++ b/src/components/ui/trainingcard.tsx
@@ -1,6 +1,7 @@
 // components/ui/TrainingCard.tsx
 'use client'
 import React from 'react'
+import Image from 'next/image'
 
 interface TrainingCardProps {
   src: string
@@ -14,7 +15,7 @@ const TrainingCard: React.FC<TrainingCardProps> = ({ src, heading, text }) => {
       {/* Icon */}
       <div className="mb-6 flex justify-center">
         <div className="w-20 h-20 flex items-center justify-center">
-          <img src={src} alt={heading} className="w-20 h-20" />
+          <Image src={src} alt={heading} width={80} height={80} className="w-20 h-20" />
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

Resolves all `@next/next/no-img-element` lint warnings and improves Core Web Vitals. Each converted image now declares an explicit intrinsic size, so the browser reserves layout space (less **CLS**, which Lighthouse — already in CI — scores) and gets automatic lazy-loading/async decoding.

## Converted to `next/Image` (5)
| Component | Image | Dimensions |
|---|---|---|
| `header` | FFC logo | 686×234 (kept responsive `h-7`/`h-11`, added `w-auto`) |
| `footer` | GuideStar seal | 108×108 |
| `free-charity-web-hosting/About-FFC-Hosting` | hosting shot | 1200×810 |
| `free-for-charity-endowment-fund-components/Hero` | hero | 512×512 (added `h-auto`) |
| `ui/trainingcard` | icon | 80×80 |

Dimensions were read from the actual asset files, so aspect ratios are exact.

## Intentionally kept as `<img>` (2, with documented `eslint-disable`)
- **`guidestar-guide/Faqs`** — external GuideStar badge served from their host; not a local optimizable asset.
- **`ui/General-Donation-Card`** — dynamic logo whose intrinsic ratio varies per image (`w-auto`); fixed `Image` dimensions would distort it.

## Also
- Improved `About-FFC-Hosting` alt text from the placeholder `"Example"` → `"Free For Charity hosting dashboard"` (a11y), and updated its test assertion to match.

## Verification
- `npm run lint` — **0** `no-img-element` warnings, 0 errors
- `npm run build` — green (static export, 39 pages)
- `npm run test` — **359 passing**
- Playwright `image-loading.spec.ts` + `logo.spec.ts` — **6/6 passing** against the built site (real-browser confirmation the logo/images render)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014W4FydyhP3fnKxSYJMG5eP)_