### PR TITLE
fix: post-cutover cleanup — author redirect, smoke-test, lychee, docs

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -53,21 +53,17 @@ https://sdgs.un.org/goals/**
 # Internal GitHub Actions badge URLs — always valid when the workflow exists
 https://github.com/FreeForCharity/FFC-IN-freeforcharity.org/actions/**
 
-# Pre-cutover: the apex domain still points at WordPress, so any link in
-# the Next.js source pointing at https://freeforcharity.org/* would hit
-# WP and report misleading 200s/404s. Skip until cutover lands.
-#
-# POST-CUTOVER ACTION: once the document-root swap is complete and the
-# 48-hour soak has passed, narrow these to only the paths we don't own:
-#     https://freeforcharity.org/hub/**          (WHMCS, third-party)
-#     https://www.freeforcharity.org/hub/**      (WHMCS, third-party)
-#     https://freeforcharity.org/cdn-cgi/**      (Cloudflare-managed)
-#     https://www.freeforcharity.org/cdn-cgi/**  (Cloudflare-managed)
-# That lets lychee validate every /about-us, /donate, /volunteer, etc.
-# against the live new site, catching broken internal links the next
-# time someone touches a navigation component.
-https://freeforcharity.org/**
-https://www.freeforcharity.org/**
+# Post-cutover: the apex now serves the Next.js static site from cPanel,
+# so lychee validates every internal link (/about-us, /donate, /volunteer,
+# etc.) against the live new site — catching broken internal links the next
+# time someone touches a navigation component. Only the paths we don't own
+# stay excluded:
+#     /hub/**     → WHMCS (third-party app, served via symlink)
+#     /cdn-cgi/** → Cloudflare-managed endpoints
+https://freeforcharity.org/hub/**
+https://www.freeforcharity.org/hub/**
+https://freeforcharity.org/cdn-cgi/**
+https://www.freeforcharity.org/cdn-cgi/**
 
 # Sites that block CI crawlers or are intentionally placeholder / flaky
 https://my.interserver.net/**

--- a/docs/CUTOVER-HANDOFF.md
+++ b/docs/CUTOVER-HANDOFF.md
@@ -1,7 +1,11 @@
 # Cutover Handoff — Free For Charity WordPress → Next.js (InterServer cPanel)
 
+> **✅ Cutover complete.** The apex `freeforcharity.org` now serves the
+> Next.js static export from cPanel (`public_html_next`). This document is
+> retained as a historical record and rollback reference.
+
 The pre-cutover engineering work is complete. This document describes
-what is done and the operator steps that remain.
+what was done and the operator steps that remain.
 
 > **Cutover day?** Follow [CUTOVER-RUNBOOK.md](CUTOVER-RUNBOOK.md) — a
 > single chronological checklist that links back here for the details.

--- a/docs/CUTOVER-REDIRECTS.md
+++ b/docs/CUTOVER-REDIRECTS.md
@@ -1,5 +1,9 @@
 # Cutover Redirect Plan
 
+> **✅ Cutover complete.** These redirects are live in
+> [`public/.htaccess`](../public/.htaccess) on the cPanel server and are
+> verified by `scripts/smoke-test.mjs`.
+
 URL changes between the WordPress site (`wordpress-static-export-2026-02-16`
 tag, 60 pages) and the Next.js redesign (~36 routes).
 

--- a/docs/CUTOVER-RUNBOOK.md
+++ b/docs/CUTOVER-RUNBOOK.md
@@ -1,5 +1,9 @@
 # Cutover Day Runbook
 
+> **✅ Cutover complete.** freeforcharity.org has been flipped to the
+> Next.js static export. This runbook is retained for historical reference
+> and in case a future re-cutover or rollback is needed.
+
 A single, chronological checklist for flipping freeforcharity.org from
 WordPress to the Next.js static export. Follow top to bottom. Each step
 links to the detailed doc when you need the full reasoning.

--- a/docs/STAGING-CHECKLIST.md
+++ b/docs/STAGING-CHECKLIST.md
@@ -1,5 +1,9 @@
 # Staging Verification Checklist
 
