### PR TITLE
feat(content): repositioning scaffold — AdminGuideLink + ffcadmin.org link map (Phase 0)

### DIFF
--- a/__tests__/components/ui/admin-guide-link.test.tsx
+++ b/__tests__/components/ui/admin-guide-link.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { axe } from '../../utils/axe'
+
+import AdminGuideLink from '@/components/ui/AdminGuideLink'
+import { adminLinks, ffcAdminUrl, FFC_ADMIN_BASE } from '@/data/admin-links'
+
+describe('AdminGuideLink', () => {
+  it('renders the primary variant with no a11y violations', async () => {
+    const { container } = render(
+      <AdminGuideLink
+        href={ffcAdminUrl(adminLinks.techstack.newModel)}
+        description="See how we build and host your site."
+      />
+    )
+    const link = screen.getByRole('link')
+    expect(link).toHaveAttribute('href', 'https://ffcadmin.org/tech-stack/')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'))
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  }, 30000)
+
+  it('renders the legacy variant with default label', async () => {
+    render(<AdminGuideLink href={ffcAdminUrl(adminLinks.techstack.legacy!)} variant="legacy" />)
+    expect(screen.getByRole('link')).toHaveTextContent(/legacy wordpress/i)
+  }, 30000)
+})
+
+describe('admin-links data', () => {
+  it('ffcAdminUrl builds absolute ffcadmin.org URLs', () => {
+    expect(ffcAdminUrl('/tech-stack/')).toBe(`${FFC_ADMIN_BASE}/tech-stack/`)
+    expect(ffcAdminUrl('tech-stack/')).toBe(`${FFC_ADMIN_BASE}/tech-stack/`)
+  })
+
+  it('every link path is root-relative so ffcAdminUrl composes cleanly', () => {
+    for (const entry of Object.values(adminLinks)) {
+      expect(entry.newModel.startsWith('/')).toBe(true)
+      if (entry.legacy) expect(entry.legacy.startsWith('/')).toBe(true)
+    }
+  })
+})

--- a/src/components/ui/AdminGuideLink.tsx
+++ b/src/components/ui/AdminGuideLink.tsx
@@ -1,0 +1,57 @@
+import React from 'react'
+
+interface AdminGuideLinkProps {
+  /** Absolute ffcadmin.org URL — build with `ffcAdminUrl()` from src/data/admin-links. */
+  href: string
+  /** Link text. Defaults depend on variant. */
+  label?: string
+  /** Optional one-line context shown above the link. */
+  description?: string
+  /** 'primary' = current GitHub Pages + AI guide; 'legacy' = WordPress option. */
+  variant?: 'primary' | 'legacy'
+}
+
+/**
+ * Standardized call-to-action that deep-links a marketing page on
+ * freeforcharity.org to its detailed, canonical guide on the FFC Admin portal
+ * (ffcadmin.org). Used across every repositioned product/guide page so the
+ * "see the full steps on FFC Admin" affordance is consistent and the external
+ * URLs live in one place (src/data/admin-links.ts).
+ */
+const AdminGuideLink: React.FC<AdminGuideLinkProps> = ({
+  href,
+  label,
+  description,
+  variant = 'primary',
+}) => {
+  const isLegacy = variant === 'legacy'
+  const text =
+    label ??
+    (isLegacy ? 'Legacy WordPress guide on FFC Admin' : 'Full step-by-step guide on FFC Admin')
+
+  return (
+    <div
+      className={`rounded-[10px] border px-[20px] py-[16px] ${
+        isLegacy ? 'border-[#e5e5e5] bg-[#fafafa]' : 'border-[#f47c20]/40 bg-[#fff7f0]'
+      }`}
+    >
+      {description ? (
+        <p className="mb-[8px] text-[14px] leading-[22px] text-[#555]">{description}</p>
+      ) : null}
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={`inline-flex items-center gap-[8px] text-[16px] font-[600] underline-offset-4 hover:underline ${
+          isLegacy ? 'text-[#555]' : 'text-[#f47c20]'
+        }`}
+      >
+        <span>{text}</span>
+        <span aria-hidden="true">&rarr;</span>
+        <span className="sr-only">(opens FFC Admin in a new tab)</span>
+      </a>
+    </div>
+  )
+}
+
+export default AdminGuideLink

--- a/src/data/admin-links.ts
+++ b/src/data/admin-links.ts
@@ -22,7 +22,15 @@ export type AdminLink = {
   legacy?: string
 }
 
