### PR TITLE
feat: reposition training & volunteer pages to AI-driven dev model (Phase C)

### DIFF
--- a/src/app/ffc-volunteer-proving-ground-core-competencies/page.tsx
+++ b/src/app/ffc-volunteer-proving-ground-core-competencies/page.tsx
@@ -1,11 +1,13 @@
 import type { Metadata } from 'next'
 import React from 'react'
 import Header from '@/components/ffc-volunteer-proving-ground-core-competencies/Header'
+import AdminGuideLink from '@/components/ui/AdminGuideLink'
+import { adminLinks, ffcAdminUrl } from '@/data/admin-links'
 
 export const metadata: Metadata = {
   title: 'Volunteer Proving Ground: Core Competencies',
   description:
-    'Mandatory first step for FFC volunteers. Learn foundational tools for security and effective collaboration in nonprofit technology services.',
+    'Mandatory first step for FFC volunteers. Learn foundational tools for security and effective collaboration in nonprofit technology services—and the path into our AI-driven static-site development workflow.',
   alternates: { canonical: '/ffc-volunteer-proving-ground-core-competencies/' },
 }
 import ContentSection from '@/components/ffc-volunteer-proving-ground-core-competencies/ContentSection'
@@ -18,6 +20,12 @@ const index = () => {
       <div className="w-full max-w-[90%] md:max-w-[80%] md:p-[2rem] mx-auto">
         <Header />
         <ContentSection />
+        <div className="max-w-[760px] mx-auto my-[32px]">
+          <AdminGuideLink
+            href={ffcAdminUrl(adminLinks['volunteer-core-competencies'].newModel)}
+            description="See the full volunteer onboarding and the contributor ladder on the FFC Admin portal."
+          />
+        </div>
         <Modulessection />
         <Footer />
       </div>

--- a/src/app/free-for-charity-ffc-web-developer-training-guide/page.tsx
+++ b/src/app/free-for-charity-ffc-web-developer-training-guide/page.tsx
@@ -1,11 +1,13 @@
 import type { Metadata } from 'next'
 import React from 'react'
 import Hero from '@/components/free-for-charity-ffc-web-developer-training-guide-components/Hero'
+import AdminGuideLink from '@/components/ui/AdminGuideLink'
+import { adminLinks, ffcAdminUrl } from '@/data/admin-links'
 
 export const metadata: Metadata = {
   title: 'Web Developer Training Guide',
   description:
-    'Comprehensive FFC training guide for setting up and managing WHMCS, Cloudflare, Microsoft 365, WordPress, and other nonprofit technology tools.',
+    'FFC web developer training for the modern stack—building GitHub Pages static sites with AI development agents (Claude and GitHub Copilot), Next.js, Cloudflare, and Microsoft 365—with the legacy WordPress workflow retained for existing sites.',
   alternates: { canonical: '/free-for-charity-ffc-web-developer-training-guide/' },
 }
 
@@ -14,6 +16,19 @@ const index = () => {
     <div>
       <div className="" data-font="segoe-font">
         <Hero />
+        <div className="w-[90%] max-w-[760px] mx-auto mt-[32px] mb-[48px]">
+          <AdminGuideLink
+            href={ffcAdminUrl(adminLinks['web-developer-training'].newModel)}
+            description="The current developer training—setting up Claude-driven development and building charity sites—lives on the FFC Admin portal."
+          />
+          <div className="mt-[16px]">
+            <AdminGuideLink
+              variant="legacy"
+              href={ffcAdminUrl(adminLinks['web-developer-training'].legacy)}
+              description="The WordPress developer workflow below is retained as a labeled legacy reference for existing sites."
+            />
+          </div>
+        </div>
       </div>
     </div>
   )

--- a/src/app/free-training-programs/page.tsx
+++ b/src/app/free-training-programs/page.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import type { Metadata } from 'next'
 import HeroSection from '@/components/ui/HeroSection'
 import FaqSection from '@/components/free-training-programs-components/faq-section'
+import AdminGuideLink from '@/components/ui/AdminGuideLink'
+import { adminLinks, ffcAdminUrl } from '@/data/admin-links'
 
 export const metadata: Metadata = {
   title: 'Free Training Programs',
@@ -55,6 +57,13 @@ const FreeTrainingProgramsPage = () => {
         paragraph="Build real-world skills in business and technology through hands-on projects that help nonprofit organizations."
         heroImg="/Images/donation.webp"
       />
+
+      <div className="w-[90%] max-w-[720px] mx-auto mt-[32px]">
+        <AdminGuideLink
+          href={ffcAdminUrl(adminLinks['training-programs'].newModel)}
+          description="See the full training plan and program tracks on the FFC Admin portal."
+        />
+      </div>
 
       {/* Win-Win-Win */}
       <section className="py-[60px] bg-[#fcfcfc]">

--- a/src/app/workforce-development/page.tsx
+++ b/src/app/workforce-development/page.tsx
@@ -1,19 +1,22 @@
 import React from 'react'
 import type { Metadata } from 'next'
 import HeroSection from '@/components/ui/HeroSection'
+import AdminGuideLink from '@/components/ui/AdminGuideLink'
+import { adminLinks, ffcAdminUrl } from '@/data/admin-links'
 
 export const metadata: Metadata = {
   title: 'Workforce Development',
   description:
-    'Free workforce development and training programs in web development and programming. Build your skills while helping charities.',
+    'Free workforce development and training in modern web development—building GitHub Pages static sites with AI development agents (Claude and GitHub Copilot)—and programming. Build your skills while helping charities.',
   alternates: {
     canonical: '/workforce-development/',
   },
 }
 
 const webDevSkills = [
+  'Building GitHub Pages static sites (Next.js, React, Tailwind CSS)',
+  'AI-assisted website development (Claude and GitHub Copilot)',
   'Website Maintenance',
-  'WordPress Theme and Plugin Setup',
   'Content Creation',
   'Form Creation',
   'CSS Customization',
@@ -37,6 +40,13 @@ const WorkforceDevelopmentPage = () => {
         paragraph="Build your career skills through hands-on experience helping nonprofits. Learn web development and programming while making a difference."
         heroImg="/Images/donation.webp"
       />
+
+      <div className="w-[90%] max-w-[720px] mx-auto mt-[32px]">
+        <AdminGuideLink
+          href={ffcAdminUrl(adminLinks['workforce-development'].newModel)}
+          description="Explore the full training tracks and the AI-driven development workflow on the FFC Admin portal."
+        />
+      </div>
 
       {/* Main Content */}
       <section className="py-[60px] bg-[#fcfcfc]">


### PR DESCRIPTION
## Summary

Phase C of repositioning **freeforcharity.org** as the marketing frontend for the new product line (free GitHub Pages static sites built with AI development agents), with **ffcadmin.org** as the canonical step-by-step source. This phase covers the **developer / volunteer / training** overview pages. Disjoint route dirs from Phase D (#320) and Phase B (#321).

### What changed
- **`/workforce-development`** — the web-dev track now leads with *building GitHub Pages static sites* and *AI-assisted development (Claude, GitHub Copilot)*; adds an `AdminGuideLink` to the FFC Admin training tracks. Metadata modernized.
- **`/free-for-charity-ffc-web-developer-training-guide`** — fixes the WHMCS/WordPress-centric metadata to the modern stack; adds a primary (Claude-driven dev) `AdminGuideLink` plus a labeled **legacy WordPress** `AdminGuideLink` after the existing guide content.
- **`/ffc-volunteer-proving-ground-core-competencies`** — adds an `AdminGuideLink` to the volunteer onboarding + contributor ladder on FFC Admin.
- **`/free-training-programs`** — adds an `AdminGuideLink` to the full training plan.

### SEO
All routes, slugs, and canonicals retained — no deletes, no redirects. Keyword coverage kept for both new ("GitHub Pages", "static site", "AI", "Claude") and legacy ("WordPress") terms.

### Accessibility
New `AdminGuideLink` instances use the WCAG-AA-compliant `#9a3412` link color. Verified against the Playwright axe spec (computes rendered contrast).

## Test plan
- [x] `npm run lint` — clean (prettier formatted)
- [x] `npm run build` — static export succeeds, all routes prerendered
- [x] `npm test` — 362 Jest tests pass
- [x] `npx playwright test tests/accessibility.spec.ts` — `/workforce-development`, `/free-for-charity-ffc-web-developer-training-guide`, `/ffc-volunteer-proving-ground-core-competencies`, `/free-training-programs` all pass

Refs #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014W4FydyhP3fnKxSYJMG5eP)_