### PR TITLE
fix(deploy): target live docroot ~/public_html (was a no-op parking dir) + smoke hardening

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,10 +1,12 @@
 # Copilot Instructions: FFC-IN-freeforcharity.org
 
-Free For Charity main nonprofit website. Next.js static site on GitHub Pages at freeforcharity.org.
+Free For Charity main nonprofit website. Next.js 16 static export served in production from InterServer cPanel at freeforcharity.org (apex). GitHub Pages is a manual staging/preview surface only.
 
 ## Workflow
 
 Issue -> branch -> PR -> merge. No direct commits to main.
+
+On merge to `main`, CI (`.github/workflows/ci.yml`, "CI - Build and Test") runs; on green, `.github/workflows/deploy-cpanel.yml` mirrors `out/` into `~/public_html` (production apex docroot) over FTPS, excluding WHMCS at `~/public_html/hub` and cPanel keepers. GitHub Pages staging is a manual preview only (`.github/workflows/deploy-gh-pages-staging.yml`).
 
 ## Pre-Push Checks (in order)
 
@@ -14,7 +16,7 @@ Issue -> branch -> PR -> merge. No direct commits to main.
 
 ## Architecture
 
-- **Framework:** Next.js App Router, TypeScript, Tailwind CSS v4
+- **Framework:** Next.js 16 (`^16.2.9`) App Router, React 19.2.7, TypeScript, Tailwind CSS v4 (Node 24.x)
 - **Output:** Static export (`output: 'export'` in next.config.ts)
 - **Pages:** `src/app/` (~29 routes, App Router conventions)
 - **Components:** `src/components/` (footer/, header/, home-page/, ui/)
@@ -25,7 +27,7 @@ Issue -> branch -> PR -> merge. No direct commits to main.
 
 - Route folders: **kebab-case only** (`about-us/`, not `aboutUs/`)
 - Asset paths: use `assetPath()` from `src/lib/assetPath.ts` for all images
-- `NEXT_PUBLIC_BASE_PATH` controls basePath for GitHub Pages subpath fallback
+- `NEXT_PUBLIC_BASE_PATH` controls basePath for the GitHub Pages subpath (staging/preview at `https://freeforcharity.github.io/FFC-IN-freeforcharity.org/`, basePath `/FFC-IN-freeforcharity.org`); production cPanel serves at ROOT so `NEXT_PUBLIC_BASE_PATH=''`
 - Conventional Commits: `feat:`, `fix:`, `docs:`, `style:`, `refactor:`, `test:`, `chore:`
 
 ## Mandatory Standards

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,7 +18,7 @@ On merge to `main`, CI (`.github/workflows/ci.yml`, "CI - Build and Test") runs;
 
 - **Framework:** Next.js 16 (`^16.2.9`) App Router, React 19.2.7, TypeScript, Tailwind CSS v4 (Node 24.x)
 - **Output:** Static export (`output: 'export'` in next.config.ts)
-- **Pages:** `src/app/` (~29 routes, App Router conventions)
+- **Pages:** `src/app/` (~35 routes, App Router conventions)
 - **Components:** `src/components/` (footer/, header/, home-page/, ui/)
 - **Content:** `src/data/` (team/, faqs/, testimonials/ as JSON + .ts loaders)
 - **Utilities:** `src/lib/`

--- a/.github/workflows/deploy-cpanel.yml
+++ b/.github/workflows/deploy-cpanel.yml
@@ -264,6 +264,16 @@ jobs:
             DELETE_FLAG="--delete"
           fi
 
+          # WHMCS GUARD 1 (pre-mirror): the live WHMCS billing portal lives at
+          # ~/public_html/hub. It is excluded from the mirror below, but if the
+          # Next.js build ever emitted its own out/hub entry, the upload would
+          # push it INTO the live portal directory. Refuse to deploy if out/
+          # contains any 'hub' entry — the build must never own that path.
+          if [ -e out/hub ]; then
+            echo "::error::out/ contains a 'hub' entry — refusing to deploy (would risk the live WHMCS at ~/public_html/hub)."
+            exit 1
+          fi
+
           # ~/public_html IS the live apex docroot. The apex cutover
           # (cpanel-apex-cutover.yml) mirrored the static export straight into
           # ~/public_html — the docroot was NOT swapped to a sibling dir — so
@@ -316,6 +326,37 @@ jobs:
             bye
           LFTP_SCRIPT
           echo "Upload to ~/public_html/ (live docroot) complete."
+
+      # WHMCS GUARD 2 (post-mirror): prove the live billing portal still serves
+      # after the deploy. A regression here (non-200, or a body that no longer
+      # looks like WHMCS) means the mirror damaged ~/public_html/hub — fail hard
+      # so the failure-alert step opens an incident instead of leaving billing
+      # silently broken. Retries absorb Cloudflare edge-cache warm-up.
+      - name: Verify WHMCS /hub survived the deploy
+        if: ${{ steps.freshness.outputs.superseded != 'true' }}
+        env:
+          BASE_URL: ${{ inputs.public_url_base || 'https://freeforcharity.org' }}
+        run: |
+          set -euo pipefail
+          HUB_URL="${BASE_URL%/}/hub/"
+          ok=""
+          for attempt in 1 2 3; do
+            body="$(curl --silent --show-error --location --max-time 25 \
+              -H "Cache-Control: no-cache" "$HUB_URL" || true)"
+            code="$(curl --silent --output /dev/null --location --max-time 25 \
+              -H "Cache-Control: no-cache" -w '%{http_code}' "$HUB_URL" || echo 000)"
+            if [ "$code" = "200" ] && printf '%s' "$body" | grep -Eqi 'whmcs|clientarea|cart\.php'; then
+              echo "WHMCS /hub healthy: HTTP $code with WHMCS marker (attempt $attempt)."
+              ok="yes"
+              break
+            fi
+            echo "WHMCS /hub check attempt $attempt: HTTP $code, no marker yet — retrying."
+            sleep 10
+          done
+          if [ -z "$ok" ]; then
+            echo "::error::WHMCS /hub did NOT survive the deploy (no 200 + WHMCS marker after 3 attempts). The live billing portal may be damaged."
+            exit 1
+          fi
 
       - name: Deploy summary
         if: ${{ steps.freshness.outputs.superseded != 'true' }}

--- a/.github/workflows/deploy-cpanel.yml
+++ b/.github/workflows/deploy-cpanel.yml
@@ -411,8 +411,13 @@ jobs:
       # CI before it can deploy, so an issue here is something the gates can't
       # see — cPanel/Cloudflare drift, an FTP/credential fault, or a live
       # third-party widget regression.
+      # Gated on `superseded != 'true'` so a stale/superseded run that fails
+      # in a non-gated early step (CI lookup, npm ci) can't open a false
+      # production incident — no upload happened on a superseded run. If the
+      # freshness step itself failed/skipped, `superseded` is empty (!= 'true'),
+      # so a genuine early failure still alerts.
       - name: Open high-priority issue on deploy/smoke failure
-        if: failure()
+        if: ${{ failure() && steps.freshness.outputs.superseded != 'true' }}
         uses: actions/github-script@v9
         with:
           script: |

--- a/.github/workflows/deploy-cpanel.yml
+++ b/.github/workflows/deploy-cpanel.yml
@@ -367,6 +367,22 @@ jobs:
             const shortSha = sha.slice(0, 8)
             const date = new Date().toISOString().slice(0, 10)
             const trigger = context.eventName
+            // Ensure the labels exist first. Creating an issue with a missing
+            // label (and the dedupe query below) would otherwise misbehave, so
+            // upsert them (422 = already exists). Same pattern as
+            // deploy-gh-pages-staging.yml.
+            const labelsNeeded = [
+              { name: 'deploy-failure', color: 'b60205', description: 'A production deploy or post-deploy smoke run failed' },
+              { name: 'incident', color: 'd93f0b', description: 'Production incident requiring immediate attention' },
+              { name: 'production-health', color: 'fbca04', description: 'Production health / smoke monitoring' },
+            ]
+            for (const label of labelsNeeded) {
+              try {
+                await github.rest.issues.createLabel({ owner: context.repo.owner, repo: context.repo.repo, ...label })
+              } catch (e) {
+                if (e.status !== 422) throw e // 422 = label already exists
+              }
+            }
             // Dedupe: append to an open deploy-failure issue so a flapping
             // deploy doesn't spam the tracker.
             const existing = await github.rest.issues.listForRepo({

--- a/.github/workflows/deploy-cpanel.yml
+++ b/.github/workflows/deploy-cpanel.yml
@@ -1,34 +1,30 @@
 name: Deploy to InterServer cPanel (production)
 
-# Builds the Next.js static export and uploads it to ~/public_html_next/
-# on the InterServer cPanel host, alongside (not over) the live docroot at
-# ~/public_html/ and the WHMCS instance at ~/public_html/hub/.
+# Builds the Next.js static export and mirrors it into ~/public_html/ — the
+# LIVE apex docroot — on the InterServer cPanel host. The apex cutover
+# (cpanel-apex-cutover.yml) mirrored the static site straight into
+# ~/public_html (the docroot was NOT swapped to a sibling dir), and WHMCS
+# lives at ~/public_html/hub as a real directory, so this deploy targets
+# ~/public_html and excludes the same proven /hub-safe keeper set (hub,
+# cgi-bin, .well-known, the parked-domain docroot, PHP configs, dotfiles).
 #
 # Credential model: GH OIDC -> Azure -> Key Vault (kv-ffc-admin-prod-cbm) ->
-# MAIN cPanel FTP creds -> lftp mirror over FTPS (AUTH TLS) ->
-# ~/public_html_next/. It reuses the
-# existing `cpanel-staging` GitHub Environment (same Azure federated
-# credential + WR_ALL_* env secrets proven by deploy-cpanel-staging.yml), so
-# NO new environment, federated credential, or secret is required. There are
-# no raw FTP_* repository secrets (the old SamKirkland/FTP-Deploy-Action
-# model was retired in favour of KV-OIDC, so no plaintext FTP password ever
-# lives in GitHub).
+# MAIN cPanel FTP creds -> lftp mirror over FTPS (AUTH TLS) -> ~/public_html.
+# It reuses the existing `cpanel-staging` GitHub Environment (same Azure
+# federated credential + WR_ALL_* env secrets proven by
+# deploy-cpanel-staging.yml), so NO new environment, federated credential, or
+# secret is required. There are no raw FTP_* repository secrets (the old
+# SamKirkland/FTP-Deploy-Action model was retired in favour of KV-OIDC, so no
+# plaintext FTP password ever lives in GitHub).
 #
-# Why the MAIN account: the `deploy-prod` FTP login is chrooted to the LIVE
-# ~/public_html/ docroot (verified 2026-06-20) and cannot reach the sibling
-# ~/public_html_next/ parking dir. The main cPanel account is homed at the
-# account root, so it can create/write ~/public_html_next/. deploy-staging is
-# jailed to the staging docroot. Re-verify any account with the reusable
-# "Verify cPanel FTP credential (read-only)" workflow.
+# Why the MAIN account: it is homed at the account root, so it can write
+# ~/public_html. Re-verify any account with the reusable "Verify cPanel FTP
+# credential (read-only)" workflow.
 #
-# POST-CUTOVER: the apex docroot has been swapped to ~/public_html_next/,
-# so this upload IS the live site. The workflow auto-deploys on every merge
-# to main (via workflow_run, after "CI - Build and Test" passes) and runs the
-# live-apex smoke suite afterward. Manual workflow_dispatch is retained for
-# forced/ad-hoc deploys, where the run_smoke/delete_remote inputs still apply.
-#
-# The /hub WHMCS symlink is excluded from the lftp mirror (see the Upload
-# step), so a clean --delete mirror never removes the billing portal.
+# The workflow auto-deploys on every merge to main (via workflow_run, after
+# "CI - Build and Test" passes) and runs the live-apex smoke suite afterward.
+# Manual workflow_dispatch is retained for forced/ad-hoc deploys, where the
+# run_smoke/delete_remote inputs still apply.
 #
 # === Prerequisites -- all already in place (no admin setup remaining) ===
 #   * GitHub Environment `cpanel-staging` with WR_ALL_FFC_AZURE_KV_CLIENT_ID
@@ -53,12 +49,12 @@ on:
   workflow_dispatch:
     inputs:
       delete_remote:
-        description: 'Remove remote files in public_html_next not in the local build (lftp --delete). True = clean mirror; False = additive upload.'
+        description: 'Remove remote files in public_html not in the local build (lftp --delete). True = clean mirror; False = additive upload.'
         required: false
         default: true
         type: boolean
       run_smoke:
-        description: 'Run the full live-apex smoke suite after upload. Only set true AFTER the apex docroot has been cut over to public_html_next.'
+        description: 'Run the full live-apex smoke suite against production after upload.'
         required: false
         default: false
         type: boolean
@@ -80,7 +76,7 @@ concurrency:
 
 jobs:
   build-and-deploy:
-    name: Build + deploy to ~/public_html_next/
+    name: Build + deploy to ~/public_html/ (live apex)
     runs-on: ubuntu-latest
     environment: cpanel-staging
     # Auto-trigger: only deploy when the CI run that fired this succeeded
@@ -203,7 +199,15 @@ jobs:
           # to *.html, and deploy-cpanel-staging.yml asserts the same. Without
           # it the upload would "succeed" but the site would be broken.
           test -f out/.htaccess
-          echo "out/ ready, $(find out -type f | wc -l) files"
+          # Floor on file count: the mirror does a --delete against the LIVE
+          # docroot, so a truncated/partial build must NOT proceed (it would
+          # wipe the live site). A healthy export is ~hundreds of files.
+          count=$(find out -type f | wc -l)
+          if [ "$count" -lt 50 ]; then
+            echo "::error::out/ has only $count files — suspiciously small build, refusing to deploy."
+            exit 1
+          fi
+          echo "out/ ready, $count files"
 
       - name: Azure login (OIDC)
         if: ${{ steps.freshness.outputs.superseded != 'true' }}
@@ -243,7 +247,7 @@ jobs:
           "CPANEL_FTP_USER=$ftpUser"     | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
           "CPANEL_FTP_PASSWORD=$ftpPw"   | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
 
-      - name: Upload out/ to ~/public_html_next/
+      - name: Upload out/ to ~/public_html/ (live apex docroot)
         if: ${{ steps.freshness.outputs.superseded != 'true' }}
         env:
           DELETE_REMOTE: ${{ inputs.delete_remote }}
@@ -260,33 +264,29 @@ jobs:
             DELETE_FLAG="--delete"
           fi
 
-          # lftp mirror notes (identical pattern to deploy-cpanel-staging.yml):
-          #   --reverse           upload (local -> remote) instead of download
-          #   --delete            remove remote files not in local (gated by input)
-          #   --parallel=4        4 concurrent transfers
-          # We mirror ./out/ into ./public_html_next/ (relative to the FTP
-          # user's home). 'hub' is excluded because the cutover runbook
-          # creates a ~/public_html_next/hub SYMLINK to ~/public_html/hub so
-          # WHMCS keeps serving after the docroot swap -- without excluding
-          # it, a --delete re-deploy would remove that symlink and 404 the
-          # billing portal. Both 'hub' and 'hub/' are listed so the exclude
-          # holds whether lftp sees it as a symlink or a directory path. cgi-bin, .well-known, .htpasswd, error_log and
-          # .ftpquota are excluded as defence-in-depth in case the server
-          # ever places them in this dir. The two directory excludes use a
-          # trailing slash ('.well-known/', 'cgi-bin/') so lftp skips the
-          # whole subtree -- a bare name could let --delete recurse into and
-          # remove their children.
-          # NOTE: .htaccess is NOT excluded -- the Next.js out/.htaccess must
-          # deploy or routing breaks (see "Verify build output" above).
-          # Script is piped to lftp via stdin (heredoc) rather than `lftp -c
-          # "..."` so the embedded password never lands in the process argv
-          # (readable via /proc by any side-car). lftp is run without -d so
-          # debug output can't leak transformed credentials past GH masking.
-          # Explicit FTPS (AUTH TLS): ssl-force aborts rather than fall back
-          # to plaintext, so the MAIN-account password is never sent in the
-          # clear; ssl-protect-data encrypts the data channel too;
-          # verify-certificate no accepts cPanel's self-signed/host-mismatched
-          # cert (the connection is still encrypted).
+          # ~/public_html IS the live apex docroot. The apex cutover
+          # (cpanel-apex-cutover.yml) mirrored the static export straight into
+          # ~/public_html — the docroot was NOT swapped to a sibling dir — so
+          # this deploy must target ~/public_html too. (Deploying to
+          # ~/public_html_next/ would write to a dead parking dir and never
+          # reach the live site.)
+          #
+          # The exclude list is the EXACT proven /hub-safe keeper set from
+          # cpanel-apex-cutover.yml. A --delete mirror removes everything in
+          # ~/public_html that isn't in out/, so every keeper MUST be excluded:
+          #   hub, hub/                WHMCS — a REAL directory at ~/public_html/hub
+          #   cgi-bin/, .well-known/   cPanel/system dirs
+          #   wh1319644.ispot.cc/      a parked-domain docroot
+          #   .user.ini, php.ini       PHP configs that /hub INHERITS (it has none)
+          #   .cache/ .tmb/ + dotfiles cPanel/system state
+          # Missing any one would wipe WHMCS, the parked domain, or /hub's PHP
+          # env on the next deploy. .htaccess is NOT excluded — the Next.js
+          # out/.htaccess must deploy or routing/redirects break.
+          #
+          # Creds piped via heredoc stdin (not `lftp -c`) so the password never
+          # lands in the process argv (/proc-readable). FTPS forced (ssl-force),
+          # so the password is never sent in the clear; verify-certificate no
+          # accepts cPanel's self-signed cert (channel still encrypted).
           lftp <<LFTP_SCRIPT 2>&1 | tail -200
             set ftp:ssl-allow yes
             set ftp:ssl-force yes
@@ -299,15 +299,23 @@ jobs:
             mirror --reverse $DELETE_FLAG --parallel=4 --verbose=1 \
               --exclude-glob 'hub' \
               --exclude-glob 'hub/' \
+              --exclude-glob 'cgi-bin/' \
+              --exclude-glob '.well-known/' \
+              --exclude-glob 'wh1319644.ispot.cc/' \
+              --exclude-glob '.cache/' \
+              --exclude-glob '.tmb/' \
               --exclude-glob '.ftpquota' \
               --exclude-glob '.htpasswd' \
               --exclude-glob 'error_log' \
-              --exclude-glob '.well-known/' \
-              --exclude-glob 'cgi-bin/' \
-              ./out/ ./public_html_next/
+              --exclude-glob '.user.ini' \
+              --exclude-glob 'php.ini' \
+              --exclude-glob '.s3backupstatus' \
+              --exclude-glob '.synthquota' \
+              --exclude-glob '.ht_wsr.txt' \
+              ./out/ ./public_html/
             bye
           LFTP_SCRIPT
-          echo "Upload to ~/public_html_next/ complete."
+          echo "Upload to ~/public_html/ (live docroot) complete."
 
       - name: Deploy summary
         if: ${{ steps.freshness.outputs.superseded != 'true' }}
@@ -316,15 +324,15 @@ jobs:
         run: |
           if [ -z "${DELETE_REMOTE:-}" ]; then DELETE_REMOTE=true; fi
           {
-            echo "## Production deploy to ~/public_html_next/"
+            echo "## Production deploy to ~/public_html/ (live apex docroot)"
             echo ""
             echo "- **Trigger:** ${{ github.event_name }}"
             echo "- **Files uploaded:** $(find out -type f | wc -l)"
             echo "- **Clean mirror (--delete):** ${DELETE_REMOTE}"
             echo ""
-            echo "Post-cutover, ~/public_html_next/ is the live apex docroot,"
-            echo "so this upload is live as soon as the Cloudflare cache"
-            echo "refreshes. The smoke step verifies the live apex."
+            echo "~/public_html is the live apex docroot, so this upload is"
+            echo "live as soon as the Cloudflare cache refreshes. The smoke"
+            echo "step verifies the live apex."
           } >> "$GITHUB_STEP_SUMMARY"
 
       # Post-cutover only. Full smoke suite: every sitemap URL returns 200,
@@ -391,8 +399,11 @@ jobs:
               labels: 'deploy-failure',
               state: 'open',
             })