+> **✅ Cutover complete.** The document-root swap has happened and the
+> apex now serves the Next.js build. This checklist is retained as a
+> historical record / template for future staged deploys.
+
 Use this checklist to verify the staged Next.js site before swapping
 the cPanel document root from `public_html` (WordPress) to
 `public_html_next` (the new build).

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -58,8 +58,9 @@ RewriteRule ^testimonial/keith-ray/?$ /#testimonials [R=301,L]
 RewriteRule ^testimonial/pardhasaradhi-namburi/?$ /#testimonials [R=301,L]
 RewriteRule ^testimonial/tashonda-payne/?$ /#testimonials [R=301,L]
 
-# Dropped WP archives + plumbing → home
-RewriteRule ^author/(adagraves|admin|clarkemoyer|globaladmin|joel|tempmigrationadmin)/?$ / [R=301,L]
+# Author archives dropped → closest equivalent content
+RewriteRule ^author/(adagraves|admin|clarkemoyer|globaladmin|joel|tempmigrationadmin)/?$ /about-us/ [R=301,L]
+# Dropped WP archives + plumbing → home (or closest section)
 RewriteRule ^category/uncategorized/?$ /blog/ [R=301,L]
 RewriteRule ^layout_type/(row|section)/?$ / [R=301,L]
 RewriteRule ^module_width/regular/?$ / [R=301,L]

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -177,12 +177,10 @@ async function main() {
   console.log(`\n-- WP→Next legacy redirects from docs/cutover-redirects.csv`)
   const redirects = loadCsvRedirects()
   for (const r of redirects) {
-    await checkRedirect(
-      `${r.code} ${r.sourcePath}`,
-      r.sourcePath,
-      r.code,
-      r.targetPath.split('#')[0]
-    )
+    // Match the full target including any #fragment. Apache emits the
+    // fragment in the Location header (e.g. /testimonial/* → /#testimonials),
+    // so stripping it here would falsely reject correct redirects.
+    await checkRedirect(`${r.code} ${r.sourcePath}`, r.sourcePath, r.code, r.targetPath)
   }
 
   console.log(`\n-- defense-in-depth`)


### PR DESCRIPTION
## Summary

Now that the apex `freeforcharity.org` serves the Next.js static build from cPanel, this cleans up the issues that surfaced during a post-cutover verification of the live site.

I ran `BASE_URL=https://freeforcharity.org npm run smoke-test` and found **10 failures**, with two distinct root causes (both fixed here):

### 1. Real `.htaccess` bug — `/author/*` redirect (6 failures)
`public/.htaccess` sent `/author/{clarkemoyer,joel,…}/` to `/`, but `docs/cutover-redirects.csv` (the source of truth) specifies **`/about-us/`** ("author archive dropped → closest content"). Fixed the rule target.

### 2. Smoke-test false positive — `#fragment` matching (4 failures)
The `/testimonial/*` → `/#testimonials` redirects are **correct** on the live site, but `scripts/smoke-test.mjs` stripped the `#fragment` from the expected target before comparing. Apache *emits* the fragment in the `Location` header, so the strip made correct redirects fail. Now it matches the full target.

**Verified against live:** 68/78 → **72/78**. The remaining 6 are the `/author/*` checks, which pass once the corrected `.htaccess` is deployed to cPanel.

### 3. `.lycheeignore` — post-cutover narrowing
Per the file's own documented "POST-CUTOVER ACTION", narrowed the `freeforcharity.org` excludes to just the paths we don't own (`/hub/**`, `/cdn-cgi/**`). Lychee now validates every internal link against the live site. Confirmed all absolute internal links in source currently return 200.

### 4. Docs — "cutover complete" banners
Added status banners to `CUTOVER-HANDOFF.md`, `CUTOVER-RUNBOOK.md`, `STAGING-CHECKLIST.md`, and `CUTOVER-REDIRECTS.md` so the runbooks reflect reality (retained for rollback reference).

## Deployment note
The `/author/*` redirect fix only takes effect on the live site after `public/.htaccess` is redeployed to cPanel (deploy workflow / operator). Everything else is repo-side.

Refs #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014W4FydyhP3fnKxSYJMG5eP)_