### PR TITLE
feat: reposition application funnel to GitHub Pages + AI product line (Phase D)

### DIFF
--- a/src/app/501c3/page.tsx
+++ b/src/app/501c3/page.tsx
@@ -1,11 +1,13 @@
 import type { Metadata } from 'next'
 import HeroSection from '@/components/ui/HeroSection'
 import HelpForCharitiesandNonprofit from '@/components/501c3-components/Help-For-Charities-and-Nonprofit'
+import AdminGuideLink from '@/components/ui/AdminGuideLink'
+import { adminLinks, ffcAdminUrl } from '@/data/admin-links'
 
 export const metadata: Metadata = {
   title: '501(c)(3) Onboarding Guide',
   description:
-    'Onboarding guide for verified 501(c)(3) charities. Get instant access to free domains, hosting, email, and technology tools from Free For Charity.',
+    'Apply to get a free website for your 501(c)(3)—a fast, secure GitHub Pages site built with AI—plus free domains, Microsoft 365 email, and technology tools from Free For Charity.',
   alternates: { canonical: '/501c3/' },
 }
 import ReadyToGetStartedAndFaq from '@/components/501c3-components/Ready-to-get-started-and-faqs'
@@ -16,9 +18,15 @@ const page = () => {
     <div>
       <HeroSection
         heading="501(c)3 Onboarding Guide"
-        paragraph="If you are representing a charity or you currently work for a charity and want to improve your own skills start here to get help for your organization. You get instant access to many of our free tools and products right away!"
+        paragraph="Apply to get a free, professionally built website for your charity—a fast, secure GitHub Pages site built with AI—plus free .org domains, Microsoft 365 email, and technology tools. Start your application below; you get instant access to many of our free products right away."
         heroImg="/Images/volunteer.webp"
       />
+      <div className="w-[90%] max-w-[720px] mx-auto mt-[32px]">
+        <AdminGuideLink
+          href={ffcAdminUrl(adminLinks.onboarding.newModel)}
+          description="Before you apply: review the charity prerequisites and the full step-by-step onboarding on the FFC Admin portal."
+        />
+      </div>
       <HelpForCharitiesandNonprofit />
       <ReadyToGetStartedAndFaq />
       <CallSection />

--- a/src/app/free-for-charity-ffc-service-delivery-stages/page.tsx
+++ b/src/app/free-for-charity-ffc-service-delivery-stages/page.tsx
@@ -5,7 +5,7 @@ import Hero from '@/components/free-for-charity-ffc-service-delivery-stages-comp
 export const metadata: Metadata = {
   title: 'Service Delivery Stages',
   description:
-    'Free For Charity service delivery process: charity validation stages, onboarding philosophy, and how we deliver free technology services to nonprofits.',
+    'How Free For Charity delivers a free nonprofit website—a fast, secure GitHub Pages static site built with AI—through our charity validation, onboarding, and launch stages, with the legacy WordPress build retained as an option.',
   alternates: { canonical: '/free-for-charity-ffc-service-delivery-stages/' },
 }
 

--- a/src/app/pre501c3/page.tsx
+++ b/src/app/pre501c3/page.tsx
@@ -4,11 +4,13 @@ import HeroSection from '@/components/ui/HeroSection'
 import ReadyToGetStarted from '@/components/help-for-charities-components/Ready-to-Get-Started-Now'
 import CharityNonprofitDirectorFaq from '@/components/help-for-charities-components/Charity-Nonprofit-Director-Faq'
 import CallSection from '@/components/help-for-charities-components/call-section'
+import AdminGuideLink from '@/components/ui/AdminGuideLink'
+import { adminLinks, ffcAdminUrl } from '@/data/admin-links'
 
 export const metadata: Metadata = {
   title: 'Pre-501(c)(3) Onboarding Guide',
   description:
-    'Onboarding guide for charities pending 501(c)(3) status. Access free tools and services from Free For Charity while your application is in progress.',
+    'For charities pending 501(c)(3) status: apply to get a free website—a fast, secure GitHub Pages site built with AI—plus free tools and services from Free For Charity while your application is in progress.',
   alternates: { canonical: '/pre501c3/' },
 }
 import Faqs from '@/components/pre501c3-components/Faqs'
@@ -19,9 +21,15 @@ const index = () => {
     <div className="w-full">
       <HeroSection
         heading="Pre-501(c)3 Onboarding Guide"
-        paragraph="If you are representing a charity or you currently work for a charity and want to improve your own skills start here to get help for your organization. You get instant access to many of our free tools and products right away!"
+        paragraph="Even while your 501(c)(3) is pending, apply to start getting help for your organization—including a free, professionally built website (a fast, secure GitHub Pages site built with AI), free domains, and Microsoft 365. You get instant access to many of our free products right away."
         heroImg="/Images/volunteer.webp"
       />
+      <div className="w-[90%] max-w-[720px] mx-auto mt-[32px]">
+        <AdminGuideLink
+          href={ffcAdminUrl(adminLinks.onboarding.newModel)}
+          description="Before you apply: review the charity prerequisites and the full step-by-step onboarding on the FFC Admin portal."
+        />
+      </div>
       <Charity />
       <Faqs />
       <ReadyToGetStarted />

--- a/src/components/free-for-charity-ffc-service-delivery-stages-components/Hero/index.tsx
+++ b/src/components/free-for-charity-ffc-service-delivery-stages-components/Hero/index.tsx
@@ -51,7 +51,7 @@ const index = () => {
           <div className="mt-[16px]">
             <AdminGuideLink
               variant="legacy"
-              href={ffcAdminUrl(adminLinks['service-delivery-stages'].legacy ?? '/')}
+              href={ffcAdminUrl(adminLinks['service-delivery-stages'].legacy)}
               description="The WordPress/Divi build steps below are retained as a labeled legacy option for charities still on the legacy stack."
             />
           </div>

--- a/src/components/free-for-charity-ffc-service-delivery-stages-components/Hero/index.tsx
+++ b/src/components/free-for-charity-ffc-service-delivery-stages-components/Hero/index.tsx
@@ -1,4 +1,6 @@
 import React from 'react'
+import AdminGuideLink from '@/components/ui/AdminGuideLink'
+import { adminLinks, ffcAdminUrl } from '@/data/admin-links'
 
 const index = () => {
   return (
@@ -15,6 +17,44 @@ const index = () => {
           <h2 className="text-[24px] font-[600] leading-[24px] pb-[10px]">
             Service Delivery Stages
           </h2>
+        </div>
+
+        {/* new-model reframe + apply CTA  */}
+        <div className="bg-white p-6 rounded-lg shadow-md my-8 max-w-[960px] mx-auto">
+          <p className="text-[#374151] text-[16px] leading-[26px] font-[500]">
+            Today FFC delivers each charity a{' '}
+            <strong>
+              free, professionally built website—a fast, secure GitHub Pages static site
+            </strong>{' '}
+            built with AI development agents (Claude and GitHub Copilot), plus free .org domains and
+            Microsoft 365. The stages below outline how we validate, onboard, and launch your
+            organization. The detailed, step-by-step build now lives on the FFC Admin portal.
+          </p>
+          <div className="flex flex-col sm:flex-row gap-[16px] mt-[20px] mb-[24px]">
+            <a
+              href="/501c3/"
+              className="rounded-[10px] bg-[#2A6682] text-white text-center font-[600] text-[16px] px-[24px] py-[14px]"
+            >
+              501(c)(3) charities: apply now
+            </a>
+            <a
+              href="/pre501c3/"
+              className="rounded-[10px] border-[2px] border-[#2A6682] text-[#2A6682] text-center font-[600] text-[16px] px-[24px] py-[14px]"
+            >
+              Pre-501(c)(3): start here
+            </a>
+          </div>
+          <AdminGuideLink
+            href={ffcAdminUrl(adminLinks['service-delivery-stages'].newModel)}
+            description="See how we build and hand off each charity site on the FFC Admin portal."
+          />
+          <div className="mt-[16px]">
+            <AdminGuideLink
+              variant="legacy"
+              href={ffcAdminUrl(adminLinks['service-delivery-stages'].legacy ?? '/')}
+              description="The WordPress/Divi build steps below are retained as a labeled legacy option for charities still on the legacy stack."
+            />
+          </div>
         </div>
 
         {/* main full content  */}
@@ -37,6 +77,11 @@ const index = () => {
             <h2 className="mb-[18px] pb-[8px] border-b border-[#e5e7eb] text-[24px] leading-[40px] font-[700] text-[#111827]">
               Supported Organization Establishment: Order of Operations
             </h2>
+            <p className="mb-[18px] text-[#6b7280] text-[13px] leading-[22px] font-[500] italic">
+              Legacy WordPress build reference. New charity sites are delivered as GitHub Pages
+              static sites built with AI agents; these steps are kept for organizations still on the
+              legacy WordPress stack.
+            </p>
             <div>
               <div className="flex-start flex flex-col gap-5 sm:flex-row sm:gap-[0px]">
                 <div className="bg-[#1f2937] text-white rounded-full w-10 h-10 flex items-center justify-center font-bold text-xl flex-shrink-0 mr-4">


### PR DESCRIPTION
## Summary

Phase D of repositioning **freeforcharity.org** as the marketing frontend for the new product line (free GitHub Pages static sites built with AI development agents), with **ffcadmin.org** as the canonical step-by-step source. This phase is scoped to the **primary CTA — the charity application funnel — and donations**, per the project goal.

### What changed
- **`/501c3`** and **`/pre501c3`** — hero copy and metadata now lead with the *free, professionally built GitHub Pages static site built with AI*, alongside free `.org` domains and Microsoft 365. Each adds an `AdminGuideLink` callout deep-linking the FFC Admin onboarding / charity-prerequisites guide. **Apply CTAs preserved.**
- **`/free-for-charity-ffc-service-delivery-stages`** — adds a new-model reframe banner with prominent **"apply now"** CTAs (→ `/501c3`, `/pre501c3`), an `AdminGuideLink` to the canonical ffcadmin.org delivery guide, and a clearly-labeled **legacy WordPress** `AdminGuideLink`. The detailed *Order of Operations* steps are now explicitly marked as the legacy WordPress build reference. Metadata updated to the new model while retaining legacy keywords.

### SEO
All routes, slugs, titles, and descriptions retained — no deletes, no redirects. Copy repositioned and keyword coverage kept for both new ("GitHub Pages", "static site", "AI") and legacy ("WordPress") terms.

### Accessibility
The new `AdminGuideLink` instances use the WCAG-AA-compliant `#9a3412` link color on the pale callout (~7:1). Verified against the Playwright axe spec (which computes rendered contrast).

## Test plan
- [x] `npm run lint` — clean (prettier formatted)
- [x] `npm run build` — static export succeeds, all routes prerendered
- [x] `npm test` — 362 Jest tests pass
- [x] `npx playwright test tests/accessibility.spec.ts` — 33/33 pass, including `/501c3`, `/pre501c3`, and `/free-for-charity-ffc-service-delivery-stages`

Refs #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014W4FydyhP3fnKxSYJMG5eP)_