-            if (existing.data.length > 0) {
-              const issue = existing.data[0]
+            // listForRepo returns PRs too (they're issues to the API); only
+            // reuse a real issue, never a PR that happens to carry the label.
+            const openIssue = existing.data.find((i) => !i.pull_request)
+            if (openIssue) {
+              const issue = openIssue
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,

--- a/.github/workflows/deploy-cpanel.yml
+++ b/.github/workflows/deploy-cpanel.yml
@@ -72,6 +72,7 @@ permissions:
   id-token: write # required for OIDC to Azure
   contents: read
   actions: read # required for the CI-green gate (gh run list)
+  issues: write # required to open a high-priority incident issue on failure
 
 concurrency:
   group: deploy-cpanel
@@ -346,3 +347,82 @@ jobs:
             -w "Home: %{http_code} on %{url_effective} in %{time_total}s\n" \
             "${BASE_URL%/}/"
           npm run smoke-test
+
+      # High-priority alert: if ANY step above failed (build, credential
+      # fetch, lftp upload, or the post-deploy smoke), open/append an incident
+      # issue. The live apex serves from the dir this workflow deploys to, so
+      # a failure can mean the site is broken or only partially deployed.
+      # A superseded run skips its steps (success), so it never lands here.
+      # These should be RARE: lint/jest/build/Playwright gate every commit in
+      # CI before it can deploy, so an issue here is something the gates can't
+      # see — cPanel/Cloudflare drift, an FTP/credential fault, or a live
+      # third-party widget regression.
+      - name: Open high-priority issue on deploy/smoke failure
+        if: failure()
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+            const sha = (context.payload.workflow_run && context.payload.workflow_run.head_sha) || context.sha
+            const shortSha = sha.slice(0, 8)
+            const date = new Date().toISOString().slice(0, 10)
+            const trigger = context.eventName
+            // Dedupe: append to an open deploy-failure issue so a flapping
+            // deploy doesn't spam the tracker.
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'deploy-failure',
+              state: 'open',
+            })
+            if (existing.data.length > 0) {
+              const issue = existing.data[0]
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `Deploy/smoke failed again on ${date} for \`${shortSha}\` (${trigger}): ${runUrl}`,
+              })
+              console.log(`Appended to open deploy-failure issue #${issue.number}`)
+              return
+            }
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `🚨 HIGH: production deploy/smoke FAILED — ${shortSha} (${date})`,
+              body: [
+                '## Production deploy or post-deploy smoke failed',
+                '',
+                '**This is a high-priority incident.** The live apex serves from the',
+                'directory this workflow deploys to, so a failure here may mean the',
+                'site is broken or a deploy landed only partially.',
+                '',
+                `- **Workflow run:** ${runUrl}`,
+                `- **Commit:** \`${shortSha}\``,
+                `- **Trigger:** ${trigger}`,
+                '',
+                'Open the run above and read which step failed:',
+                '- **Build / Verify** — a build regression slipped past CI (rare).',
+                '- **Azure login / Key Vault** — OIDC or credential issue.',
+                '- **Upload (lftp)** — FTP/network failure; the live site may be',
+                '  partially mirrored. Re-running the deploy re-mirrors cleanly.',
+                '- **Smoke suite** — the site deployed but a live check failed (broken',
+                '  URL, missing asset, /hub down, PayPal/Zeffy regression, redirect',
+                '  drift). Reproduce: `BASE_URL=https://freeforcharity.org npm run smoke-test`.',
+                '',
+                '## Next steps',
+                '1. Read the failed step\'s logs in the run above.',
+                '2. If the live site is broken, follow `docs/ROLLBACK.md`.',
+                '3. Fix the root cause, then re-run the deploy (or merge a fix — main',
+                '   auto-deploys).',
+                '4. Close this issue once production is verified green.',
+                '',
+                'These should be rare — every commit passes lint/jest/build/Playwright',
+                'in CI before it can deploy. An issue here is something those gates',
+                'cannot catch.',
+                '',
+                '_Opened automatically by `.github/workflows/deploy-cpanel.yml`._',
+              ].join('\n'),
+              labels: ['deploy-failure', 'incident', 'production-health'],
+            })
+            console.log('Created high-priority deploy-failure issue')

--- a/.github/workflows/deploy-cpanel.yml
+++ b/.github/workflows/deploy-cpanel.yml
@@ -341,10 +341,15 @@ jobs:
           HUB_URL="${BASE_URL%/}/hub/"
           ok=""
           for attempt in 1 2 3; do
-            body="$(curl --silent --show-error --location --max-time 25 \
-              -H "Cache-Control: no-cache" "$HUB_URL" || true)"
-            code="$(curl --silent --output /dev/null --location --max-time 25 \
-              -H "Cache-Control: no-cache" -w '%{http_code}' "$HUB_URL" || echo 000)"
+            # Single request: capture the body AND the status code from the
+            # same response. Two separate curls could observe different states
+            # (the portal recovering mid-check) and the marker grep could then
+            # be matched against a different response than the code. Append the
+            # code on its own trailing line, then split body/code apart.
+            resp="$(curl --silent --show-error --location --max-time 25 \
+              -H "Cache-Control: no-cache" -w $'\n%{http_code}' "$HUB_URL" || printf '\n000')"
+            code="${resp##*$'\n'}"
+            body="${resp%$'\n'*}"
             if [ "$code" = "200" ] && printf '%s' "$body" | grep -Eqi 'whmcs|clientarea|cart\.php'; then
               echo "WHMCS /hub healthy: HTTP $code with WHMCS marker (attempt $attempt)."
               ok="yes"

--- a/.github/workflows/deploy-cpanel.yml
+++ b/.github/workflows/deploy-cpanel.yml
@@ -202,7 +202,9 @@ jobs:
           # Floor on file count: the mirror does a --delete against the LIVE
           # docroot, so a truncated/partial build must NOT proceed (it would
           # wipe the live site). A healthy export is ~hundreds of files.
-          count=$(find out -type f | wc -l)
+          # Trim whitespace: `wc -l` can pad with leading spaces on some
+          # platforms, which would break the numeric `-lt` test below.
+          count=$(find out -type f | wc -l | tr -d '[:space:]')
           if [ "$count" -lt 50 ]; then
             echo "::error::out/ has only $count files — suspiciously small build, refusing to deploy."
             exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ src/
     globals.css         # Global styles (Tailwind v4 imports)
     sitemap.ts          # Dynamic sitemap generator
     robots.ts           # Robots.txt generator
-    [route]/page.tsx    # ~29 additional routes
+    [route]/page.tsx    # ~35 routes total
   components/           # Reusable UI components
     footer/             # Mandatory 3-column footer (FFC standard)
     header/             # Navigation header

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,15 +8,16 @@
 
 ## Tech Stack
 
-| Layer     | Technology                                                  |
-| --------- | ----------------------------------------------------------- |
-| Framework | Next.js with App Router (see package.json for version)      |
-| Language  | TypeScript (strict mode)                                    |
-| Styling   | Tailwind CSS v4 (CSS-based config, no tailwind.config file) |
-| Export    | Static (`output: 'export'` in next.config.ts)               |
-| Hosting   | GitHub Pages (custom domain freeforcharity.org)             |
-| CI/CD     | GitHub Actions                                              |
-| Testing   | Playwright (E2E)                                            |
+| Layer     | Technology                                                       |
+| --------- | ---------------------------------------------------------------- |
+| Framework | Next.js 16 (App Router) — `next ^16.2.9`, React `19.2.7`         |
+| Runtime   | Node 24.x                                                        |
+| Language  | TypeScript (strict mode)                                         |
+| Styling   | Tailwind CSS v4 (CSS-based config, no tailwind.config file)      |
+| Export    | Static (`output: 'export'` in next.config.ts)                    |
+| Hosting   | InterServer cPanel (apex freeforcharity.org, served from root)   |
+| CI/CD     | GitHub Actions (`ci.yml` build+test, `deploy-cpanel.yml` deploy) |
+| Testing   | Playwright (E2E)                                                 |
 
 ---
 
@@ -48,6 +49,7 @@ All changes follow this process:
    3. `npm run test` -- Run Playwright E2E tests
 5. **PR** -- Open a Pull Request, link to the issue with `Fixes #NNN`
 6. **Merge** -- Merge via PR review (no direct commits to `main`)
+7. **Deploy** -- Every merge to `main` runs CI (`.github/workflows/ci.yml`). On green, `.github/workflows/deploy-cpanel.yml` auto-deploys to production by `lftp`-mirroring `out/` into `~/public_html` (the live apex docroot) over FTPS, excluding WHMCS at `~/public_html/hub` and cPanel keepers.
 
 ---
 
@@ -106,11 +108,11 @@ Component files use PascalCase: `HeroSection.tsx`, `DonateButton.tsx`.
 
 ---
 
-## GitHub Pages & Asset Paths
+## Deployment Targets & Asset Paths
 
-This site deploys to `https://freeforcharity.org` (custom domain) via GitHub Pages.
+**Production** is `https://freeforcharity.org` (apex), served from **InterServer cPanel** out of `~/public_html` at the site root. Production serves from root, so `NEXT_PUBLIC_BASE_PATH=''` (no subpath) and the `basePath`/`assetPrefix` in `next.config.ts` remain empty. WHMCS lives at `~/public_html/hub` and is excluded from deploys. Auto-deploy happens on every merge to `main` after CI passes (`deploy-cpanel.yml`).
 
-The `basePath` and `assetPrefix` in `next.config.ts` are controlled by `NEXT_PUBLIC_BASE_PATH` for subpath fallback support. For custom domain deployment, these remain empty.
+**Staging / preview** uses GitHub Pages as a manual preview via `.github/workflows/deploy-gh-pages-staging.yml`, served at the subpath `https://freeforcharity.github.io/FFC-IN-freeforcharity.org/`. There the `basePath`/`assetPrefix` are set to `/FFC-IN-freeforcharity.org` (via `NEXT_PUBLIC_BASE_PATH`) and the `assetPath()` helper (`src/lib/assetPath.ts`) resolves correctly. A cPanel staging target also exists via `deploy-cpanel-staging.yml`. Always use `assetPath()` for images and assets so they work on both root (production) and subpath (preview) surfaces.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ Invoke these when the task matches their purpose. If no matching agent exists, p
 
 ## Project-Specific Notes
 
-- This is a **multi-page site** (not single-page like the template). ~29 routes under `src/app/`.
+- This is a **multi-page site** (not single-page like the template). ~35 routes under `src/app/`.
 - The homepage uses the **Figma redesign layout**, not the template order.
 - **Footer and Team sections are mandatory FFC-wide standards.** See AGENTS.md for requirements.
 - All content is **hardcoded in components** — there is no CMS.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,5 +92,5 @@ Invoke these when the task matches their purpose. If no matching agent exists, p
 - **Footer and Team sections are mandatory FFC-wide standards.** See AGENTS.md for requirements.
 - All content is **hardcoded in components** — there is no CMS.
 - Content data lives in `src/data/` (team members, FAQs, testimonials as JSON).
