### PR TITLE
feat: reposition hosting & tech stack to GitHub Pages + AI product line (Phase B)

### DIFF
--- a/src/app/free-charity-web-hosting/page.tsx
+++ b/src/app/free-charity-web-hosting/page.tsx
@@ -5,7 +5,7 @@ import Hero from '@/components/free-charity-web-hosting/Hero'
 export const metadata: Metadata = {
   title: 'Free Nonprofit Web Hosting',
   description:
-    'Free WordPress hosting, domain registration, and email setup for nonprofit organizations. Powered by Free For Charity volunteers.',
+    'Free website hosting for nonprofits—fast, secure GitHub Pages static sites built with AI development agents—plus free domain registration and Microsoft 365 email, with legacy WordPress hosting still available. Powered by Free For Charity volunteers.',
   alternates: { canonical: '/free-charity-web-hosting/' },
 }
 import Hosting from '@/components/free-charity-web-hosting/hosting'

--- a/src/app/techstack/page.tsx
+++ b/src/app/techstack/page.tsx
@@ -5,7 +5,7 @@ import Hero from '@/components/techstack-components/Hero'
 export const metadata: Metadata = {
   title: 'Tech Stack',
   description:
-    'Understanding the Free For Charity WordPress hosting architecture, including Cloudflare, DirectAdmin, and Microsoft 365 integration layers.',
+    'The Free For Charity tech stack: free GitHub Pages static-site hosting, Next.js, AI-built sites (Claude and GitHub Copilot), GitHub Actions CI/CD, Cloudflare, and Microsoft 365—with the legacy WordPress architecture retained for existing sites.',
   alternates: { canonical: '/techstack/' },
 }
 

--- a/src/components/domains/Setup-Email-Hosting/index.tsx
+++ b/src/components/domains/Setup-Email-Hosting/index.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import Image from 'next/image'
 import { assetPath } from '@/lib/assetPath'
