### PR TITLE
feat(content): lead homepage + metadata with the new product line (Phase A)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,14 +7,21 @@ import CookieConsent from '@/components/cookie-consent'
 // Get basePath for GitHub Pages deployment
 const basePath = process.env.NEXT_PUBLIC_BASE_PATH || ''
 
+// Single source of truth for the site description so the meta, OpenGraph, and
+// Twitter tags never drift. SITE_DESCRIPTION is the full SEO description;
+// SOCIAL_DESCRIPTION is the shorter line used for social previews.
+const SITE_DESCRIPTION =
+  'Free For Charity builds free websites for nonprofits—fast, secure GitHub Pages static sites built with AI development agents—plus free domains and Microsoft 365, so charities put more resources back into their missions.'
+const SOCIAL_DESCRIPTION =
+  'Free websites for nonprofits—fast, secure GitHub Pages static sites built with AI—plus free domains and Microsoft 365.'
+
 export const metadata: Metadata = {
   metadataBase: new URL('https://www.freeforcharity.org'),
   title: {
     default: 'Free For Charity | Reduce Costs, Increase Impact',
     template: '%s | Free For Charity',
   },
-  description:
-    'Free For Charity builds free websites for nonprofits—fast, secure GitHub Pages static sites built with AI development agents—plus free domains and Microsoft 365, so charities put more resources back into their missions.',
+  description: SITE_DESCRIPTION,
   keywords: [
     'nonprofit',
     'charity',
@@ -47,8 +54,7 @@ export const metadata: Metadata = {
     url: 'https://www.freeforcharity.org/',
     siteName: 'Free For Charity',
     title: 'Free For Charity | Reduce Costs, Increase Impact',
-    description:
-      'Connecting students, professionals, and businesses with nonprofits to reduce costs and increase revenues.',
+    description: SOCIAL_DESCRIPTION,
     images: [
       {
         url: `${basePath}/web-app-manifest-512x512.png`,
@@ -62,8 +68,7 @@ export const metadata: Metadata = {
     card: 'summary_large_image',
     site: '@freeforcharity',
     title: 'Free For Charity | Reduce Costs, Increase Impact',
-    description:
-      'Connecting students, professionals, and businesses with nonprofits to reduce costs and increase revenues.',
+    description: SOCIAL_DESCRIPTION,
     images: [`${basePath}/web-app-manifest-512x512.png`],
   },
   icons: {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,12 +14,16 @@ export const metadata: Metadata = {
     template: '%s | Free For Charity',
   },
   description:
-    'Free For Charity connects students, professionals, and businesses with nonprofits to reduce costs and increase revenues—putting more resources back into their missions.',
+    'Free For Charity builds free websites for nonprofits—fast, secure GitHub Pages static sites built with AI development agents—plus free domains and Microsoft 365, so charities put more resources back into their missions.',
   keywords: [
     'nonprofit',
     'charity',
     'volunteer',
     'donate',
+    'free nonprofit website',
+    'GitHub Pages hosting',
+    'static site',
+    'AI website development',
     'free hosting',
     'domains',
     'Microsoft 365',

--- a/src/components/home-page/Our-Programs/index.tsx
+++ b/src/components/home-page/Our-Programs/index.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import Image from 'next/image'
 import OrangeFaqItem from '@/components/ui/OrangeFaqItem'
+import AdminGuideLink from '@/components/ui/AdminGuideLink'
+import { adminLinks, ffcAdminUrl } from '@/data/admin-links'
 import { assetPath } from '@/lib/assetPath'
 
 const index = () => {
@@ -82,8 +84,8 @@ const index = () => {
             </h3>
           </div>
           <p className="text-[25px] font-[400]  " data-font="lato-font">
-            Free static site hosting for nonprofit organizations using Microsoft GitHub Pages, with
-            websites built using GitHub Copilot AI:
+            Free static-site hosting for nonprofits on GitHub Pages, with modern websites built by
+            AI development agents (Claude and GitHub Copilot):
           </p>
         </div>
 
@@ -134,6 +136,13 @@ const index = () => {
               </li>
             </ul>
           </OrangeFaqItem>
+        </div>
+
+        <div className="lg:pl-[50px] mt-[24px] max-w-[680px]">
+          <AdminGuideLink
+            href={ffcAdminUrl(adminLinks['build-from-template'].newModel)}
+            description="Ready to build? Charities and volunteers follow the full step-by-step site build on the FFC Admin portal."
+          />
         </div>
 
         <div className="mt-[60px]">

--- a/src/components/ui/AdminGuideLink.tsx
+++ b/src/components/ui/AdminGuideLink.tsx
@@ -43,7 +43,9 @@ const AdminGuideLink: React.FC<AdminGuideLinkProps> = ({
         target="_blank"
         rel="noopener noreferrer"
         className={`inline-flex items-center gap-[8px] text-[16px] font-[600] underline-offset-4 hover:underline ${
-          isLegacy ? 'text-[#555]' : 'text-[#f47c20]'
+          // #9a3412 (deep brand orange) clears WCAG AA contrast on the pale
+          // #fff7f0 callout (~7:1); the lighter #f47c20 is only 2.55:1 as text.
+          isLegacy ? 'text-[#555]' : 'text-[#9a3412]'
         }`}
       >
         <span>{text}</span>


### PR DESCRIPTION
## Phase A — homepage + metadata

Repositioning the public site as the marketing frontend for the new product line (GitHub Pages static sites + AI-driven development). This phase establishes the messaging + the deep-link pattern on the highest-visibility surface, building on the Phase 0 scaffold (#317).

### Changes
- **Homepage "Our Programs" (FFC Hosting pillar)** — modernized the intro to *"Free static-site hosting for nonprofits on GitHub Pages, with modern websites built by AI development agents (Claude and GitHub Copilot)"* (was "GitHub Copilot AI" only), and added an **`AdminGuideLink`** deep-linking the canonical **build-charity-site-from-template** guide on `ffcadmin.org` — the first use of the marketing-frontend → canonical-detail pattern.
- **Root metadata (`layout.tsx`)** — the site description now leads with the new product line (free GitHub Pages static sites built with AI, + domains + M365), and the keyword set gains `GitHub Pages hosting`, `static site`, `AI website development`, `free nonprofit website` **while keeping the legacy keywords** (`free hosting`, `domains`, `Microsoft 365`) for SEO continuity.

### Safety / SEO
- No routes or URLs changed; no deletes/redirects.
- The hosting pillar already led with the new model — this sharpens it and adds the canonical deep-link.

### Verification
- `npm run build` (static export) ✅
- `npm test` — home component tests 12/12 ✅ (no test asserted the old copy)
- `npm run lint` / prettier clean ✅

### Next (parallel, disjoint route dirs)
Phases B–E: hosting & stack · developer/volunteer/training overviews · charity onboarding/delivery · admin pointer & directories — each deep-linking ffcadmin.org via `AdminGuideLink`, all routes/SEO preserved.

Refs the approved repositioning plan · builds on #317.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014W4FydyhP3fnKxSYJMG5eP)_