-- Currently on Next.js 15.5.7 — upgrade to Next.js 16 is planned.
+- On Next.js 16 (App Router) with React 19.
 - Tailwind CSS v4 with CSS-based config (no tailwind.config file).

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -45,7 +45,7 @@ npm run preview      # Serve built output locally
 
 ```
 src/
-  app/            --> Pages and routes (App Router, ~29 routes)
+  app/            --> Pages and routes (App Router, ~35 routes)
   components/     --> Reusable UI components (footer/, header/, home-page/, ui/)
   data/           --> Content modules (.ts loaders) and JSON data files (team/, faqs/, testimonials/)
   lib/            --> Utilities (including assetPath helper)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -12,14 +12,15 @@ See **AGENTS.md** for the complete project reference. This file gives you the pr
 
 ## Quick Context
 
-| What      | Detail                                             |
-| --------- | -------------------------------------------------- |
-| Framework | Next.js with App Router (see package.json)         |
-| Language  | TypeScript (strict)                                |
-| Styling   | Tailwind CSS v4 (CSS-based config, no config file) |
-| Output    | Static export (`output: 'export'`)                 |
-| Hosting   | GitHub Pages (custom domain freeforcharity.org)    |
-| Tests     | Playwright (E2E)                                   |
+| What      | Detail                                                       |
+| --------- | ------------------------------------------------------------ |
+| Framework | Next.js 16 (App Router) — `next ^16.2.9`, React `19.2.7`     |
+| Runtime   | Node 24.x                                                    |
+| Language  | TypeScript (strict)                                          |
+| Styling   | Tailwind CSS v4 (CSS-based config, no config file)           |
+| Output    | Static export (`output: 'export'`)                           |
+| Hosting   | InterServer cPanel (apex freeforcharity.org, served at root) |
+| Tests     | Playwright (E2E)                                             |
 
 The site is **fully static**. No server-side rendering, no API routes, no middleware. Every page must be renderable at build time.
 
@@ -103,13 +104,13 @@ Most text content lives in `src/data/` as `.ts` modules or `.json` files in subd
 1. Create a branch: `git checkout -b fix/descriptive-name`
 2. Make your changes and commit using Conventional Commits: `git commit -m "fix: resolve broken link on about page"`
 3. Push and open a PR that references the issue: `Fixes #42`
-4. All CI checks must pass before merging
+4. All CI checks must pass before merging. Once merged to `main`, CI (`ci.yml`) runs and, on green, `deploy-cpanel.yml` auto-deploys to production.
 
 ---
 
 ## Asset Path Helper
 
-The site deploys to `https://freeforcharity.org` (custom domain) and `https://freeforcharity.github.io/FFC-IN-freeforcharity.org/` (subpath fallback). The `assetPath()` function from `src/lib/assetPath.ts` handles this automatically.
+Production is `https://freeforcharity.org` (InterServer cPanel, served from root, no basePath). The GitHub Pages staging/preview surface at `https://freeforcharity.github.io/FFC-IN-freeforcharity.org/` serves from a subpath (`/FFC-IN-freeforcharity.org`). The `assetPath()` function from `src/lib/assetPath.ts` handles both automatically.
 
 ```tsx
 // Always use assetPath() for images and static assets
@@ -117,7 +118,7 @@ import { assetPath } from '@/lib/assetPath'
 ;<img src={assetPath('/Images/logo.png')} alt="Logo" />
 ```
 
-Never hardcode absolute paths to assets. They will break on one of the two deployment targets.
+Never hardcode absolute paths to assets. They will break on the subpath preview surface.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Free For Charity connects students, professionals, and businesses with nonprofit
 
 ## Site Structure
 
-The website consists of **29 pages** covering:
+The website consists of **35 page routes** covering:
 
 - **Main pages**: Home, About Us, Contact Us
 - **Program pages**: 501c3, Pre-501c3, Help for Charities, Domains, Free Charity Web Hosting, Endowment Fund