+import AdminGuideLink from '@/components/ui/AdminGuideLink'
+import { adminLinks, ffcAdminUrl } from '@/data/admin-links'
 
 const index = () => {
   return (
@@ -127,6 +129,13 @@ const index = () => {
             Click here
           </a>
         </div>
+      </div>
+
+      <div className="w-[90%] md:w-[80%] max-w-[680px] mx-auto mt-[40px]">
+        <AdminGuideLink
+          href={ffcAdminUrl(adminLinks.domains.newModel)}
+          description="Follow the full Microsoft 365 email setup guide on the FFC Admin portal."
+        />
       </div>
     </div>
   )

--- a/src/components/free-charity-web-hosting/About-FFC-Hosting/index.tsx
+++ b/src/components/free-charity-web-hosting/About-FFC-Hosting/index.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import Image from 'next/image'
 import { assetPath } from '@/lib/assetPath'
+import AdminGuideLink from '@/components/ui/AdminGuideLink'
+import { adminLinks, ffcAdminUrl } from '@/data/admin-links'
 
 const index = () => {
   return (
@@ -31,6 +33,21 @@ const index = () => {
             501(c)3 designation; Free For Charity was founded to help charities avoid these costly
             problems and focus on doing the great work they need to do.
           </p>
+          <p
+            className="mt-[16px] text-[18px] font-[500] leading-[29px] text-center"
+            data-font="raleway-font"
+          >
+            Today we deliver each charity a free, professionally built website—a fast, secure GitHub
+            Pages static site built with AI development agents (Claude and GitHub Copilot)—plus free
+            .org domains and Microsoft 365. WordPress hosting remains available as a labeled legacy
+            option for existing sites.
+          </p>
+          <div className="mt-[20px] max-w-[560px] mx-auto">
+            <AdminGuideLink
+              href={ffcAdminUrl(adminLinks['free-charity-web-hosting'].newModel)}
+              description="See what FFC delivers and how each charity site is built on the FFC Admin portal."
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/techstack-components/Hero/index.tsx
+++ b/src/components/techstack-components/Hero/index.tsx
@@ -1,19 +1,75 @@
 'use client'
 import React from 'react'
+import AdminGuideLink from '@/components/ui/AdminGuideLink'
+import { adminLinks, ffcAdminUrl } from '@/data/admin-links'
 
 const UnderstandingHosting: React.FC = () => {
   return (
     <div className="min-h-screen w-full pt-[160px] pb-[70px]">
       <div className="w-full max-w-[90%] md:max-w-[80%] mx-auto" data-font="aria-font">
         <h1 className="font-[400] text-[30px] text-[#333] leading-[30px] pb-[10px]">
-          Understanding Your Free For Charity WordPress Website Hosting: A Layered Approach
+          Your Free For Charity Tech Stack: GitHub Pages + AI-Built Static Sites
         </h1>
 
         <p className="font-[400] text-[14px] text-[#666] leading-[24px] pb-[1em]">
-          Your FreeForCharity.org website utilizes a powerful combination of services to provide a
-          secure, reliable, and feature-rich online presence. Think of it like a layered cake, with
-          each layer playing a crucial role:
+          Today FreeForCharity.org delivers each charity a fast, secure static website built with a
+          modern, low-maintenance stack. Think of it like a layered cake, with each layer playing a
+          crucial role:
         </p>
+
+        {/* New-model layers */}
+        <ul className="list-disc list-inside pb-[1em] space-y-[6px]">
+          <li className="font-[400] text-[14px] text-[#666] leading-[24px]">
+            <span className="font-[700]">Hosting: GitHub Pages</span> — free, reliable static
+            hosting with automatic HTTPS and custom-domain support; no server to maintain.
+          </li>
+          <li className="font-[400] text-[14px] text-[#666] leading-[24px]">
+            <span className="font-[700]">
+              Framework: Next.js (static export) + React + Tailwind CSS
+            </span>{' '}
+            — modern, responsive, fast-loading sites built from version-controlled source.
+          </li>
+          <li className="font-[400] text-[14px] text-[#666] leading-[24px]">
+            <span className="font-[700]">
+              Build: AI development agents (Claude and GitHub Copilot)
+            </span>{' '}
+            — professional sites delivered faster, with consistent quality across every charity.
+          </li>
+          <li className="font-[400] text-[14px] text-[#666] leading-[24px]">
+            <span className="font-[700]">CI/CD: GitHub Actions</span> — automated tests,
+            accessibility checks, and security scanning gate every change before it deploys.
+          </li>
+          <li className="font-[400] text-[14px] text-[#666] leading-[24px]">
+            <span className="font-[700]">DNS &amp; SSL: Cloudflare</span> — fast, secure delivery
+            and DNS management connecting your domain to your site.
+          </li>
+          <li className="font-[400] text-[14px] text-[#666] leading-[24px]">
+            <span className="font-[700]">Email: Microsoft 365</span> — professional email and
+            collaboration tools for your organization.
+          </li>
+        </ul>
+
+        <div className="max-w-[680px] pb-[1.5em]">
+          <AdminGuideLink
+            href={ffcAdminUrl(adminLinks.techstack.newModel)}
+            description="See the full, current tech stack and how each charity site is built on the FFC Admin portal."
+          />
+        </div>
+
+        <h2 className="font-[400] text-[24px] text-[#333] leading-[30px] pt-[1em] pb-[6px] border-t border-[#e5e5e5] mt-[1em]">
+          Legacy WordPress Architecture
+        </h2>
+        <p className="font-[400] text-[14px] text-[#666] leading-[24px] pb-[1em] italic">
+          The layered WordPress hosting below is retained for charities still on the legacy stack.
+          New sites use the GitHub Pages + AI stack above.
+        </p>
+        <div className="max-w-[680px] pb-[1.5em]">
+          <AdminGuideLink
+            variant="legacy"
+            href={ffcAdminUrl(adminLinks.techstack.legacy ?? '/')}
+            description="Legacy WordPress hosting tech stack reference on the FFC Admin portal."
+          />
+        </div>
 
         {/* 1️⃣ Foundation */}
         <ol className="list-decimal list-inside pb-[1em]">

--- a/src/components/techstack-components/Hero/index.tsx
+++ b/src/components/techstack-components/Hero/index.tsx
@@ -66,7 +66,7 @@ const UnderstandingHosting: React.FC = () => {
         <div className="max-w-[680px] pb-[1.5em]">
           <AdminGuideLink
             variant="legacy"
-            href={ffcAdminUrl(adminLinks.techstack.legacy ?? '/')}
+            href={ffcAdminUrl(adminLinks.techstack.legacy)}
             description="Legacy WordPress hosting tech stack reference on the FFC Admin portal."
           />
         </div>


### PR DESCRIPTION
## Summary

Phase B of repositioning **freeforcharity.org** as the marketing frontend for the new product line (free GitHub Pages static sites built with AI development agents), with **ffcadmin.org** as the canonical step-by-step source. This phase covers the **hosting & tech-stack** pages — the product story that justifies the application (primary CTA). Disjoint route dirs from Phase D (#320).

### What changed
- **`/techstack`** — now leads with the current stack (GitHub Pages hosting, Next.js static export, AI development agents (Claude + GitHub Copilot), GitHub Actions CI/CD, Cloudflare, Microsoft 365) and a primary `AdminGuideLink` to the canonical tech-stack guide. The existing Interserver / Softaculous / WPMUDEV / Divi layers are retained under a clearly-labeled **"Legacy WordPress Architecture"** heading with a legacy `AdminGuideLink`. Metadata updated to the new stack.
- **`/free-charity-web-hosting`** — fixes the **"Free WordPress hosting"** metadata mislabel to the new model; adds a new-model paragraph + `AdminGuideLink` to the *About FFC Hosting* section.
- **`/domains`** — adds an `AdminGuideLink` to the Microsoft 365 email setup guide.

### SEO
All routes, slugs, and canonicals retained — no deletes, no redirects. Keyword coverage kept for both new ("GitHub Pages", "static site", "AI") and legacy ("WordPress") terms.

### Accessibility
New `AdminGuideLink` instances use the WCAG-AA-compliant `#9a3412` link color. Verified against the Playwright axe spec (computes rendered contrast).

## Test plan
- [x] `npm run lint` — clean (prettier formatted)
- [x] `npm run build` — static export succeeds, all routes prerendered
- [x] `npm test` — 362 Jest tests pass
- [x] `npx playwright test tests/accessibility.spec.ts` — `/techstack`, `/free-charity-web-hosting`, `/domains` all pass

Refs #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014W4FydyhP3fnKxSYJMG5eP)_