### PR TITLE
fix(deploy): make optional KV-secret fetches truly non-fatal (clear $LASTEXITCODE)

### DIFF
--- a/.github/workflows/deploy-cpanel.yml
+++ b/.github/workflows/deploy-cpanel.yml
@@ -266,6 +266,10 @@ jobs:
           } catch {
             Write-Host "::warning::APIM gateway key unavailable — post-mirror parity check will be skipped. $($_.Exception.Message)"
             "APIM_KEY=" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+            # Get-KvSecret's `az` call left $LASTEXITCODE=1 before throwing;
+            # clear it or GitHub's pwsh wrapper exits the step non-zero even
+            # though we deliberately handled this as non-fatal.
+            $global:LASTEXITCODE = 0
           }
 
           # Cloudflare token — DEFENSIVE: a missing/renamed secret must not fail
@@ -279,7 +283,14 @@ jobs:
           } catch {
             Write-Host "::warning::Cloudflare token '$($env:CF_KV_SECRET_NAME)' not found in $vault — post-deploy edge purge will be skipped. $($_.Exception.Message)"
             "CF_API_TOKEN=" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+            # Clear the failed `az` exit code so this handled-as-non-fatal miss
+            # doesn't make GitHub's pwsh wrapper fail the whole step.
+            $global:LASTEXITCODE = 0
           }
+          # Final guard: a caught optional-secret miss above must never leave a
+          # non-zero exit code for the step. (Required FTP creds throw uncaught
+          # and abort earlier, so reaching here means they loaded fine.)
+          exit 0
 
       - name: Upload out/ to ~/public_html/ (live apex docroot)
         if: ${{ steps.freshness.outputs.superseded != 'true' }}


### PR DESCRIPTION
## Hotfix for the PR1 (#313) deploy regression

The first auto-deploy after #313 **failed** ([run 28293666625](https://github.com/FreeForCharity/FFC-IN-freeforcharity.org/actions/runs/28293666625)) — but **production was not touched**: the failure was in the cred-fetch step, *before* the upload, so the live site kept serving the previous good build.

### Root cause
`Get-KvSecret` runs `az keyvault secret show`, which sets `$LASTEXITCODE=1` on a missing secret **before** throwing. My defensive `try/catch` for the (still-unprovisioned) Cloudflare token *did* catch the throw and log the intended warning — but GitHub's pwsh wrapper appends `if ($LASTEXITCODE) { exit $LASTEXITCODE }`, so the lingering `1` failed the whole step. The catch was therefore not actually non-fatal.

```
ERROR: (SecretNotFound) ...wr-all-cbm-cloudflare-ffc-api-token... not found
##[warning]Cloudflare token ... not found ... edge purge will be skipped.   ← catch ran
##[error]Process completed with exit code 1.                                 ← but step still failed
```

### Fix
- Reset `$global:LASTEXITCODE = 0` in the **APIM** and **Cloudflare** catch blocks.
- Add a final `exit 0` guard in the cred-fetch step.
- Required FTP secrets still throw **uncaught** and abort the step before that guard, so a genuine credential failure still fails the deploy hard.

### Effect
- Unblocks the parity check / Cloudflare purge / incident auto-close from #313.
- The Cloudflare purge will cleanly **skip** (logged) until the real token secret name is provisioned — exactly as intended.
- Once this deploys green, the spurious `deploy-failure` incident opened by the failed run **auto-closes** (validating the new lifecycle end-to-end).

Refs #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014W4FydyhP3fnKxSYJMG5eP)_