@@ -43,11 +43,11 @@ For a complete list, see the [Site Map](#site-map) section below.
 - **React**: 19.2.7
 - **Styling**: Tailwind CSS v4
 - **UI Components**:
-  - Framer Motion 12.23.24 (animations)
-  - Lucide React 0.469.0 (icons)
-  - React Icons 5.5.0 (additional icons)
-  - Swiper 12.0.3 (carousels)
-- **Testing**: Playwright 1.56.0
+  - Framer Motion 12.40 (animations)
+  - Lucide React 0.575 (icons)
+  - React Icons 5.6 (additional icons)
+  - Swiper 12.2 (carousels)
+- **Testing**: Playwright 1.60 (E2E) + Jest 30 with React Testing Library & jest-axe (unit/component/a11y)
 - **Linting**: ESLint 9 with Next.js config
 - **Build**: Static export (`output: export`) deployed to cPanel; also previewable on GitHub Pages staging
 
@@ -89,7 +89,7 @@ _Server starts in ~1 second with Turbopack. Visit http://localhost:3000_
 npm run dev          # Start development server (with Turbopack)
 npm run build        # Build for production (~15-20 seconds)
 npm run preview      # Preview production build (requires build first)
-npm run lint         # Run ESLint (expect 11 warnings)
+npm run lint         # Run ESLint (expect 0 errors)
 npm test             # Run Playwright tests (requires build first)
 npm run test:headed  # Run tests with visible browser
 npm run test:ui      # Run tests in interactive UI mode
@@ -97,7 +97,7 @@ npm run test:ui      # Run tests in interactive UI mode
 
 ## Testing
 
-This project uses Playwright for end-to-end testing to ensure quality and consistency.
+This project uses **Playwright** for end-to-end testing and **Jest + React Testing Library + jest-axe** for unit, component, and accessibility tests, ensuring quality and consistency.
 
 ### Quick Start
 
@@ -116,51 +116,35 @@ npm run test:ui       # Interactive UI mode
 
 ### Test Coverage
 
-**Test Statistics**: 29 tests across 6 test suites
+**Two test layers:**
 
-- ✅ 28 passing tests
-- ⏭️ 1 skipped test (image dimensions - unreliable in CI)
-- 📊 Execution time: ~25-30 seconds
+- **Playwright E2E** — 18 spec files in `tests/` covering navigation, images,
+  cookie consent, copyright, contact, footer, team, mobile nav, dropdowns,
+  external links, analytics loading, donation flows, trailing-slash behavior,
+  accessibility (axe-core), and the post-deploy smoke spec.
+- **Jest + React Testing Library + jest-axe** — 20 unit/component/a11y test
+  files in `__tests__/` rendering components and asserting they have no axe
+  violations.
 
-The test suite includes:
+The Playwright E2E suites include:
 
-1. **Logo and Image Visibility** (`tests/logo.spec.ts`) - 3 tests
-   - Header logo display
-   - Hero section image display
-   - Logo consistency verification
-
-2. **Image Loading** (`tests/image-loading.spec.ts`) - 3 tests
-   - Image visibility and loading
-   - Hero image from local assets
-   - Image dimensions check (skipped)
-
-3. **Animated Numbers** (`tests/animated-numbers.spec.ts`) - 5 tests
-   - Results 2023 section statistics
-   - Animation from 0 on scroll
-   - Animation triggers once
-   - Reduced motion support
-
-4. **Mission Video** (`tests/mission-video.spec.ts`) - 2 tests
-   - Video element presence
-   - Video source configuration
-
-5. **Cookie Consent Banner** (`tests/cookie-consent.spec.ts`) - 14 tests
-   - Banner display and interactions (5 tests)
-   - Preferences modal functionality (7 tests)
-   - Accessibility attributes (2 tests)
-
-6. **Footer Copyright** (`tests/copyright.spec.ts`) - 2 tests
-   - Copyright notice with current year
-   - Link to freeforcharity.org
+- **Logo & Image Visibility** (`tests/logo.spec.ts`, `tests/image-loading.spec.ts`)
+- **Animated Numbers** (`tests/animated-numbers.spec.ts`) — Results 2023 stats, scroll triggers, reduced-motion
+- **Mission Video** (`tests/mission-video.spec.ts`)
+- **Cookie Consent Banner** (`tests/cookie-consent.spec.ts`) — banner, preferences modal, a11y attributes
+- **Navigation & Footer** (`tests/navigation.spec.ts`, `tests/footer-complete.spec.ts`, `tests/mobile-navigation.spec.ts`, `tests/dropdown-navigation.spec.ts`)
+- **Accessibility** (`tests/accessibility.spec.ts`) — WCAG 2.1 AA via axe-core
+- **Donation flows, contact, team, analytics, external links, trailing-slash, post-deploy smoke**
 
 **Test Configuration** (`playwright.config.ts`)
 
 - Uses system Chromium to avoid network restrictions
-- Runs against production build (`npm run preview`)
+- Runs against the production build (`npm run preview`)
 - Retries failed tests 2x in CI, 0x locally
 - Collects traces on first retry for debugging
 
-Tests run automatically on every push to main via GitHub Actions before deployment.
+Both layers run automatically on every push/PR to `main` via the
+`CI - Build and Test` workflow, before the production deploy.
 
 **Full Testing Documentation**: See [TESTING.md](./TESTING.md) for complete details.
 
@@ -172,11 +156,9 @@ Tests run automatically on every push to main via GitHub Actions before deployme
 npm run lint
 ```
 
-Currently reports **11 warnings** (expected):
-
-- 6 warnings about using `<img>` instead of Next.js `<Image>` component (acceptable for static export)
-- 3 warnings about unused imports
-- 2 warnings about React hooks dependencies
+Currently passes with **0 errors**. ESLint runs clean in CI (the
+`<img>`-over-`next/image` rule is intentionally relaxed for the static
+export). Treat any new error as a blocker before committing.
 
 **TypeScript**
 
@@ -246,7 +228,7 @@ FFC-IN-freeforcharity.org/
 │   │   ├── globals.css         # Global styles
 │   │   ├── sitemap.ts          # Sitemap generation
 │   │   ├── robots.ts           # Robots.txt generation
-│   │   ├── [29 page routes]/  # All site pages
+│   │   ├── [35 page routes]/  # All site pages
 │   │   └── Figma-Home-page/    # Main homepage component
 │   ├── components/              # React components
 │   │   ├── Header/             # Site header
@@ -467,13 +449,13 @@ This automatically handles the basePath for both scenarios (empty in production,
 
 - **Directory**: `./out`
 - **Files**: Static HTML, CSS, JS, and assets
-- **Routes**: 29 page routes + 3 system routes (`/_not-found`, `/robots.txt`, `/sitemap.xml`) = 32 total
+- **Routes**: 35 page routes + system routes (`/_not-found`, `/robots.txt`, `/sitemap.xml`)
 - **Size**: ~180 kB First Load JS (homepage)
 - **Build Time**: ~15-20 seconds
 
 ## Site Map
 
-The website consists of 29 page routes organized as follows:
+The website consists of 35 page routes organized as follows:
 
 ### Main Pages
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Free For Charity
 
 [![CI - Build and Test](https://github.com/FreeForCharity/FFC-IN-freeforcharity.org/actions/workflows/ci.yml/badge.svg)](https://github.com/FreeForCharity/FFC-IN-freeforcharity.org/actions/workflows/ci.yml)
-[![Deploy to GitHub Pages](https://github.com/FreeForCharity/FFC-IN-freeforcharity.org/actions/workflows/deploy.yml/badge.svg)](https://github.com/FreeForCharity/FFC-IN-freeforcharity.org/actions/workflows/deploy.yml)
+[![Deploy to cPanel (production)](https://github.com/FreeForCharity/FFC-IN-freeforcharity.org/actions/workflows/deploy-cpanel.yml/badge.svg)](https://github.com/FreeForCharity/FFC-IN-freeforcharity.org/actions/workflows/deploy-cpanel.yml)
 [![CodeQL](https://github.com/FreeForCharity/FFC-IN-freeforcharity.org/actions/workflows/codeql.yml/badge.svg)](https://github.com/FreeForCharity/FFC-IN-freeforcharity.org/actions/workflows/codeql.yml)
 [![Lighthouse CI](https://github.com/FreeForCharity/FFC-IN-freeforcharity.org/actions/workflows/lighthouse.yml/badge.svg)](https://github.com/FreeForCharity/FFC-IN-freeforcharity.org/actions/workflows/lighthouse.yml)
 
-Free For Charity website built with Next.js 16.0.10 (App Router).
+Free For Charity website built with Next.js 16 (App Router).
 
 ## Organization
 
@@ -31,17 +31,17 @@ For a complete list, see the [Site Map](#site-map) section below.
 
 ## Deployment
 
-- **Primary Site**: [https://www.freeforcharity.org](https://www.freeforcharity.org) (custom domain with CNAME)
-- **GitHub Pages**: [https://freeforcharity.github.io/FFC-IN-freeforcharity.org/](https://freeforcharity.github.io/FFC-IN-freeforcharity.org/)
-- **Hosting**: GitHub Pages
-- **Deployment**: Automated via GitHub Actions on push to `main` branch
-- **Build Configuration**: Dual deployment support (custom domain and GitHub Pages basePath)
+- **Primary Site**: [https://www.freeforcharity.org](https://www.freeforcharity.org) (apex domain, served from root path)
+- **Production Hosting**: InterServer cPanel — the static export is served from `~/public_html` at the root path
+- **Production Deployment**: Auto-deploy on merge to `main` after CI passes, via [`.github/workflows/deploy-cpanel.yml`](.github/workflows/deploy-cpanel.yml) (FTPS mirror of `out/` into `~/public_html`)
+- **Staging / Preview**: GitHub Pages is a manual preview surface at [https://freeforcharity.github.io/FFC-IN-freeforcharity.org/](https://freeforcharity.github.io/FFC-IN-freeforcharity.org/) (project subpath); a separate cPanel staging account is also available
+- **Build Configuration**: Production builds at the root path (`NEXT_PUBLIC_BASE_PATH=''`); the GitHub Pages staging build uses the `/FFC-IN-freeforcharity.org` basePath
 
 ## Tech Stack
 
-- **Framework**: Next.js 16.0.10 (App Router with TypeScript)
-- **React**: 19.2.0
-- **Styling**: Tailwind CSS 4.1.12
+- **Framework**: Next.js 16 (App Router with TypeScript)
+- **React**: 19.2.7
+- **Styling**: Tailwind CSS v4
 - **UI Components**:
   - Framer Motion 12.23.24 (animations)
   - Lucide React 0.469.0 (icons)
@@ -49,7 +49,7 @@ For a complete list, see the [Site Map](#site-map) section below.
   - Swiper 12.0.3 (carousels)
 - **Testing**: Playwright 1.56.0
 - **Linting**: ESLint 9 with Next.js config
-- **Build**: Static export for GitHub Pages deployment
+- **Build**: Static export (`output: export`) deployed to cPanel; also previewable on GitHub Pages staging
 
 ## Local Development
 
@@ -232,7 +232,8 @@ Reusable components in `src/components/UI/`:
 FFC-IN-freeforcharity.org/
 ├── .github/
 │   ├── workflows/
-│   │   └── nextjs.yml          # CI/CD pipeline for GitHub Pages
+│   │   ├── ci.yml              # CI - Build and Test (runs on every push/PR)
+│   │   └── deploy-cpanel.yml   # Production deploy to cPanel on merge to main
 │   └── copilot-instructions.md # Instructions for GitHub Copilot agents
 ├── public/                      # Static assets
 │   ├── Images/                  # Image files
@@ -263,7 +264,7 @@ FFC-IN-freeforcharity.org/
 │   │   ├── team.ts            # Team data loader
 │   │   └── testimonials.ts     # Testimonial data loader
 │   └── lib/
-│       └── assetPath.ts        # Helper for GitHub Pages asset paths
+│       └── assetPath.ts        # Helper for basePath-aware asset paths (GitHub Pages staging subpath)
 ├── tests/                       # Playwright tests
 │   ├── logo.spec.ts            # Logo visibility tests
 │   ├── image-loading.spec.ts   # Image loading tests
@@ -383,26 +384,31 @@ vi src/app/robots.ts
 
 ## Deployment Details
 
-### Production Deployment
+### Production Deployment (cPanel)
 
-The site uses **dual deployment** strategy:
+Production runs on **InterServer cPanel** at the apex domain [https://www.freeforcharity.org](https://www.freeforcharity.org), served from the **root path**.
 
-1. **Custom Domain**: [https://www.freeforcharity.org](https://www.freeforcharity.org)
-   - Primary production site
-   - CNAME configured in DNS
-   - No basePath required
-   - Assets served from root path
+- **Hosting**: InterServer cPanel
+- **Docroot**: `~/public_html` (the live apex docroot)
+- **basePath**: none — `NEXT_PUBLIC_BASE_PATH` is empty (`''`); assets served from root
+- **How it deploys**: every merge to `main` runs the **CI - Build and Test** workflow (`.github/workflows/ci.yml`); on green, `.github/workflows/deploy-cpanel.yml` auto-deploys by `lftp`-mirroring the static export `out/` into `~/public_html` over FTPS. The mirror excludes the WHMCS billing portal at `~/public_html/hub` and the cPanel keeper files.
 
-2. **GitHub Pages**: [https://freeforcharity.github.io/FFC-IN-freeforcharity.org/](https://freeforcharity.github.io/FFC-IN-freeforcharity.org/)
-   - Backup/alternative URL
-   - Requires basePath: `/FFC-IN-freeforcharity.org`
-   - Assets served from subpath
+### Staging / Preview Surfaces
 
-### CI/CD Pipeline
+These are secondary, non-production surfaces:
 
-**Workflow**: `.github/workflows/nextjs.yml`
+1. **GitHub Pages** (manual preview): [https://freeforcharity.github.io/FFC-IN-freeforcharity.org/](https://freeforcharity.github.io/FFC-IN-freeforcharity.org/)
+   - Triggered manually via `.github/workflows/deploy-gh-pages-staging.yml`
+   - Served at the project subpath, so it requires basePath `/FFC-IN-freeforcharity.org`
+   - Assets served from the subpath (this is why `NEXT_PUBLIC_BASE_PATH` and the `assetPath()` helper exist)
 
-**Trigger**: Push to `main` branch
+2. **cPanel staging**: a separate staging cPanel account via `.github/workflows/deploy-cpanel-staging.yml`
+
+### CI Pipeline
+
+**Workflow**: `.github/workflows/ci.yml` (CI - Build and Test)
+
+**Trigger**: Pushes and pull requests (and as the gate before production deploy on `main`)
 
 **Pipeline Steps**:
 
@@ -410,19 +416,18 @@ The site uses **dual deployment** strategy:
 2. Setup Node.js 24
 3. Install dependencies with `npm ci`
 4. Install Playwright browsers
-5. Build with `NEXT_PUBLIC_BASE_PATH=/FFC-IN-freeforcharity.org`
+5. Build the static export
 6. Run Playwright tests
-7. Upload build artifacts (./out directory)
-8. Deploy to GitHub Pages (only if tests pass)
+
+On a green run against `main`, `deploy-cpanel.yml` then mirrors `out/` into `~/public_html`.
 
 **Environment Variables**:
 
-- `NEXT_PUBLIC_BASE_PATH`: Set to `/FFC-IN-freeforcharity.org` for GitHub Pages deployment
-- Not set (empty) for custom domain deployment
+- `NEXT_PUBLIC_BASE_PATH`: empty (`''`) for the production/root-path build (cPanel); set to `/FFC-IN-freeforcharity.org` only for the GitHub Pages staging build
 
 ### Local Production Build
 
-**Build for custom domain** (default):
+**Build for production / root path** (default — matches cPanel):
 
 ```bash
 npm run build
@@ -430,7 +435,7 @@ npm run preview
 # Visit http://localhost:3000
 ```
 
-**Build for GitHub Pages** (with basePath):
+**Build for GitHub Pages staging** (with basePath subpath):
 
 ```bash
 NEXT_PUBLIC_BASE_PATH=/FFC-IN-freeforcharity.org npm run build
@@ -448,7 +453,7 @@ npm run preview
 - `assetPrefix: process.env.NEXT_PUBLIC_BASE_PATH || ""` - Asset path prefix
 
 **Asset Path Helper**:
-When adding images that need to work on both deployments, use the `assetPath()` helper:
+When adding images that need to work on both the production root path and the GitHub Pages staging subpath, use the `assetPath()` helper:
 
 ```typescript
 import { assetPath } from "@/lib/assetPath";
@@ -456,7 +461,7 @@ import { assetPath } from "@/lib/assetPath";
 <img src={assetPath("/Images/my-image.png")} alt="Description" />
 ```
 
-This automatically handles the basePath for both deployment scenarios.
+This automatically handles the basePath for both scenarios (empty in production, the subpath on GitHub Pages staging).
 
 ### Build Output
 
@@ -587,6 +592,6 @@ This project is maintained by Free For Charity, a 501(c)(3) nonprofit organizati
 
 ---
 
-**Documentation Status**: ✅ Updated February 2026  
-**Next.js Version**: 16.0.10  
+**Documentation Status**: ✅ Updated June 2026  
+**Next.js Version**: 16  
 **Node.js Version**: 24.x required

--- a/TESTING.md
+++ b/TESTING.md
@@ -133,9 +133,9 @@ npm run build  # Type checking is part of build process
 
 ### Overview
 
-The project uses **Playwright** for end-to-end testing. All tests run automatically in CI before deployment.
+The project uses **Playwright** for end-to-end (E2E) testing and **Jest + React Testing Library + jest-axe** (jsdom) for unit, component, and accessibility tests. All tests run automatically in CI (`.github/workflows/ci.yml`) before the production deploy to InterServer cPanel (`.github/workflows/deploy-cpanel.yml`). GitHub Pages is now a manual staging/preview surface only (`.github/workflows/deploy-gh-pages-staging.yml`), not production.
 
-**Test Framework**: Playwright v1.56.0  
+**E2E Test Framework**: Playwright v1.56.0  
 **Browser**: Chromium (uses system browser to avoid network restrictions)  
 **Test Statistics**:
 
@@ -178,14 +178,15 @@ npx playwright test --debug
 
 #### CI/CD Environment
 
-Tests run automatically in GitHub Actions:
+Tests run automatically in GitHub Actions (`ci.yml`):
 
-- **Trigger**: Every push to main branch
-- **Environment**: Ubuntu latest with Node.js 24
+- **Trigger**: Every push / pull request to the `main` branch
+- **Environment**: Ubuntu latest with Node.js 24.x
+- **Pipeline**: Format check, lint, Jest unit/component tests, build, internal link check, then Playwright E2E
 - **Browser Setup**: `npx playwright install --with-deps chromium`
-- **Build**: Built with `NEXT_PUBLIC_BASE_PATH=/freeforcharity-web`
-- **Retry Logic**: Failed tests retry 2 times
-- **Failure Handling**: Deployment blocked if tests fail
+- **Production build**: Built at root path with `NEXT_PUBLIC_BASE_PATH=''` (the cPanel apex docroot). The GitHub Pages staging build uses `NEXT_PUBLIC_BASE_PATH=/FFC-IN-freeforcharity.org`.
+- **Retry Logic**: Failed E2E tests retry 2 times
+- **Failure Handling**: The production deploy (`deploy-cpanel.yml`) only runs after CI is green
 
 ### Test Files and Coverage
 
@@ -371,32 +372,43 @@ Key settings:
 
 ## CI/CD Integration
 
-### GitHub Actions Workflow
+### GitHub Actions Workflows
 
-**File**: `.github/workflows/nextjs.yml`
-
-**Pipeline Steps**:
+**CI** (`.github/workflows/ci.yml`) — runs on every push / PR to `main`:
 
 1. ✅ Checkout repository
-2. ✅ Setup Node.js 24 with caching
+2. ✅ Setup Node.js 24.x with caching
 3. ✅ Install dependencies (`npm ci`)
-4. ✅ Restore Next.js build cache
-5. ✅ Install Playwright browsers with system dependencies
-6. ✅ Build with `NEXT_PUBLIC_BASE_PATH=/freeforcharity-web`
-7. ✅ Run Playwright test suite (with `CI=true`)
-8. ✅ Upload build artifacts (`./out` directory)
-9. ✅ Deploy to GitHub Pages (only if tests pass)
+4. ✅ Format check and lint
+5. ✅ Run Jest unit/component/a11y tests (jest-axe, jsdom)
+6. ✅ Build the site
+7. ✅ Internal link check
+8. ✅ Install Playwright browsers with system dependencies
+9. ✅ Run Playwright E2E suite (with `CI=true`)
 
-**Triggers**:
+**Production deploy** (`.github/workflows/deploy-cpanel.yml`) — runs only after CI is green on `main`. It mirrors the built `out/` directory into `~/public_html` on InterServer cPanel (the live apex docroot for `freeforcharity.org`, served at the root path with `NEXT_PUBLIC_BASE_PATH=''`), excluding the WHMCS install at `~/public_html/hub`.
 
-- Push to `main` branch
-- Manual workflow dispatch
+**Staging / preview deploy** (`.github/workflows/deploy-gh-pages-staging.yml`) — manual only. Publishes to GitHub Pages at the subpath `https://freeforcharity.github.io/FFC-IN-freeforcharity.org/`, where `basePath` `/FFC-IN-freeforcharity.org` plus the `assetPath()` helper apply.
+
+**Other workflows**: `lighthouse.yml` (performance), `lychee.yml` (link checking), `scheduled-prod-smoke.yml` (scheduled production smoke checks).
+
+> Note: the old GitHub Pages **production** workflows (`deploy.yml` / `nextjs.yml`) have been removed — production is no longer served from GitHub Pages.
 
 **Failure Handling**:
 
-- Tests must pass before deployment
+- CI must pass before the production deploy runs
 - Build artifacts uploaded even on test failure
 - Traces and screenshots available for debugging
+
+### Post-Deploy Smoke Tests
+
+After a production deploy, run the smoke harness against the live site:
+
+```bash
+npm run smoke-test    # runs scripts/smoke-test.mjs
+```
+
+It hits the live apex (`freeforcharity.org`), the WHMCS hub at `/hub`, and verifies key redirects. The `scheduled-prod-smoke.yml` workflow runs these checks on a schedule.
 
 ### TypeScript
 
@@ -439,7 +451,7 @@ npm audit
 
 - [ ] Logo displays in Header (top navigation)
 - [ ] Logo renders correctly on all pages
-- [ ] Images load on both custom domain and GitHub Pages
+- [ ] Images load on both the production apex (root path) and the GitHub Pages staging/preview subpath
 - [ ] Responsive design works on mobile, tablet, desktop
 - [ ] Mobile navigation menu functions correctly
 - [ ] All animations work smoothly
@@ -570,9 +582,9 @@ cat src/data/team.ts
 
 **Issue: Images not loading**
 
-- **Custom domain**: Images should load from root path
-- **GitHub Pages**: Images need basePath prefix
-- **Solution**: Use `assetPath()` helper from `src/lib/assetPath.ts`
+- **Production (cPanel apex)**: Images load from the root path (`NEXT_PUBLIC_BASE_PATH=''`)
+- **GitHub Pages staging/preview**: Images need the `/FFC-IN-freeforcharity.org` basePath prefix
+- **Solution**: Use `assetPath()` helper from `src/lib/assetPath.ts` so both surfaces resolve correctly
 
 ## File Structure Reference
 
@@ -584,7 +596,9 @@ freeforcharity-web/
 │   └── README.md                  # Test documentation
 ├── playwright.config.ts            # Playwright configuration
 ├── .github/workflows/
-│   └── nextjs.yml                 # CI/CD pipeline with automated tests
+│   ├── ci.yml                     # CI: format, lint, Jest, build, links, Playwright E2E
+│   ├── deploy-cpanel.yml          # Production deploy to InterServer cPanel (apex)
+│   └── deploy-gh-pages-staging.yml # Manual GitHub Pages staging/preview deploy
 ├── public/                         # Static assets
 ├── src/data/
 │   ├── faqs/
@@ -611,10 +625,10 @@ freeforcharity-web/
 
 ### High Priority
 
-1. **Accessibility Testing**
-   - Tool: @axe-core/playwright
+1. **Accessibility Testing** (partially adopted)
+   - Tool: `@axe-core/playwright` (E2E) and `jest-axe` (unit/component)
    - Purpose: Automated WCAG 2.1 compliance checks
-   - Benefit: Ensure site is accessible to all users
+   - Status: In use today; expand coverage to remaining pages/components
 
 2. **Mobile Responsive Testing**
    - Tool: Playwright viewport configuration

--- a/TESTING.md
+++ b/TESTING.md
@@ -13,16 +13,17 @@ This guide provides comprehensive documentation for testing the Free For Charity
 ### Run Tests
 
 ```bash
-# Build the application
-npm run build
+# Jest unit / component / a11y tests (jsdom — no build required)
+npm test              # Run the Jest suite once
+npm run test:watch    # Jest in watch mode
+npm run test:coverage # Jest with coverage report
 
-# Install Playwright browsers (first time only)
-npx playwright install chromium
-
-# Run tests
-npm test              # Headless mode (default)
-npm run test:headed   # With visible browser
-npm run test:ui       # Interactive Playwright UI
+# Playwright E2E tests (require a production build first)
+npm run build                       # Build the static site
+npx playwright install chromium     # Install browsers (first time only)
+npm run test:e2e          # Headless mode (default)
+npm run test:e2e:headed   # With visible browser
+npm run test:e2e:ui       # Interactive Playwright UI
 ```
 
 ## Quick Test Checklist
@@ -43,7 +44,7 @@ npm install           # Takes ~10-15 seconds
 ### 3. Run Linter
 
 ```bash
-npm run lint          # Expect 11 warnings (see below)
+npm run lint          # Passes clean: 0 errors
 ```
 
 ### 4. Build Application
@@ -61,7 +62,8 @@ npm run preview       # Visit http://localhost:3000
 ### 6. Run Automated Tests
 
 ```bash
-npm test              # Requires build first
+npm test              # Jest unit/component/a11y tests (no build required)
+npm run test:e2e      # Playwright E2E tests (requires build first)
 ```
 
 ## Code Quality & Linting
@@ -74,28 +76,9 @@ npm test              # Requires build first
 npm run lint
 ```
 
-**Current Output**: 11 warnings (expected)
+**Current Output**: Passes clean — **0 errors**.
 
-**Warning Breakdown**:
-
-1. **Image Optimization Warnings** (6 warnings)
-   - Files: `Footer/index.tsx`, `Header/index.tsx`, `General-Donation-Card.tsx`, `trainingcard.tsx`, `About-FFC-Hosting/index.tsx`, `Hero/index.tsx` (endowment fund)
-   - Issue: Using `<img>` instead of Next.js `<Image />` component
-   - Status: ✅ **Acceptable** - Required for static export with unoptimized images
-   - Recommendation: No action needed for static export
-
-2. **Unused Import Warnings** (3 warnings)
-   - `Link` in `501c3-components/Ready-to-get-started-and-faqs/index.tsx`
-   - `assetPath` in `Figma-Home-Page-Components/Mission/index.tsx`
-   - `Image` in `free-charity-web-hosting/About-FFC-Hosting/index.tsx`
-   - Status: ⚠️ **Can be cleaned up**
-   - Recommendation: Remove unused imports
-
-3. **React Hooks Warnings** (2 warnings)
-   - `useEffect` missing dependency in `ClientTestimonials/index.tsx`
-   - `ref` cleanup function warning in `CallToActionCard.tsx`
-   - Status: ⚠️ **Review recommended**
-   - Recommendation: Review and fix if causing issues
+The source tree lints without errors. (A trivial "Unused eslint-disable directive" warning may surface in generated files under `coverage/`, which is not part of the source and can be ignored.)
 
 **Rules Enabled**:
 
@@ -135,41 +118,44 @@ npm run build  # Type checking is part of build process
 
 The project uses **Playwright** for end-to-end (E2E) testing and **Jest + React Testing Library + jest-axe** (jsdom) for unit, component, and accessibility tests. All tests run automatically in CI (`.github/workflows/ci.yml`) before the production deploy to InterServer cPanel (`.github/workflows/deploy-cpanel.yml`). GitHub Pages is now a manual staging/preview surface only (`.github/workflows/deploy-gh-pages-staging.yml`), not production.
 
-**E2E Test Framework**: Playwright v1.56.0  
-**Browser**: Chromium (uses system browser to avoid network restrictions)  
-**Test Statistics**:
+The suite is organized in two layers:
 
-- **Total**: 29 tests across 6 test suites
-- **Passing**: 28 tests ✅
-- **Skipped**: 1 test ⏭️
-- **Execution Time**: ~25-30 seconds
+- **Jest unit / component / a11y layer** — **20 test files** under `__tests__/`. Uses Jest + React Testing Library + jest-axe in a jsdom environment to render components and pages and assert on markup, behavior, data integrity, and accessibility (axe). Runs with `npm test` (no build required).
+- **Playwright E2E layer** — **18 spec files** in `tests/` (`*.spec.ts`). Drives a real browser against the built site to verify end-to-end behavior, navigation, and rendering. Runs with `npm run test:e2e` (requires `npm run build` first).
+
+**E2E Test Framework**: Playwright (Chromium — uses system browser to avoid network restrictions)  
+**Unit/Component Framework**: Jest + React Testing Library + jest-axe (jsdom)
 
 ### Running Tests
 
 #### Local Development
 
 ```bash
-# Build the site first (required)
-npm run build
+# Jest unit/component/a11y tests (no build required)
+npm test              # Run once
+npm run test:watch    # Watch mode
+npm run test:coverage # With coverage
 
-# Install Playwright browsers (first time only)
-npx playwright install chromium
-
-# Run tests in different modes
-npm test              # Headless mode (default)
-npm run test:headed   # With browser visible
-npm run test:ui       # Interactive Playwright UI
+# Playwright E2E tests
+npm run build                       # Build the site first (required)
+npx playwright install chromium     # Install browsers (first time only)
+npm run test:e2e          # Headless mode (default)
+npm run test:e2e:headed   # With browser visible
+npm run test:e2e:ui       # Interactive Playwright UI
 ```
 
 #### Individual Test Execution
 
 ```bash
-# Run specific test file
+# Run a specific Jest test file
+npx jest __tests__/components/header/index.test.tsx
+
+# Run a specific Playwright spec file
 npx playwright test logo.spec.ts
 npx playwright test image-loading.spec.ts
 npx playwright test animated-numbers.spec.ts
 
-# Run specific test by name
+# Run a specific Playwright test by name
 npx playwright test -g "should display logo"
 
 # Debug mode
@@ -190,163 +176,67 @@ Tests run automatically in GitHub Actions (`ci.yml`):
 
 ### Test Files and Coverage
 
-This section details all 6 test suites and their 29 test cases.
+This section summarizes the two test layers by file and area. It describes coverage by file/category rather than enumerating individual test cases, since both suites evolve.
 
-#### 1. Logo and Image Visibility (`tests/logo.spec.ts`) - 3 tests
+#### Playwright E2E layer (`tests/` — 18 spec files)
 
-Tests that verify the Free For Charity logo and images display correctly.
+Each file below is a `*.spec.ts` in `tests/`, grouped by area:
 
-**Test Cases:**
+**Navigation & layout**
 
-1. **`should display logo in header`**
-   - **Purpose**: Verifies logo appears in site header
-   - **Checks**: Logo visibility, src attribute, alt text
-2. **`should display hero section image`**
-   - **Purpose**: Validates hero section image displays correctly
-   - **Checks**: Hero image element present and visible
+- `navigation.spec.ts` — primary site navigation and routing
+- `dropdown-navigation.spec.ts` — dropdown menu behavior
+- `mobile-navigation.spec.ts` — mobile menu / hamburger navigation
+- `trailing-slash.spec.ts` — trailing-slash URL handling
+- `external-links.spec.ts` — external link targets and attributes
 
-3. **`both header logo and hero image should be present on the same page`**
-   - **Purpose**: Ensures both logo and hero image are visible simultaneously
-   - **Checks**: Both images present, consistent display
+**Page content & sections**
 
-#### 2. Image Loading (`tests/image-loading.spec.ts`) - 3 tests
+- `contact-page.spec.ts` — contact page rendering and behavior
+- `team-section.spec.ts` — team / board member section
+- `footer-complete.spec.ts` — footer content and completeness
+- `copyright.spec.ts` — footer copyright notice (current year, org link)
+- `logo.spec.ts` — header logo and hero image visibility
+- `image-loading.spec.ts` — image loading and visibility
+- `mission-video.spec.ts` — mission section video element
+- `animated-numbers.spec.ts` — Results section animated statistics
 
-Tests that verify image loading performance and visibility.
+**Behavior & integrations**
 
-**Test Cases:**
+- `cookie-consent.spec.ts` — cookie consent banner and preferences modal
+- `donation-flows.spec.ts` — donation flow paths
+- `analytics-loading.spec.ts` — analytics script loading
+- `accessibility.spec.ts` — accessibility checks (`@axe-core/playwright`)
+- `post-deploy-smoke.spec.ts` — post-deploy smoke checks
 
-1. **`images should load correctly and be visible`**
-   - **Purpose**: Confirms images load without errors
-   - **Checks**: Image visibility, no broken images
+#### Jest unit / component / a11y layer (`__tests__/` — 20 test files)
 
-2. **`hero image should load from local assets`**
-   - **Purpose**: Verifies hero image loads from correct local asset path
-   - **Checks**: Hero image src attribute, visibility, not broken
+Jest + React Testing Library + jest-axe (jsdom) render components and pages and assert on markup, behavior, data integrity, and accessibility. Grouped by area:
 
-3. **`images have natural dimensions indicating successful load`** ⏭️ **SKIPPED**
-   - **Purpose**: Checks images have natural (non-zero) dimensions after loading
-   - **Checks**: naturalWidth and naturalHeight properties are greater than zero
-   - **Status**: Skipped due to timing/rendering differences in CI
+**App / routing / metadata**
 
-#### 3. Animated Numbers (`tests/animated-numbers.spec.ts`) - 5 tests
+- `app/metadata.test.ts` — page metadata
+- `app/sitemap.test.ts` — sitemap generation
+- `app/page-render.test.tsx` — page render smoke tests
+- `app/all-sections` and `components/all-sections.test.tsx` — broad section rendering coverage
 
-Tests the Results 2023 section with animated statistics.
+**Components**
 
-**Test Cases:**
+- `components/header/index.test.tsx` — site header
+- `components/home/MissionSection.test.tsx`, `home/Contactus/index.test.tsx`, `home/Ourblogs/index.test.tsx` — homepage sections
+- `components/donate-components/Free-for-Charity-Donation-Options/index.test.tsx`, `donate-components/measurable-impact.test.tsx` — donate components
+- `components/guidestar-guide/Faqs.test.tsx`, `guidestar-guide/Free-for-charity/index.test.tsx` — GuideStar guide components
+- `components/free-charity-web-hosting/About-FFC-Hosting/index.test.tsx` — hosting page component
+- `components/ui/ui-batch-1.test.tsx`, `ui/ui-batch-2.test.tsx`, `ui/ui-batch-3.test.tsx` — UI component batches
 
-1. **`should display the Results-2023 section with all four statistics`**
-   - **Purpose**: Verifies all statistics cards are present
-   - **Checks**: Four result cards display correctly
+**Data & libraries**
 
-2. **`should start with numbers at 0 before scrolling into view`**
-   - **Purpose**: Ensures numbers are not pre-animated
-   - **Checks**: All statistics display 0 before scrolling into view
+- `data/data-files.test.ts` — data file integrity (team, FAQs, testimonials)
+- `data/image-paths.test.ts` — image path validity
+- `lib/assetPath.test.ts` — `assetPath()` helper
+- `lib/config.test.ts` — configuration helpers
 
-3. **`should animate numbers only once when scrolled into view`**
-   - **Purpose**: Verifies animation triggers on scroll and does not repeat
-   - **Checks**: Numbers animate from 0 to target values only once per page load
-
-4. **`should display correct descriptions for each statistic`**
-   - **Purpose**: Ensures each statistic card has the correct label/description
-   - **Checks**: Descriptions match expected text for each statistic
-
-5. **`should respect prefers-reduced-motion preference`**
-   - **Purpose**: Accessibility for users with motion sensitivity
-   - **Checks**: Animation is disabled when prefers-reduced-motion is set
-
-#### 4. Mission Video (`tests/mission-video.spec.ts`) - 2 tests
-
-Tests the video element in the mission section.
-
-**Test Cases:**
-
-1. **`should display video in mission section`**
-   - **Purpose**: Verifies video element exists
-   - **Checks**: Video element present and visible
-
-2. **`should have video source configured correctly`**
-   - **Purpose**: Validates video source configuration
-   - **Checks**: Video src attribute is set correctly
-
-#### 5. Cookie Consent Banner (`tests/cookie-consent.spec.ts`) - 14 tests
-
-Tests the cookie consent banner functionality across 3 test suites.
-
-**Test Suite 1: Cookie Consent Banner** (5 tests)
-
-1. **`should display cookie consent banner on first visit`**
-   - **Purpose**: Verifies banner appears for new users
-   - **Checks**: Banner visible on initial page load
-
-2. **`should hide banner after clicking Accept All`**
-   - **Purpose**: Tests accept all button functionality
-   - **Checks**: Banner disappears after clicking Accept All
-
-3. **`should hide banner after clicking Decline All`**
-   - **Purpose**: Tests decline all button functionality
-   - **Checks**: Banner disappears after clicking Decline All
-
-4. **`should persist Accept All choice and not show banner on subsequent visits`**
-   - **Purpose**: Validates accept preference persistence
-   - **Checks**: Banner doesn't reappear after acceptance
-
-5. **`should persist Decline All choice and not show banner on subsequent visits`**
-   - **Purpose**: Validates decline preference persistence
-   - **Checks**: Banner doesn't reappear after declining
-
-**Test Suite 2: Cookie Preferences Modal** (7 tests)
-
-6. **`should open preferences modal when clicking Customize`**
-   - **Purpose**: Tests customize button opens modal
-   - **Checks**: Modal becomes visible
-
-7. **`should close modal when clicking Cancel`**
-   - **Purpose**: Tests cancel button closes modal
-   - **Checks**: Modal disappears without saving
-
-8. **`should close modal when pressing Escape key`**
-   - **Purpose**: Tests keyboard accessibility
-   - **Checks**: Escape key closes modal
-
-9. **`should close modal when clicking outside (overlay)`**
-   - **Purpose**: Tests clicking overlay closes modal
-   - **Checks**: Modal closes on overlay click
-
-10. **`should have necessary and functional cookies always checked and disabled`**
-    - **Purpose**: Ensures essential cookies cannot be disabled
-    - **Checks**: Essential cookies checkbox is checked and disabled
-
-11. **`should allow toggling analytics and marketing cookies`**
-    - **Purpose**: Tests cookie preference toggles
-    - **Checks**: Analytics and marketing checkboxes can be toggled
-
-12. **`should save custom preferences correctly`**
-    - **Purpose**: Validates saving custom cookie preferences
-    - **Checks**: Selected preferences are saved and persisted
-
-**Test Suite 3: Cookie Consent Accessibility** (2 tests)
-
-13. **`modal should have proper ARIA attributes`**
-    - **Purpose**: Ensures modal accessibility
-    - **Checks**: Modal has proper ARIA attributes
-
-14. **`banner should have proper ARIA attributes`**
-    - **Purpose**: Ensures banner accessibility
-    - **Checks**: Banner has proper ARIA attributes
-
-#### 6. Footer Copyright (`tests/copyright.spec.ts`) - 2 tests
-
-Tests the footer copyright notice.
-
-**Test Cases:**
-
-1. **`should display copyright notice with current year`**
-   - **Purpose**: Verifies copyright text includes current year
-   - **Checks**: Current year appears in copyright notice
-
-2. **`should display link to freeforcharity.org in copyright notice`**
-   - **Purpose**: Ensures footer contains link to organization's website
-   - **Checks**: Link to https://freeforcharity.org is present in copyright notice
+Many component and page tests include jest-axe assertions for accessibility; a shared axe helper lives at `__tests__/utils/axe.ts`.
 
 ### Test Configuration
 
@@ -459,7 +349,7 @@ npm audit
 ### Content Verification
 
 - [ ] Homepage loads completely
-- [ ] All 29 pages are accessible
+- [ ] All 35 page routes are accessible
 - [ ] Team members display correctly (5 board members)
 - [ ] Testimonials render properly (3 testimonials)
 - [ ] FAQs are visible and formatted correctly
@@ -590,10 +480,17 @@ cat src/data/team.ts
 
 ```
 freeforcharity-web/
-├── tests/                          # Test suite
-│   ├── logo.spec.ts               # Logo visibility tests (3 tests)
-│   ├── github-pages.spec.ts       # Deployment compatibility tests (3 tests)
-│   └── README.md                  # Test documentation
+├── tests/                          # Playwright E2E specs (18 *.spec.ts files)
+│   ├── logo.spec.ts               # Logo / hero image visibility
+│   ├── navigation.spec.ts         # Site navigation
+│   ├── cookie-consent.spec.ts     # Cookie consent banner & modal
+│   └── ...                        # (see "Test Files and Coverage")
+├── __tests__/                      # Jest unit/component/a11y tests (20 files)
+│   ├── components/                # Component render + axe tests
+│   ├── app/                       # Page render, metadata, sitemap
+│   ├── data/                      # Data file integrity
+│   ├── lib/                       # Helper unit tests
+│   └── utils/axe.ts               # Shared jest-axe helper
 ├── playwright.config.ts            # Playwright configuration
 ├── .github/workflows/
 │   ├── ci.yml                     # CI: format, lint, Jest, build, links, Playwright E2E
@@ -716,6 +613,5 @@ freeforcharity-web/
 
 ---
 
-**Test Suite Status**: ✅ 5 passing, 1 skipped  
-**Integration Status**: ✅ Complete  
-**Last Tested**: October 2025
+**Test Suite Status**: ✅ Jest (20 test files) + Playwright E2E (18 spec files), lint clean (0 errors)  
+**Integration Status**: ✅ Complete

--- a/docs/CUTOVER-HANDOFF.md
+++ b/docs/CUTOVER-HANDOFF.md
@@ -1,8 +1,17 @@
 # Cutover Handoff — Free For Charity WordPress → Next.js (InterServer cPanel)
 
-> **✅ Cutover complete.** The apex `freeforcharity.org` now serves the
-> Next.js static export from cPanel (`public_html_next`). This document is
-> retained as a historical record and rollback reference.
+> **⚠️ Historical planning document — superseded.** The cutover did NOT
+> swap the document root to `public_html_next`, and there is NO
+> `~/public_html_next/hub -> ~/public_html/hub` symlink. The cutover
+> mirrored the Next.js static export straight into `~/public_html` (the
+> live apex docroot), excluding WHMCS at `~/public_html/hub` (a real
+> directory) and the other cPanel keepers. Production now deploys via
+> [`.github/workflows/deploy-cpanel.yml`](../.github/workflows/deploy-cpanel.yml)
+> (mirror-in-place into `~/public_html`); rollback is
+> [`docs/ROLLBACK.md`](ROLLBACK.md). (`~/public_html_next` is a SEPARATE
+> staging account/docroot used by `deploy-cpanel-staging.yml`, not a
+> production or rollback target.) The body below describes the original
+> swap-based plan and is kept for historical context only.
 
 The pre-cutover engineering work is complete. This document describes
 what was done and the operator steps that remain.

--- a/docs/CUTOVER-REDIRECTS.md
+++ b/docs/CUTOVER-REDIRECTS.md
@@ -107,9 +107,11 @@ inbound links.
 
 No action required at cutover. The rules are part of
 [`public/.htaccess`](../public/.htaccess), which is included in
-`out/.htaccess` after `next build` and uploaded as part of the cPanel
-deploy. They activate the moment the document root is swapped to
-`public_html_next` (see `docs/CUTOVER-HANDOFF.md`).
+`out/.htaccess` after `next build` and mirrored into `~/public_html`
+(the live apex docroot) on every production deploy. They are live the
+moment that `.htaccess` lands in `~/public_html` — no document-root swap
+is involved (see `docs/CUTOVER-HANDOFF.md` and
+[`.github/workflows/deploy-cpanel.yml`](../.github/workflows/deploy-cpanel.yml)).
 
 After cutover, smoke-test 5 sample URLs in an incognito browser:
 
@@ -146,10 +148,13 @@ guessing. Until then, don't.
 
 ## Rollback
 
-The cutover rollback (cPanel document-root swap from `public_html_next`
-back to `public_html`) automatically deactivates all `.htaccess`
-redirects, because the old `public_html/.htaccess` (WordPress) takes
-over. No separate redirect-rollback step needed.
+There is no document-root swap to reverse. Because the redirects ship in
+`out/.htaccess` and are mirrored into `~/public_html` on every deploy,
+rolling back the site (revert + redeploy on `main`, a manual
+`workflow_dispatch` of a known-good ref, or a cPanel backup restore)
+also rolls back the redirect set — the redeployed `.htaccess` replaces
+the current one. Follow [`docs/ROLLBACK.md`](ROLLBACK.md); no separate
+redirect-rollback step is needed.
 
 If Cloudflare Bulk Redirects are enabled, disable that rule in
 Cloudflare with a single toggle.

--- a/docs/CUTOVER-RUNBOOK.md
+++ b/docs/CUTOVER-RUNBOOK.md
@@ -1,8 +1,14 @@
 # Cutover Day Runbook
 
-> **✅ Cutover complete.** freeforcharity.org has been flipped to the
-> Next.js static export. This runbook is retained for historical reference
-> and in case a future re-cutover or rollback is needed.
+> **⚠️ Historical planning document — superseded.** The cutover did NOT
+> swap the document root to `public_html_next`. It mirrored the Next.js
+> static export straight into `~/public_html` (the live apex docroot),
+> excluding WHMCS at `~/public_html/hub` and the other cPanel keepers.
+> Production now deploys via
+> [`.github/workflows/deploy-cpanel.yml`](../.github/workflows/deploy-cpanel.yml)
+> (mirror-in-place into `~/public_html`); rollback is
+> [`docs/ROLLBACK.md`](ROLLBACK.md). The steps below describe the original
+> swap-based plan and are kept for historical context only.
 
 A single, chronological checklist for flipping freeforcharity.org from
 WordPress to the Next.js static export. Follow top to bottom. Each step

--- a/docs/ROLLBACK.md
+++ b/docs/ROLLBACK.md
@@ -1,104 +1,181 @@
-# Rollback Procedure: cPanel Document-Root Swap
+# Rollback Procedure: Production Apex (cPanel mirror-in-place)
 
-Roll back the freeforcharity.org website from the Next.js static export
-(`public_html_next`) back to the WordPress install (`public_html`).
-Used when something breaks in the first 14 days after cutover.
+Roll back freeforcharity.org when a deploy ships a broken build to the
+live apex.
 
-**Estimated rollback time: 2–5 minutes.** No DNS propagation involved
-— the document-root swap takes effect immediately on the InterServer
-cPanel host.
+> **Architecture (read this first).** The apex cutover mirrored the
+> Next.js static export **straight into `~/public_html`** — the document
+> root was **never swapped** to a sibling directory. Every production
+> deploy (`.github/workflows/deploy-cpanel.yml`) does an `lftp` mirror of
+> `out/` into `~/public_html` with `--delete`, **excluding** the proven
+> keeper set so it never touches WHMCS, the parked domain, or the cPanel
+> system files. Consequences for rollback:
+>
+> - There is **no document-root swap** to undo. The old DNS-flip /
+>   doc-root-swap rollbacks no longer apply.
+> - `~/public_html` no longer contains the old WordPress install — it
+>   holds the Next.js static files. You roll back by **re-mirroring a
+>   known-good build**, not by pointing the doc root elsewhere.
+> - **WHMCS at `~/public_html/hub/` is never modified** by any deploy
+>   (it is excluded from the mirror). A bad apex deploy does **not** take
+>   billing down, and rollback must likewise leave `/hub/` untouched.
+> - `~/public_html_next` is the **staging** docroot (a separate cPanel
+>   account / URL), not production. Don't deploy production there.
 
----
-
-## Prerequisites
-
-You will need access to:
-
-- **InterServer cPanel** for the freeforcharity.org account.
-- (Optional) SSH/Terminal access in cPanel for verifying file state.
-- The full cPanel backup downloaded during pre-flight (see
-  `docs/CUTOVER-HANDOFF.md` → "Pre-flight" step 1) — only needed if the
-  swap doesn't recover the WP files for some reason.
-
-The WordPress install at `~/public_html/` is **never modified** during or
-after cutover. It remains in place as the rollback target for at least
-14 days.
-
----
-
-## Step 1 — Swap the document root back in cPanel
-
-1. Log in to InterServer cPanel.
-2. Go to **Domains → manage `freeforcharity.org`**.
-3. Change the document root from `public_html_next` back to `public_html`.
-4. Save / apply. The swap takes effect on the next HTTP request.
+**Estimated rollback time: 5–10 minutes** (one revert + the auto-deploy
+that follows, or a single manual `workflow_dispatch`). No DNS
+propagation is involved.
 
 ---
 
-## Step 2 — Bust the Cloudflare cache
+## Decision: which rollback do I need?
 
-Cloudflare caches HTML aggressively. After the swap, force a refresh
-so visitors see the WordPress site immediately:
+| Situation                                                 | Use          |
+| --------------------------------------------------------- | ------------ |
+| A bad commit shipped; the previous commit was good        | **Option A** |
+| You need the site good _right now_, can't wait for CI     | **Option B** |
+| The mirror was interrupted / files on disk look corrupted | **Option C** |
+| `/hub/` (WHMCS) itself is down                            | **See note** |
 
-1. Cloudflare dashboard → `freeforcharity.org` zone → **Caching → Configuration**.
-2. **Purge Everything**. Confirm.
+> **Note on WHMCS.** Deploys exclude `~/public_html/hub`, so an apex
+> deploy cannot break `/hub/`. If `/hub/` is down, it is **not** an apex
+> deploy regression — do not roll back the apex. Treat it as a WHMCS /
+> cPanel / Cloudflare incident: check InterServer cPanel and the WHMCS
+> admin at `freeforcharity.org/hub/globaladmin`, and the escalation
+> contacts below.
 
 ---
 
-## Step 3 — Verify WordPress is responding
+## Option A — Revert the bad commit (preferred)
+
+Main auto-deploys: reverting on `main` re-mirrors the previous-good
+static export automatically.
 
 ```bash
-curl -I https://freeforcharity.org
-# Expect: HTTP/2 200 with WordPress-style headers (link rel="https://api.w.org/", etc.)
-
-curl -I https://freeforcharity.org/hub/
-# Expect: HTTP/2 200 — WHMCS still works (it never moved)
-
-curl -I https://freeforcharity.org/wp-login.php
-# Expect: HTTP/2 200 — WP admin reachable again
+git switch main && git pull
+git revert --no-edit <bad-commit-sha>   # or a range: <oldest>^..<newest>
+git push origin main
 ```
 
-Also verify visually in an incognito browser. If you see the Figma
-redesign, Cloudflare cache hasn't purged yet — wait 1–2 minutes and
+Then watch it ship:
+
+1. **CI — Build and Test** runs on the revert commit.
+2. On green, **Deploy to InterServer cPanel (production)** fires via
+   `workflow_run` and mirrors the reverted (good) `out/` into
+   `~/public_html`.
+3. The post-deploy smoke suite + the "Verify WHMCS /hub survived"
+   step confirm the apex and billing are healthy.
+
+This is the cleanest path: the rolled-back state is a real commit on
+`main`, so history and production stay in sync.
+
+---
+
+## Option B — Redeploy a known-good commit now (fastest)
+
+Skips the revert/CI round-trip — deploy a prior good commit directly.
+
+1. GitHub repo → **Actions → Deploy to InterServer cPanel (production)**
+   → **Run workflow**.
+2. Set **Use workflow from** to the **known-good ref** (a tag or commit;
+   pick the last commit whose deploy was green).
+3. Leave `delete_remote = true` (clean mirror) and set
+   `run_smoke = true` so the live checks run after upload.
+4. Run it. The CI-green gate requires that ref to have passed CI, and
+   the freshness guard is bypassed on manual dispatch (operator intent).
+
+> Follow up with **Option A** afterward so `main` reflects the
+> rolled-back state — otherwise the next merge re-ships the bad commit.
+
+---
+
+## Option C — Restore `~/public_html` from a cPanel backup (last resort)
+
+Only if the mirror left the apex files corrupted in a way a redeploy
+can't fix (e.g. a half-finished upload plus an unrelated disk issue).
+
+1. Log in to **InterServer cPanel** for the freeforcharity.org account.
+2. **Files → Backup / File Manager** → restore `~/public_html` from the
+   most recent good backup (the pre-flight backup from
+   `docs/CUTOVER-HANDOFF.md` → "Pre-flight" step 1, or a nightly).
+3. **Do not** restore over `~/public_html/hub` unless WHMCS itself is
+   the problem — keep billing's live state.
+4. Once stable, run **Option A or B** to get a clean, known-good static
+   export back in place from CI.
+
+---
+
+## Bust the Cloudflare cache (after any option)
+
+Cloudflare caches HTML aggressively. After the files are good, force a
+refresh so visitors stop seeing the broken version:
+
+1. Cloudflare dashboard → `freeforcharity.org` zone →
+   **Caching → Configuration**.
+2. **Purge Everything**. Confirm.
+
+The deploy/smoke steps send `Cache-Control: no-cache`, but visitor
+traffic still hits the edge cache until it's purged.
+
+---
+
+## Verify production is healthy
+
+```bash
+curl -I https://freeforcharity.org/
+# Expect: HTTP/2 200 — the Next.js apex
+
+curl -sS https://freeforcharity.org/hub/ | grep -iE 'whmcs|clientarea|cart\.php'
+# Expect: a WHMCS marker — billing still works (it never moved)
+
+BASE_URL=https://freeforcharity.org npm run smoke-test
+# Full live suite: every sitemap URL, the WP->Next redirects, /hub, assets.
+```
+
+Also check visually in an incognito browser. If you still see the broken
+version, the Cloudflare cache hasn't purged yet — wait 1–2 minutes and
 retry.
 
 ---
 
-## Step 4 — Disable the Next.js deploy workflow (optional)
+## Stop further auto-deploys while investigating (optional)
 
-If you want to prevent accidental redeploys to `public_html_next/`
-while you investigate:
+If you need to freeze production while you dig in:
 
-1. GitHub repo → **Settings → Actions → General → Workflow permissions**, or
-2. Open `.github/workflows/deploy-cpanel.yml` and add `if: false` to the job, or
-3. Disable the workflow from the Actions tab in GitHub UI.
+1. GitHub repo → **Actions** tab → **Deploy to InterServer cPanel
+   (production)** → **⋯ → Disable workflow**, or
+2. Add `if: false` to the job in `.github/workflows/deploy-cpanel.yml`
+   and push (this also stops the auto-deploy on the revert — re-enable
+   before using Option A).
 
-This step is optional — the workflow is already manual-trigger only.
+Re-enable once you're ready to ship the fix.
 
 ---
 
-## Step 5 — Open a post-mortem issue
+## Open a post-mortem issue
 
 After stabilizing, open a GitHub issue documenting:
 
 - What broke (specific pages, features, or infra).
-- When it was detected.
-- How long the outage lasted.
+- When it was detected and how long the degradation lasted.
 - Root cause.
-- Fix required before re-attempting cutover.
+- The guard/test that should have caught it (so we close the gap).
+
+The deploy workflow auto-opens a `🚨 HIGH … deploy/smoke FAILED`
+incident issue on failure — fold the post-mortem into that issue if one
+exists.
 
 ---
 
-## Important Notes
+## Reference
 
-| Item                         | Detail                                                                                                                                           |
-| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `~/public_html/`             | Original WordPress install. Do not touch for at least 14 days post-cutover.                                                                      |
-| `~/public_html/hub/`         | WHMCS. Never modified by the cutover; same files serve both before and after.                                                                    |
-| `~/public_html_next/`        | Next.js static export. Created by the first `deploy-cpanel.yml` run.                                                                             |
-| `~/public_html_next/hub`     | Symlink to `~/public_html/hub`. Keeps `/hub/` working under the new document root.                                                               |
-| Cloudflare role              | Continues to proxy as before — no DNS change in either direction.                                                                                |
-| `docs/cutover-redirects.csv` | If Cloudflare Bulk Redirects were enabled, disable that rule too — `.htaccess` redirects vanish automatically when the document root swaps back. |
+| Item                  | Detail                                                                                               |
+| --------------------- | ---------------------------------------------------------------------------------------------------- |
+| `~/public_html/`      | **Live apex docroot.** Holds the Next.js static export; re-mirrored on every production deploy.      |
+| `~/public_html/hub/`  | **WHMCS billing.** Excluded from every deploy mirror — never modified by an apex deploy or rollback. |
+| `~/public_html_next/` | **Staging** docroot (separate cPanel account / URL). Not production; not a rollback target.          |
+| Cloudflare role       | Proxies the apex — purge the cache after a rollback so visitors leave the broken edge copy.          |
+| Deploy workflow       | `.github/workflows/deploy-cpanel.yml` (auto on merge to `main` after CI; manual dispatch for B).     |
 
 ---
 
@@ -113,4 +190,6 @@ After stabilizing, open a GitHub issue documenting:
 
 ---
 
-_Last updated: 2026-05-15 (rewrote for cPanel document-root swap; previous version was for a DNS-flip rollback that no longer applies)._
+_Last updated: 2026-06-27 (rewritten for the mirror-in-place apex model;
+the previous version described a `public_html_next` document-root swap
+that never reflected how the cutover actually deployed)._

--- a/docs/STAGING-CHECKLIST.md
+++ b/docs/STAGING-CHECKLIST.md
@@ -1,12 +1,18 @@
 # Staging Verification Checklist
 
-> **✅ Cutover complete.** The document-root swap has happened and the
-> apex now serves the Next.js build. This checklist is retained as a
-> historical record / template for future staged deploys.
+> **✅ Cutover complete.** No document-root swap happened. The apex
+> `freeforcharity.org` cutover mirrored the Next.js static export
+> straight into `~/public_html` (the live apex docroot), excluding WHMCS
+> at `~/public_html/hub` and the other cPanel keepers. Production now
+> deploys via `.github/workflows/deploy-cpanel.yml` (mirror-in-place into
+> `~/public_html`); rollback is `docs/ROLLBACK.md`. This checklist is
+> retained as a historical record and remains a valid template for
+> verifying a STAGING deploy before promotion. References to
+> `public_html_next` below describe the SEPARATE staging docroot/account,
+> not production.
 
-Use this checklist to verify the staged Next.js site before swapping
-the cPanel document root from `public_html` (WordPress) to
-`public_html_next` (the new build).
+Use this checklist to verify a staged Next.js build (on the STAGING
+surface) before promoting it to production.
 
 The cutover target is **InterServer cPanel**, not GitHub Pages — the
 apex domain stays on the existing origin so that WHMCS at `/hub/`
@@ -28,22 +34,22 @@ CI-based checks in this table run automatically on every push to `main`; rows
 marked `manual` must be run by hand. Confirm all checks are green or completed
 before proceeding to the manual checks below.
 
-| Check             | Workflow                      | What It Verifies                                                                                                                             |
-| ----------------- | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| Format            | `ci.yml`                      | Prettier formatting                                                                                                                          |
-| Lint              | `ci.yml`                      | ESLint — no errors                                                                                                                           |
-| Unit tests        | `ci.yml`                      | Jest (metadata, sitemap, data files, assetPath)                                                                                              |
-| Build             | `ci.yml`                      | `next build` — static export succeeds                                                                                                        |
-| Internal links    | `ci.yml`                      | Playwright: no broken internal links (`post-deploy-smoke.spec.ts`)                                                                           |
-| External links    | `lychee.yml`                  | Scheduled Lychee link checker against deployed site                                                                                          |
-| Accessibility     | `ci.yml`                      | axe-core via Playwright (`tests/accessibility.spec.ts`) — WCAG 2.1 AA                                                                        |
-| E2E tests         | `ci.yml`                      | Playwright: navigation, images, cookie consent, copyright, contact page, footer, team, mobile nav, dropdowns, external links                 |
-| Lighthouse        | `lighthouse.yml`              | Performance / a11y / SEO / best practices thresholds on multiple URLs                                                                        |
-| CodeQL            | `codeql.yml`                  | Static analysis for JS/TS and Actions                                                                                                        |
-| Linkinator        | manual                        | Optional: run `npm run check-links` on `./out` for additional coverage                                                                       |
-| Visual regression | manual                        | Run `npm run visual-regression` to compare each non-homepage page against the live WordPress origin (see `docs/visual-regression/README.md`) |
-| Deploy            | `deploy-cpanel.yml`           | Manual-trigger FTPS upload of `out/` to `~/public_html_next/` on InterServer cPanel (production)                                             |
-| Staging preview   | `deploy-gh-pages-staging.yml` | Manual-trigger GitHub Pages preview build (optional; useful for `npm run visual-regression`)                                                 |
+| Check             | Workflow                      | What It Verifies                                                                                                                                             |
+| ----------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Format            | `ci.yml`                      | Prettier formatting                                                                                                                                          |
+| Lint              | `ci.yml`                      | ESLint — no errors                                                                                                                                           |
+| Unit tests        | `ci.yml`                      | Jest (metadata, sitemap, data files, assetPath)                                                                                                              |
+| Build             | `ci.yml`                      | `next build` — static export succeeds                                                                                                                        |
+| Internal links    | `ci.yml`                      | Playwright: no broken internal links (`post-deploy-smoke.spec.ts`)                                                                                           |
+| External links    | `lychee.yml`                  | Scheduled Lychee link checker against deployed site                                                                                                          |
+| Accessibility     | `ci.yml`                      | axe-core via Playwright (`tests/accessibility.spec.ts`) — WCAG 2.1 AA                                                                                        |
+| E2E tests         | `ci.yml`                      | Playwright: navigation, images, cookie consent, copyright, contact page, footer, team, mobile nav, dropdowns, external links                                 |
+| Lighthouse        | `lighthouse.yml`              | Performance / a11y / SEO / best practices thresholds on multiple URLs                                                                                        |
+| CodeQL            | `codeql.yml`                  | Static analysis for JS/TS and Actions                                                                                                                        |
+| Linkinator        | manual                        | Optional: run `npm run check-links` on `./out` for additional coverage                                                                                       |
+| Visual regression | manual                        | Run `npm run visual-regression` to compare each non-homepage page against the live WordPress origin (see `docs/visual-regression/README.md`)                 |
+| Deploy            | `deploy-cpanel.yml`           | Manual-trigger FTPS mirror of `out/` into `~/public_html` on InterServer cPanel (production, mirror-in-place — excludes `hub/` and the other cPanel keepers) |
+| Staging preview   | `deploy-gh-pages-staging.yml` | Manual-trigger GitHub Pages preview build (optional; useful for `npm run visual-regression`)                                                                 |
 
 ---
 

--- a/docs/performance-baseline/README.md
+++ b/docs/performance-baseline/README.md
@@ -35,6 +35,6 @@ Compare against the Next.js Lighthouse CI after cutover.
 
 ## How to compare post-cutover
 
-After the document-root swap and 48-hour soak, run Lighthouse against the new
+After cutover and a 48-hour soak, run Lighthouse against the new
 Next.js export at the same URLs and append a `next-` prefixed report set.
 Delta of > 10 points on perf or LCP > +500ms is worth investigating.

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -36,39 +36,61 @@ function record(name, ok, detail) {
   process.stdout.write(`${ok ? PASS : FAIL} ${name}${detail ? ` — ${detail}` : ''}\n`)
 }
 
-async function request(path, { followRedirects = true, readBody = false } = {}) {
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+
+async function request(path, { followRedirects = true, readBody = false, retries = 2 } = {}) {
   const url = path.startsWith('http') ? path : `${BASE_URL}${path}`
-  const controller = new AbortController()
-  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS)
-  try {
-    const res = await fetch(url, {
-      method: 'GET',
-      redirect: followRedirects ? 'follow' : 'manual',
-      signal: controller.signal,
-      headers: {
-        'User-Agent': 'ffc-smoke-test/1.0',
-        // Bust the Cloudflare edge cache so a freshly-deployed origin
-        // is observed instead of a stale cached version. Without this,
-        // a smoke run immediately after deploy can pass against the
-        // pre-deploy HTML and report green on a regression.
-        'Cache-Control': 'no-cache',
-        Pragma: 'no-cache',
-      },
-    })
-    let body
-    if (readBody) {
-      body = await res.text()
-    } else {
-      // Eagerly discard the response stream — without this Node's fetch
-      // keeps the body buffer around until GC, which adds up across
-      // ~50 sitemap+redirect checks per run.
-      await res.body?.cancel?.()
+  // Retry transient failures — a network blip (DNS/TLS/timeout) or an
+  // upstream 5xx (Cloudflare/origin) on any one of ~90 checks would otherwise
+  // red the whole run. Real regressions (4xx, wrong redirect, missing marker)
+  // are NOT retried, so this only suppresses flakes, never masks a failure.
+  for (let attempt = 0; ; attempt++) {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), TIMEOUT_MS)
+    try {
+      const res = await fetch(url, {
+        method: 'GET',
+        redirect: followRedirects ? 'follow' : 'manual',
+        signal: controller.signal,
+        headers: {
+          'User-Agent': 'ffc-smoke-test/1.0',
+          // Bust the Cloudflare edge cache so a freshly-deployed origin
+          // is observed instead of a stale cached version. Without this,
+          // a smoke run immediately after deploy can pass against the
+          // pre-deploy HTML and report green on a regression.
+          'Cache-Control': 'no-cache',
+          Pragma: 'no-cache',
+        },
+      })
+      let body
+      if (readBody) {
+        body = await res.text()
+      } else {
+        // Eagerly discard the response stream — without this Node's fetch
+        // keeps the body buffer around until GC, which adds up across
+        // ~50 sitemap+redirect checks per run.
+        await res.body?.cancel?.()
+      }
+      clearTimeout(timer)
+      if (res.status >= 500 && attempt < retries) {
+        await sleep(500 * (attempt + 1))
+        continue
+      }
+      return {
+        status: res.status,
+        location: res.headers.get('location'),
+        headers: res.headers,
+        url: res.url,
+        body,
+      }
+    } catch (err) {
+      clearTimeout(timer)
+      if (attempt < retries) {
+        await sleep(500 * (attempt + 1))
+        continue
+      }
+      return { status: 0, error: err.message }
     }
-    return { status: res.status, location: res.headers.get('location'), url: res.url, body }
-  } catch (err) {
-    return { status: 0, error: err.message }
-  } finally {
-    clearTimeout(timer)
   }
 }
 
@@ -117,6 +139,71 @@ async function checkNextAssetLoads() {
   const r = await request(match[0])
   const detail = r.error ? `${match[0]} → ${r.status} (${r.error})` : `${match[0]} → ${r.status}`
   record(`Next.js JS bundle loads`, r.status === 200, detail)
+  // Content-hashed chunks must be cached long and immutable, or every visit
+  // re-downloads the bundle (perf regression / wrong cache config).
+  if (r.status === 200) {
+    const cc = r.headers && r.headers.get('cache-control')
+    record(
+      `static assets immutably cached`,
+      Boolean(cc && /immutable/i.test(cc)),
+      `${match[0]} cache-control: ${cc || '(absent)'}`
+    )
+  }
+}
+
+// Assert a single response header matches (substring or RegExp). Catches
+// .htaccess / Cloudflare drift that a status-code check can't see.
+async function checkHeader(name, path, header, matcher) {
+  const r = await request(path)
+  const val = r.headers && r.headers.get(header)
+  const ok = val
+    ? matcher instanceof RegExp
+      ? matcher.test(val)
+      : val.toLowerCase().includes(String(matcher).toLowerCase())
+    : false
+  record(name, Boolean(ok), `${path} ${header}: ${val || '(absent)'}`)
+}
+
+// The security headers the .htaccess is expected to set. A missing/weakened
+// header is a real security regression even though the page still 200s.
+async function checkSecurityHeaders(name, path) {
+  const required = {
+    'x-content-type-options': /nosniff/i,
+    'x-frame-options': /sameorigin|deny/i,
+    'referrer-policy': /.+/,
+    'strict-transport-security': /max-age=\d+/i,
+  }
+  const r = await request(path)
+  const missing = []
+  for (const [h, re] of Object.entries(required)) {
+    const val = r.headers && r.headers.get(h)
+    if (!val || !re.test(val)) missing.push(val ? `${h}=${val}` : `${h} (absent)`)
+  }
+  record(
+    name,
+    missing.length === 0,
+    missing.length ? `${path} → ${missing.join('; ')}` : `${path} → all present`
+  )
+}
+
+// http:// must 301/308 to https:// — never serve the site in the clear.
+async function checkHttpsRedirect(name) {
+  const httpUrl = `${BASE_URL.replace(/^https:/, 'http:')}/`
+  const r = await request(httpUrl, { followRedirects: false })
+  const ok = [301, 302, 307, 308].includes(r.status) && /^https:\/\//.test(r.location || '')
+  record(name, ok, `${httpUrl} → ${r.status} ${r.location || '(no Location)'}`)
+}
+
+// A 404 must render the custom Next.js not-found page, not just return the
+// status — a server/host default 404 (or a blank body) would still be 404.
+async function check404Renders(name) {
+  const r = await request('/this-page-does-not-exist-xyz/', { readBody: true })
+  const hasMarker = r.body ? /page not|404|free for charity/i.test(r.body) : false
+  record(
+    name,
+    r.status === 404 && hasMarker,
+    `/…nonexistent → ${r.status}${hasMarker ? ' (custom 404 body)' : ' (no 404 marker)'}`
+  )
 }
 
 function parseSitemap(xml) {
@@ -208,10 +295,19 @@ async function main() {
   // 200 can mask an empty/partial index.html (e.g. a truncated upload), so
   // assert a known marker from the rendered page.
   await checkBodyContains(`/ renders homepage content`, '/', ['free for charity'])
-  await checkStatus(`unknown URL returns 404`, '/this-page-does-not-exist-xyz/', 404)
+  await check404Renders(`custom 404 page renders`)
   await checkStatus(`favicon`, '/favicon.ico', 200)
   await checkStatus(`sitemap.xml`, '/sitemap.xml', 200)
   await checkStatus(`robots.txt`, '/robots.txt', 200)
+
+  console.log(`\n-- security, headers & transport`)
+  // Security headers the .htaccess sets — a missing one is a real regression.
+  await checkSecurityHeaders(`homepage sets security headers`, '/')
+  // The site must never be served over plaintext HTTP.
+  await checkHttpsRedirect(`http:// redirects to https://`)
+  // Content types: a wrong type (e.g. the 415 class of bug) breaks consumers.
+  await checkHeader(`sitemap.xml served as XML`, '/sitemap.xml', 'content-type', /xml/i)
+  await checkHeader(`robots.txt served as text`, '/robots.txt', 'content-type', /text\/plain/i)
 
   console.log(`\n-- special components`)
   // The two donation/revenue surfaces — a 200 isn't enough; assert the

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -105,13 +105,18 @@ async function checkBodyContains(name, path, expectedSubstrings) {
 // be blank/non-interactive for real users).
 async function checkNextAssetLoads() {
   const home = await request('/', { readBody: true })
+  if (home.error) {
+    record(`Next.js JS bundle loads`, false, `/ → ${home.status} (${home.error})`)
+    return
+  }
   const match = home.body && home.body.match(/\/_next\/static\/[^"')\s]+\.js/)
   if (!match) {
-    record(`Next.js bundle referenced on homepage`, false, '/ → no /_next/static/*.js reference')
+    record(`Next.js JS bundle loads`, false, '/ → no /_next/static/*.js reference found')
     return
   }
   const r = await request(match[0])
-  record(`Next.js JS bundle loads`, r.status === 200, `${match[0]} → ${r.status}`)
+  const detail = r.error ? `${match[0]} → ${r.status} (${r.error})` : `${match[0]} → ${r.status}`
+  record(`Next.js JS bundle loads`, r.status === 200, detail)
 }
 
 function parseSitemap(xml) {
@@ -203,14 +208,6 @@ async function main() {
   // 200 can mask an empty/partial index.html (e.g. a truncated upload), so
   // assert a known marker from the rendered page.
   await checkBodyContains(`/ renders homepage content`, '/', ['free for charity'])
-  // WHMCS at /hub/ — assert response includes a WHMCS-specific marker so
-  // a stale index.html or directory listing doesn't pass as a healthy hub.
-  await checkBodyContains(`/hub/ serves WHMCS (not a placeholder)`, '/hub/', [
-    'whmcs',
-    'WHMCompleteSolution',
-    'cart.php',
-    'clientarea',
-  ])
   await checkStatus(`unknown URL returns 404`, '/this-page-does-not-exist-xyz/', 404)
   await checkStatus(`favicon`, '/favicon.ico', 200)
   await checkStatus(`sitemap.xml`, '/sitemap.xml', 200)
@@ -226,6 +223,16 @@ async function main() {
     '/free-for-charity-endowment-fund/',
     ['zeffy']
   )
+  // PayPal return flow: the donation-confirmation callback must 302 to
+  // /donate AND preserve the transaction query (tx=...), or the post-donation
+  // confirmation params are lost. (The CSV loop above only covers the
+  // no-query case; this asserts the param actually survives.)
+  await checkRedirect(
+    `/donation-confirmation preserves the PayPal tx param`,
+    '/donation-confirmation/?tx=SMOKE123',
+    302,
+    '/donate/?tx=SMOKE123'
+  )
   // Mandatory FFC-wide homepage sections (Team + testimonials) — their
   // absence means a broken/partial render, not just a styling diff.
   await checkBodyContains(`homepage renders the Team section`, '/', ['the free for charity team'])
@@ -239,6 +246,27 @@ async function main() {
   await checkStatus(`logo asset loads`, '/Images/ffc-logo-banner.webp', 200)
   // The built JS bundle must actually have uploaded (catches partial deploys).
   await checkNextAssetLoads()
+
+  console.log(`\n-- WHMCS billing portal (/hub — third-party PHP app via symlink)`)
+  // Every /hub endpoint must serve real WHMCS, not a Next.js 404 or a
+  // placeholder — proves the public_html_next/hub symlink and the WHMCS app
+  // survived the deploy. These are live customer flows: store, cart, login,
+  // announcements, and the admin console.
+  const WHMCS_MARKERS = ['whmcs', 'WHMCompleteSolution', 'cart.php', 'clientarea']
+  await checkBodyContains(`/hub/ storefront`, '/hub/', WHMCS_MARKERS)
+  await checkBodyContains(`/hub/cart.php (order/cart)`, '/hub/cart.php', WHMCS_MARKERS)
+  await checkBodyContains(
+    `/hub/clientarea.php (client login)`,
+    '/hub/clientarea.php',
+    WHMCS_MARKERS
+  )
+  await checkBodyContains(`/hub/announcements.php`, '/hub/announcements.php', WHMCS_MARKERS)
+  await checkBodyContains(
+    `/hub/store product page`,
+    '/hub/store/ffc-consulting/nonprofit-charity-onboarding',
+    WHMCS_MARKERS
+  )
+  await checkBodyContains(`/hub/globaladmin (admin login)`, '/hub/globaladmin', WHMCS_MARKERS)
 
   const failed = results.filter((r) => !r.ok)
   console.log(`\n${results.length - failed.length}/${results.length} passed`)

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -99,6 +99,21 @@ async function checkBodyContains(name, path, expectedSubstrings) {
   record(name, ok, detail)
 }
 
+// Verify the hashed Next.js JS bundle is actually on the server. A partial
+// or interrupted upload can leave the HTML at 200 while the /_next/static
+// chunks 404 — a status-only homepage check would miss that (the page would
+// be blank/non-interactive for real users).
+async function checkNextAssetLoads() {
+  const home = await request('/', { readBody: true })
+  const match = home.body && home.body.match(/\/_next\/static\/[^"')\s]+\.js/)
+  if (!match) {
+    record(`Next.js bundle referenced on homepage`, false, '/ → no /_next/static/*.js reference')
+    return
+  }
+  const r = await request(match[0])
+  record(`Next.js JS bundle loads`, r.status === 200, `${match[0]} → ${r.status}`)
+}
+
 function parseSitemap(xml) {
   const locs = [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map((m) => m[1])
   return locs.map((u) => new URL(u).pathname)
@@ -200,6 +215,30 @@ async function main() {
   await checkStatus(`favicon`, '/favicon.ico', 200)
   await checkStatus(`sitemap.xml`, '/sitemap.xml', 200)
   await checkStatus(`robots.txt`, '/robots.txt', 200)
+
+  console.log(`\n-- special components`)
+  // The two donation/revenue surfaces — a 200 isn't enough; assert the
+  // actual payment integrations are present in the rendered HTML so a
+  // retired PayPal button or a dropped Zeffy embed is caught.
+  await checkBodyContains(`/donate exposes the PayPal hosted button`, '/donate/', ['9ZKQ23YC3G2J2'])
+  await checkBodyContains(
+    `/free-for-charity-endowment-fund mounts the Zeffy form`,
+    '/free-for-charity-endowment-fund/',
+    ['zeffy']
+  )
+  // Mandatory FFC-wide homepage sections (Team + testimonials) — their
+  // absence means a broken/partial render, not just a styling diff.
+  await checkBodyContains(`homepage renders the Team section`, '/', ['the free for charity team'])
+  await checkBodyContains(`homepage renders testimonials`, '/', ['testimonial'])
+  // Contact page (no form, by policy) must still expose the contact methods.
+  await checkBodyContains(`/contact-us exposes a mailto link`, '/contact-us/', ['mailto:'])
+  // robots.txt must advertise the sitemap (proves it's the FFC robots.txt,
+  // not a host default, and keeps SEO crawling intact).
+  await checkBodyContains(`robots.txt references the sitemap`, '/robots.txt', ['sitemap:'])
+  // Header/footer logo asset must be on the server.
+  await checkStatus(`logo asset loads`, '/Images/ffc-logo-banner.webp', 200)
+  // The built JS bundle must actually have uploaded (catches partial deploys).
+  await checkNextAssetLoads()
 
   const failed = results.filter((r) => !r.ok)
   console.log(`\n${results.length - failed.length}/${results.length} passed`)

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -155,6 +155,10 @@ async function checkNextAssetLoads() {
 // .htaccess / Cloudflare drift that a status-code check can't see.
 async function checkHeader(name, path, header, matcher) {
   const r = await request(path)
+  if (r.error) {
+    record(name, false, `${path} → ${r.status} (${r.error})`)
+    return
+  }
   const val = r.headers && r.headers.get(header)
   const ok = val
     ? matcher instanceof RegExp
@@ -174,6 +178,10 @@ async function checkSecurityHeaders(name, path) {
     'strict-transport-security': /max-age=\d+/i,
   }
   const r = await request(path)
+  if (r.error) {
+    record(name, false, `${path} → ${r.status} (${r.error})`)
+    return
+  }
   const missing = []
   for (const [h, re] of Object.entries(required)) {
     const val = r.headers && r.headers.get(h)

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -102,6 +102,13 @@ async function checkStatus(name, path, expected) {
 
 async function checkRedirect(name, path, expectedStatus, expectedLocationSuffix) {
   const r = await request(path, { followRedirects: false })
+  // Surface the underlying fetch failure (timeout / DNS / TLS) so a flaky
+  // network blip is distinguishable from a real redirect regression —
+  // critical now that revenue flows (donation-confirmation) assert redirects.
+  if (r.error) {
+    record(name, false, `${path} → ${r.status} (${r.error})`)
+    return
+  }
   const locOk = r.location && r.location.endsWith(expectedLocationSuffix)
   const ok = r.status === expectedStatus && locOk
   record(name, ok, `${path} → ${r.status} ${r.location || '(no Location)'}`)

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -206,11 +206,19 @@ async function checkHttpsRedirect(name) {
 // status — a server/host default 404 (or a blank body) would still be 404.
 async function check404Renders(name) {
   const r = await request('/this-page-does-not-exist-xyz/', { readBody: true })
-  const hasMarker = r.body ? /page not|404|free for charity/i.test(r.body) : false
+  if (r.error) {
+    record(name, false, `/…nonexistent → ${r.status} (${r.error})`)
+    return
+  }
+  // Marker is the unique <h1> from src/app/not-found.tsx ("We couldn't find
+  // that page"). The served apostrophe is U+2019 (&rsquo;), so `.` spans it.
+  // A generic host/CDN 404 (just "404" / "page not found") won't match this,
+  // avoiding the false positives the broad old marker produced.
+  const hasMarker = r.body ? /we couldn.t find that page/i.test(r.body) : false
   record(
     name,
     r.status === 404 && hasMarker,
-    `/…nonexistent → ${r.status}${hasMarker ? ' (custom 404 body)' : ' (no 404 marker)'}`
+    `/…nonexistent → ${r.status}${hasMarker ? ' (custom 404 body)' : ' (no custom-404 marker)'}`
   )
 }
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,6 +1,6 @@
 # Test Suite
 
-This directory contains automated end-to-end tests for the Free For Charity web application using Playwright.
+This directory contains automated end-to-end (E2E) tests for the Free For Charity web application using Playwright. The project also has Jest + React Testing Library + jest-axe unit, component, and accessibility tests (jsdom) that live alongside the source and run in CI before the E2E suite.
 
 ## Test Statistics
 
@@ -292,8 +292,8 @@ npm run test:ui
 # Run only logo tests
 npx playwright test logo.spec.ts
 
-# Run only GitHub Pages tests
-npx playwright test github-pages.spec.ts
+# Run only the post-deploy smoke tests
+npx playwright test post-deploy-smoke.spec.ts
 
 # Run a specific test by name
 npx playwright test -g "should display logo in top left corner"
@@ -328,27 +328,31 @@ Tests are configured in `playwright.config.ts` at the project root.
 
 ## CI/CD Integration
 
-Tests are automatically run in GitHub Actions on every push to the main branch.
+Tests run automatically in GitHub Actions on every push / PR to the `main` branch.
 
-**Workflow**: `.github/workflows/nextjs.yml`
+**Workflow**: `.github/workflows/ci.yml` ("CI - Build and Test")
 
 **CI Pipeline Steps**:
 
 1. ✅ Checkout repository
-2. ✅ Setup Node.js 20
+2. ✅ Setup Node.js 24.x
 3. ✅ Install dependencies (`npm ci`)
-4. ✅ Install Playwright browsers with system deps
-5. ✅ Build Next.js with GitHub Pages basePath
-6. ✅ Run test suite
-7. ✅ Upload test artifacts on failure
-8. ✅ Deploy only if tests pass
+4. ✅ Format check and lint
+5. ✅ Run Jest unit/component/a11y tests (jest-axe, jsdom)
+6. ✅ Build the production site (root path, `NEXT_PUBLIC_BASE_PATH=''`)
+7. ✅ Internal link check
+8. ✅ Install Playwright browsers with system deps
+9. ✅ Run Playwright E2E suite
+
+On green, the production deploy (`.github/workflows/deploy-cpanel.yml`) mirrors `out/` into `~/public_html` on InterServer cPanel (the live apex docroot for `freeforcharity.org`), excluding the WHMCS hub at `~/public_html/hub`. GitHub Pages is now a manual staging/preview surface only (`deploy-gh-pages-staging.yml`) at the `/FFC-IN-freeforcharity.org` subpath, where `basePath` + `assetPath()` apply. The old GitHub Pages production workflows (`deploy.yml` / `nextjs.yml`) have been removed.
+
+After deploy, `npm run smoke-test` (`scripts/smoke-test.mjs`, also run on a schedule via `scheduled-prod-smoke.yml`) verifies the live apex, the WHMCS `/hub`, and key redirects.
 
 **Test Failure Handling**:
 
-- If any test fails, the build is marked as failed
-- Deployment to GitHub Pages is blocked
+- If any test fails, CI is marked as failed
+- The production deploy is blocked until CI is green
 - Test artifacts and traces are uploaded for debugging
-- Team is notified of failure
 
 ## Writing New Tests
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -7,7 +7,7 @@ This directory contains automated end-to-end (E2E) tests for the Free For Charit
 - **Total Tests**: 125 tests across 9 test suites
 - **Status**: ✅ 124 passing, ⏭️ 1 skipped
 - **Execution Time**: ~40-60 seconds
-- **Framework**: Playwright v1.56.0
+- **Framework**: Playwright v1.60
 
 ## Test Files
 
@@ -532,4 +532,4 @@ When tests fail in CI:
 
 **Test Suite Status**: ✅ 124 passing, 1 skipped
 **Last Updated**: February 2026
-**Framework**: Playwright v1.56.0
+**Framework**: Playwright v1.60


### PR DESCRIPTION
## 🔴 Critical fix — production deploys were a no-op

The auto-deploy in `deploy-cpanel.yml` mirrored the build into **`~/public_html_next/`**, but that is **not the live docroot**. The apex cutover (`cpanel-apex-cutover.yml`) mirrored the static export straight into **`~/public_html`** (the docroot was never swapped to a sibling dir), with WHMCS at `~/public_html/hub` as a **real directory**.

So every auto-deploy uploaded to a dead parking dir and **never updated the live site** — which is exactly why the `/author/*` `.htaccess` fix never went live and the post-deploy smoke kept failing on it ([run 28278269277](https://github.com/FreeForCharity/FFC-IN-freeforcharity.org/actions/runs/28278269277)). Caught by @clarkemoyer.

### The fix
- Mirror `./out/` into **`./public_html/`** (the live apex docroot).
- Use the **exact proven `/hub`-safe keeper excludes** from `cpanel-apex-cutover.yml`: `hub`, `cgi-bin/`, `.well-known/`, the parked-domain docroot `wh1319644.ispot.cc/`, the PHP configs `.user.ini`/`php.ini` that `/hub` inherits, and the system dotfiles. The previous minimal exclude set would have **deleted the parked domain and `/hub`'s PHP env** on a `--delete` mirror into `public_html`.
- Add a **build-size floor** (≥50 files) before the `--delete` mirror so a truncated build can't wipe the live site.
- Updated the header, job name, input descriptions, and summary to match.

## Smoke-test hardening (also in this PR)
- **Retry logic** in `request()` (transient network / 5xx) — fewer flaky false-positives.
- **Special components:** PayPal hosted button, Zeffy form, Team + testimonials, contact mailto, robots→sitemap, logo, JS-bundle-loaded.
- **WHMCS portal:** `/hub/`, `cart.php`, `clientarea.php`, `announcements.php`, a store product page, `globaladmin`.
- **Donation return flow:** `/donation-confirmation/?tx=…` preserves the `tx` query into `/donate/`.
- **Security/transport/caching:** security headers (HSTS, nosniff, frame, referrer), http→https, XML/text content-types, immutable static-asset cache, custom-404 render.

## High-priority failure alerting
`deploy-cpanel.yml` opens (or appends to) a `🚨 HIGH … deploy/smoke FAILED` incident issue on **any** deploy or smoke failure (labels `deploy-failure`/`incident`/`production-health`, labels upserted first, PRs filtered from dedupe, superseded runs never alert).

## Review
All Copilot threads resolved (label upsert, fetch-error surfacing in `checkHeader`/`checkSecurityHeaders`/`checkNextAssetLoads`, PR-filtered dedupe).

## ⚠️ Note on merging
Merging this triggers an auto-deploy that, for the **first time, actually writes to the live `~/public_html`** with `--delete`. The keep-list is the proven cutover set and a build-size floor guards against an empty build, but this is a destructive-to-live mirror — worth a careful look before merge. The **atomic stage-then-swap** redesign remains the recommended follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)