### PR TITLE
fix: resolve React hook lint warnings (behavior-preserving)

### DIFF
--- a/src/components/cookie-consent/index.tsx
+++ b/src/components/cookie-consent/index.tsx
@@ -307,6 +307,7 @@ export default function CookieConsent() {
     }
 
     // Check if user has already made a choice with error handling
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- must read persisted consent from localStorage on the client after hydration; a lazy useState initializer runs during static prerender where localStorage is undefined, so it can never load saved prefs
     loadPreferencesFromLocalStorage(true)
 
     // Cleanup function to remove the window method

--- a/src/components/free-charity-web-hosting/ClientTestimonials/index.tsx
+++ b/src/components/free-charity-web-hosting/ClientTestimonials/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useCallback } from 'react'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { testimonials } from '@/data/testimonials'
 import { assetPath } from '@/lib/assetPath'
@@ -10,28 +10,30 @@ export default function TestimonialSlider() {
   const [isHovered, setIsHovered] = useState(false)
   const [transitioning, setTransitioning] = useState(false)
 
-  useEffect(() => {
-    if (!isHovered) {
-      const interval = setInterval(() => handleNext(), 5000)
-      return () => clearInterval(interval)
-    }
-  }, [isHovered])
-
-  const handlePrev = () => {
-    startTransition((prev) => (prev - 1 + testimonials.length) % testimonials.length)
-  }
-
-  const handleNext = () => {
-    startTransition((prev) => (prev + 1) % testimonials.length)
-  }
-
-  const startTransition = (getNextIndex: (prev: number) => number) => {
+  const startTransition = useCallback((getNextIndex: (prev: number) => number) => {
     setTransitioning(true)
     setTimeout(() => {
       setCurrentIndex(getNextIndex)
       setTimeout(() => setTransitioning(false), 300)
     }, 300)
-  }
+  }, [])
+
+  const handleNext = useCallback(
+    () => startTransition((prev) => (prev + 1) % testimonials.length),
+    [startTransition]
+  )
+
+  const handlePrev = useCallback(
+    () => startTransition((prev) => (prev - 1 + testimonials.length) % testimonials.length),
+    [startTransition]
+  )
+
+  useEffect(() => {
+    if (!isHovered) {
+      const interval = setInterval(handleNext, 5000)
+      return () => clearInterval(interval)
+    }
+  }, [isHovered, handleNext])
 
   return (
     <div className="py-16 bg-white">

--- a/src/components/free-charity-web-hosting/FAQs/index.tsx
+++ b/src/components/free-charity-web-hosting/FAQs/index.tsx
@@ -1,5 +1,5 @@
 'use client'
-import React, { useState, useRef, useEffect } from 'react'
+import React, { useState, useRef } from 'react'
 import { FaPlus, FaMinus } from 'react-icons/fa'
 
 /* ---------------------------------------------------
@@ -21,19 +21,32 @@ const AccordionItem: React.FC<AccordionItemProps> = ({
   small = false,
 }) => {
   const [height, setHeight] = useState('0px')
-  const contentRef = useRef<HTMLDivElement>(null)
+  const [measured, setMeasured] = useState(false)
+  const contentRef = useRef<HTMLDivElement | null>(null)
 
-  useEffect(() => {
-    if (contentRef.current) {
-      setHeight(isOpen ? `${contentRef.current.scrollHeight}px` : '0px')
+  // Ref callback measures the content the moment the node mounts so that
+  // items rendered open on first paint expand without a layout effect.
+  const measureRef = (node: HTMLDivElement | null) => {
+    contentRef.current = node
+    if (node && isOpen && !measured) {
+      setHeight(`${node.scrollHeight}px`)
+      setMeasured(true)
     }
-  }, [isOpen])
+  }
+
+  const handleToggle = () => {
+    const next = !isOpen
+    if (contentRef.current) {
+      setHeight(next ? `${contentRef.current.scrollHeight}px` : '0px')
+    }
+    onToggle()
+  }
 
   return (
     <div className="mb-4 border-2 border-[#0567B1] rounded-[10px] overflow-hidden transition-all duration-300">
       {/* Header */}
       <button
-        onClick={onToggle}
+        onClick={handleToggle}
         className={`w-full px-4 py-3 flex items-center justify-between text-left transition-all duration-300 cursor-pointer ${
           isOpen ? 'bg-white/90' : 'bg-none'
         }`}
@@ -66,10 +79,10 @@ const AccordionItem: React.FC<AccordionItemProps> = ({
         className={`overflow-hidden transition-all duration-500 ease-in-out ${
           isOpen ? 'bg-white/90' : 'bg-white'
         }`}
-        style={{ maxHeight: height }}
+        style={{ maxHeight: isOpen ? height : '0px' }}
       >
         <div
-          ref={contentRef}
+          ref={measureRef}
           className={`px-4 pb-4 pt-2 font-[500] transition-colors duration-300 ${
             small ? 'text-[16px] leading-[26px]' : 'text-[18px] leading-[29px]'
           }`}

--- a/src/components/home-page/VoicesofGratitude/index.tsx
+++ b/src/components/home-page/VoicesofGratitude/index.tsx
@@ -20,7 +20,7 @@ export default function TestimonialSlider() {
     }, 4000) // Change slide every 4 seconds
 
     return () => clearInterval(interval)
-  }, [isPaused, testimonials.length])
+  }, [isPaused])
 
   const goToSlide = (index: number) => {
     setCurrentIndex(index)

--- a/src/components/home/Testimonials/index.tsx
+++ b/src/components/home/Testimonials/index.tsx
@@ -53,6 +53,7 @@ const TestimonialSlider: React.FC = () => {
           prevEl?: HTMLElement | null
           nextEl?: HTMLElement | null
         }
+        // eslint-disable-next-line react-hooks/immutability -- intentional Swiper navigation wiring: assigning prev/next els to the instance's navigation params before init() is the library's documented imperative pattern
         navigationParams.prevEl = prevRef.current
         navigationParams.nextEl = nextRef.current
       }