-/** Keyed by the freeforcharity.org route the link is surfaced on. */
+/**
+ * Keyed by a stable guide topic — usually the page's route slug (e.g.
+ * `techstack`, `domains`), but intentionally NOT a 1:1 mirror of `src/app/`
+ * folder names: long routes use a short, readable alias (e.g.
+ * `service-delivery-stages` for the `free-for-charity-ffc-service-delivery-stages`
+ * page), and some entries are supplementary ffcadmin.org guides referenced
+ * alongside a page rather than a page of their own (e.g. `build-from-template`,
+ * `developer-environment-setup`, `contributor-ladder`, `site-owner`).
+ */
 export const adminLinks = {
   techstack: {
     newModel: '/tech-stack/',

--- a/src/data/admin-links.ts
+++ b/src/data/admin-links.ts
@@ -1,0 +1,108 @@
+// Canonical deep-links from the freeforcharity.org marketing frontend to the
+// detailed, authoritative guides on the FFC Admin portal (ffcadmin.org).
+//
+// freeforcharity.org is the public marketing site; ffcadmin.org holds the
+// step-by-step workflows and is the single source of truth. Every product /
+// guide page on this site should point at the matching ffcadmin.org page
+// instead of duplicating the steps (which is how the old copy went stale).
+//
+// `newModel` = the current GitHub Pages + AI-driven-development guide.
+// `legacy`   = the WordPress/cPanel equivalent under ffcadmin.org's
+//              /legacy-wordpress-administration/ section (kept for existing
+//              charities still on the legacy stack).
+//
+// Slugs verified against https://ffcadmin.org/sitemap.xml.
+
+export const FFC_ADMIN_BASE = 'https://ffcadmin.org'
+
+export type AdminLink = {
+  /** Path to the up-to-date (GitHub Pages + AI) guide on ffcadmin.org. */
+  newModel: string
+  /** Optional path to the legacy WordPress equivalent on ffcadmin.org. */
+  legacy?: string
+}
+
+/** Keyed by the freeforcharity.org route the link is surfaced on. */
+export const adminLinks = {
+  techstack: {
+    newModel: '/tech-stack/',
+    legacy: '/legacy-wordpress-administration/wordpress-hosting-techstack/',
+  },
+  'free-charity-web-hosting': {
+    newModel: '/what-ffc-delivers/',
+    legacy: '/legacy-wordpress-administration/wordpress-web-hosting/',
+  },
+  'build-from-template': {
+    newModel: '/guides/build-charity-site-from-template/',
+  },
+  domains: {
+    newModel: '/guides/microsoft-365-email/',
+    legacy: '/legacy-wordpress-administration/wordpress-domains/',
+  },
+  'web-developer-training': {
+    newModel: '/training/web-developer/',
+    legacy: '/legacy-wordpress-administration/wordpress-web-developer-training/',
+  },
+  'developer-environment-setup': {
+    newModel: '/developer-environment-setup/claude-desktop/',
+  },
+  'service-delivery-stages': {
+    newModel: '/sites-list/',
+    legacy: '/legacy-wordpress-administration/wordpress-service-delivery-stages/',
+  },
+  'volunteer-core-competencies': {
+    newModel: '/volunteer/',
+    legacy: '/legacy-wordpress-administration/wordpress-volunteer-core-competencies/',
+  },
+  'contributor-ladder': {
+    newModel: '/contributor-ladder/',
+  },
+  'workforce-development': {
+    newModel: '/training/',
+  },
+  'tools-for-success': {
+    newModel: '/guides/',
+    legacy: '/legacy-wordpress-administration/wordpress-tools-for-success/',
+  },
+  'online-impacts-onboarding': {
+    newModel: '/site-owner/',
+    legacy: '/legacy-wordpress-administration/wordpress-online-impacts-onboarding/',
+  },
+  'guidestar-guide': {
+    newModel: '/guides/candid/',
+    legacy: '/legacy-wordpress-administration/wordpress-guidestar-guide/',
+  },
+  'charity-validation': {
+    newModel: '/charity-prerequisites/',
+    legacy: '/legacy-wordpress-administration/wordpress-charity-validation/',
+  },
+  'training-programs': {
+    newModel: '/training/',
+    legacy: '/legacy-wordpress-administration/wordpress-training-programs/',
+  },
+  onboarding: {
+    newModel: '/charity-prerequisites/',
+  },
+  'site-owner': {
+    newModel: '/site-owner/',
+  },
+  'help-for-charities': {
+    newModel: '/what-ffc-delivers/',
+  },
+  consulting: {
+    newModel: '/guides/',
+  },
+  ffcadmin: {
+    newModel: '/',
+  },
+  'cpanel-backup-sop': {
+    newModel: '/legacy-wordpress-administration/wordpress-cpanel-backup-sop/',
+  },
+} satisfies Record<string, AdminLink>
+
+export type AdminLinkKey = keyof typeof adminLinks
+
+/** Build an absolute ffcadmin.org URL from a path (e.g. '/tech-stack/'). */
+export function ffcAdminUrl(path: string): string {
+  return `${FFC_ADMIN_BASE}${path.startsWith('/') ? path : `/${path}`}`
+}


### PR DESCRIPTION
## Phase 0 — scaffold for the product-line repositioning

First, foundational PR of the initiative to reposition **freeforcharity.org as the marketing frontend** for the new product line (**GitHub Pages static sites + AI-driven development**), with **ffcadmin.org** as the canonical, detailed source. The per-page phases (A–E) build on this.

### What's here (no page/content changes yet)
- **`src/data/admin-links.ts`** — the single source-of-truth map of each freeforcharity.org route → its canonical `ffcadmin.org` guide (`newModel` + optional `legacy` WordPress equivalent under `/legacy-wordpress-administration/`), plus an `ffcAdminUrl()` helper. Slugs verified against `ffcadmin.org/sitemap.xml`.
- **`src/components/ui/AdminGuideLink.tsx`** — a standardized, accessible CTA that deep-links a marketing page to its detailed ffcadmin.org guide. `primary` (current GitHub Pages + AI guide) and `legacy` (WordPress option) variants; opens in a new tab with an `sr-only` hint.
- **Jest render + jest-axe + data tests** (`__tests__/components/ui/admin-guide-link.test.tsx`).

### Why scaffold-first
Centralizing the external links + the CTA component in one place avoids the duplication that made the old per-page copy go stale, and lets Phases A–E land in **parallel** over disjoint route directories without conflicts.

### Verification
- `npm test` (the new suite passes: render, a11y, URL composition, root-relative paths)
- `npm run build` (static export succeeds)
- `npm run lint` / prettier clean

### What's next (separate PRs, parallel)
- **Phase A:** homepage hero / Our-Programs / footer + mission (global files).
- **Phases B–E:** hosting & stack · developer/volunteer/training overviews · charity onboarding/delivery · admin pointer & directories — each scoped to disjoint route dirs, each deep-linking ffcadmin.org via this component, all routes/SEO preserved.

Refs the approved repositioning plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014W4FydyhP3fnKxSYJMG5eP)_