--- a/src/components/ui/Accordian.tsx
+++ b/src/components/ui/Accordian.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState, useRef, useEffect } from 'react'
+import React, { useState, useRef } from 'react'
 import { FaPlus, FaMinus } from 'react-icons/fa'
 
 interface AccordionItemProps {
@@ -14,13 +14,13 @@ const AccordionItem: React.FC<AccordionItemProps> = ({ number, title, children }
   const [height, setHeight] = useState('0px')
   const contentRef = useRef<HTMLDivElement>(null)
 
-  useEffect(() => {
+  const toggle = () => {
+    const next = !isOpen
+    setIsOpen(next)
     if (contentRef.current) {
-      setHeight(isOpen ? `${contentRef.current.scrollHeight}px` : '0px')
+      setHeight(next ? `${contentRef.current.scrollHeight}px` : '0px')
     }
-  }, [isOpen])
-
-  const toggle = () => setIsOpen(!isOpen)
+  }
 
   return (
     <div className="mb-5 border border-[#1c6e92] rounded-[10px] overflow-hidden">

--- a/src/components/ui/AccordianBold.tsx
+++ b/src/components/ui/AccordianBold.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState, useRef, useEffect } from 'react'
+import React, { useState, useRef } from 'react'
 import { FaPlus, FaMinus } from 'react-icons/fa'
 
 interface AccordionItemProps {
@@ -14,13 +14,13 @@ const AccordionItem: React.FC<AccordionItemProps> = ({ number, title, children }
   const [height, setHeight] = useState('0px')
   const contentRef = useRef<HTMLDivElement>(null)
 
-  useEffect(() => {
+  const toggle = () => {
+    const next = !isOpen
+    setIsOpen(next)
     if (contentRef.current) {
-      setHeight(isOpen ? `${contentRef.current.scrollHeight}px` : '0px')
+      setHeight(next ? `${contentRef.current.scrollHeight}px` : '0px')
     }
-  }, [isOpen])
-
-  const toggle = () => setIsOpen(!isOpen)
+  }
 
   return (
     <div className="mb-5 border-[6px] border-[#0C71C3] rounded-[25px] overflow-hidden">

--- a/src/components/ui/CallToActionCard.tsx
+++ b/src/components/ui/CallToActionCard.tsx
@@ -13,6 +13,7 @@ const IconTextCard: React.FC<IconTextCardProps> = ({ icon, iconLabel = 'icon', t
   const cardRef = useRef<HTMLDivElement | null>(null)
 
   useEffect(() => {
+    const node = cardRef.current
     const observer = new IntersectionObserver(
       (entries) => {
         entries.forEach((entry) => {
@@ -25,10 +26,10 @@ const IconTextCard: React.FC<IconTextCardProps> = ({ icon, iconLabel = 'icon', t
       { threshold: 0.3 } // 30% visible triggers animation
     )
 
-    if (cardRef.current) observer.observe(cardRef.current)
+    if (node) observer.observe(node)
 
     return () => {
-      if (cardRef.current) observer.unobserve(cardRef.current)
+      if (node) observer.unobserve(node)
     }
   }, [])
 

--- a/src/components/ui/Frequently-Asked-Questions.tsx
+++ b/src/components/ui/Frequently-Asked-Questions.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState, useRef, useEffect } from 'react'
+import React, { useState, useRef } from 'react'
 import Image from 'next/image'
 import { assetPath } from '@/lib/assetPath'
 
@@ -14,13 +14,13 @@ const FrequentlyAskedQuestions: React.FC<AccordionItemProps> = ({ title, childre
   const [height, setHeight] = useState('0px')
   const contentRef = useRef<HTMLDivElement>(null)
 
-  useEffect(() => {
+  const toggle = () => {
+    const next = !isOpen
+    setIsOpen(next)
     if (contentRef.current) {
-      setHeight(isOpen ? `${contentRef.current.scrollHeight}px` : '0px')
+      setHeight(next ? `${contentRef.current.scrollHeight}px` : '0px')
     }
-  }, [isOpen])
-
-  const toggle = () => setIsOpen(!isOpen)
+  }
 
   return (
     <div className="mb-5 overflow-hidden" data-font="lato-font">

--- a/src/components/ui/OrangeFaqItem.tsx
+++ b/src/components/ui/OrangeFaqItem.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState, useRef, useEffect } from 'react'
+import React, { useState, useRef } from 'react'
 import Image from 'next/image'
 import { assetPath } from '@/lib/assetPath'
 
@@ -14,13 +14,13 @@ const AccordionItem: React.FC<AccordionItemProps> = ({ title, children }) => {
   const [height, setHeight] = useState('0px')
   const contentRef = useRef<HTMLDivElement>(null)
 
-  useEffect(() => {
+  const toggle = () => {
+    const next = !isOpen
+    setIsOpen(next)
     if (contentRef.current) {
-      setHeight(isOpen ? `${contentRef.current.scrollHeight}px` : '0px')
+      setHeight(next ? `${contentRef.current.scrollHeight}px` : '0px')
     }
-  }, [isOpen])
-
-  const toggle = () => setIsOpen(!isOpen)
+  }
 
   return (
     <div


### PR DESCRIPTION
## Summary

Clears the remaining `react-hooks/*` lint warnings with behavior-preserving changes. After this, `npm run lint` reports **0 warnings** from source (down from 19 at the start of this cleanup arc).

## Genuine fixes
- **Accordions** (`Accordian`, `AccordianBold`, `Frequently-Asked-Questions`, `OrangeFaqItem`, `free-charity-web-hosting/FAQs`) — `react-hooks/set-state-in-effect`. Drop the effect that measured `scrollHeight`; measure in the toggle handler instead. Behavior is identical because the inner content div always reports its full `scrollHeight` regardless of the clipping wrapper. `FAQs` (parent-owned single-open state) additionally binds the wrapper to `isOpen` and uses a one-shot ref callback, so a sibling-driven close and first-paint-open both work without an effect.
- **`ClientTestimonials`** — `useCallback`-wrap `startTransition`/`handleNext`/`handlePrev` and order them before the autoplay effect (fixes used-before-declared + missing-dependency).
- **`VoicesofGratitude`** — drop the non-reactive `testimonials.length` effect dependency.
- **`CallToActionCard`** — capture `cardRef.current` in a local before the `IntersectionObserver` cleanup uses it.

## Intentional patterns kept (documented `eslint-disable`)
- **`home/Testimonials`** — imperative Swiper navigation wiring (`navigationParams.prevEl/nextEl`) before `init()` is the library's documented pattern.
- **`cookie-consent`** — consent must be read from `localStorage` in an effect after hydration; a lazy `useState` initializer runs during static prerender where `localStorage` is undefined and could never load saved preferences.

## Verification
- `npm run lint` — **0** `react-hooks` warnings, 0 errors
- `npm run build` — green (39 static pages)
- `npm run test` — **359 passing**
- Interactive Playwright check — the FAQ accordion still expands/collapses on click (`aria-expanded` toggles correctly)

Refs #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014W4FydyhP3fnKxSYJMG5eP)_