### PR TITLE
feat: reposition admin pointer, directories & consulting to new model (Phase E)

### DIFF
--- a/src/app/charity-and-nonprofit-technology-directory/page.tsx
+++ b/src/app/charity-and-nonprofit-technology-directory/page.tsx
@@ -1,11 +1,13 @@
 import React from 'react'
 import type { Metadata } from 'next'
 import HeroSection from '@/components/ui/HeroSection'
+import AdminGuideLink from '@/components/ui/AdminGuideLink'
+import { adminLinks, ffcAdminUrl } from '@/data/admin-links'
 
 export const metadata: Metadata = {
   title: 'Charity and Nonprofit Technology Directory',
   description:
-    'Explore free and open source technology tools for nonprofit organizations. Find solutions for web hosting, office automation, CRM, and more.',
+    'Explore free and open source technology tools for nonprofit organizations. Find solutions for static-site web hosting, AI-assisted development, office automation, CRM, and more.',
   alternates: {
     canonical: '/charity-and-nonprofit-technology-directory/',
   },
@@ -15,10 +17,10 @@ const categories = [
   {
     name: 'Charity Websites',
     items: [
-      'WordPress Web Hosting',
-      'WordPress Themes',
-      'WordPress Plugins',
-      'WordPress Management',
+      'GitHub Pages Static Site Hosting',
+      'AI-Assisted Site Development (Claude, GitHub Copilot)',
+      'Next.js / React / Tailwind CSS',
+      'Legacy: WordPress Hosting, Themes & Plugins',
     ],
   },
   {
@@ -43,6 +45,13 @@ const TechDirectoryPage = () => {
         paragraph="A nonprofit technology directory focused on startup charities with a preference for open source and free solutions."
         heroImg="/Images/donation.webp"
       />
+
+      <div className="w-[90%] max-w-[720px] mx-auto mt-[32px]">
+        <AdminGuideLink
+          href={ffcAdminUrl(adminLinks.consulting.newModel)}
+          description="See the curated guides and partner tools FFC recommends on the FFC Admin portal."
+        />
+      </div>
 
       {/* Intro */}
       <section className="py-[60px] bg-[#fcfcfc]">

--- a/src/app/consulting/page.tsx
+++ b/src/app/consulting/page.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import type { Metadata } from 'next'
 import HeroSection from '@/components/ui/HeroSection'
+import AdminGuideLink from '@/components/ui/AdminGuideLink'
+import { adminLinks, ffcAdminUrl } from '@/data/admin-links'
 
 export const metadata: Metadata = {
   title: 'Consulting',
@@ -19,6 +21,13 @@ const ConsultingPage = () => {
         paragraph="Free For Charity provides free consulting services to nonprofits. Our team helps charities with technology, operations, and strategy — all at no cost."
         heroImg="/Images/donation.webp"
       />
+
+      <div className="w-[90%] max-w-[720px] mx-auto mt-[32px]">
+        <AdminGuideLink
+          href={ffcAdminUrl(adminLinks.consulting.newModel)}
+          description="Browse the partner tools and step-by-step guides FFC uses with charities on the FFC Admin portal."
+        />
+      </div>
 
       {/* Main Content */}
       <section className="py-[60px] bg-[#fcfcfc]">

--- a/src/app/ffcadmin-free-for-charity-cpanel-backup-sop/page.tsx
+++ b/src/app/ffcadmin-free-for-charity-cpanel-backup-sop/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
+import AdminGuideLink from '@/components/ui/AdminGuideLink'
+import { adminLinks, ffcAdminUrl } from '@/data/admin-links'
 
 export const metadata: Metadata = {
   title: 'cPanel Backup SOP',
@@ -43,6 +45,13 @@ export default function CpanelBackupSop() {
           </Link>
           .
         </p>
+        <div className="max-w-[560px]">
+          <AdminGuideLink
+            variant="legacy"
+            href={ffcAdminUrl(adminLinks['cpanel-backup-sop'].newModel)}
+            description="Legacy WordPress/cPanel backup SOP reference on the FFC Admin portal."
+          />
+        </div>
       </div>
     </div>
   )

--- a/src/app/ffcadmin-free-for-charity-cpanel-backup-sop/page.tsx
+++ b/src/app/ffcadmin-free-for-charity-cpanel-backup-sop/page.tsx
@@ -48,7 +48,7 @@ export default function CpanelBackupSop() {
         <div className="max-w-[560px]">
           <AdminGuideLink
             variant="legacy"
-            href={ffcAdminUrl(adminLinks['cpanel-backup-sop'].newModel)}
+            href={ffcAdminUrl(adminLinks['cpanel-backup-sop'].legacy)}
             description="Legacy WordPress/cPanel backup SOP reference on the FFC Admin portal."
           />
         </div>

--- a/src/app/ffcadmin/page.tsx
+++ b/src/app/ffcadmin/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from 'next'
 import React from 'react'
+import AdminGuideLink from '@/components/ui/AdminGuideLink'
+import { adminLinks, ffcAdminUrl } from '@/data/admin-links'
 
 export const metadata: Metadata = {
   title: 'FFC Admin',
@@ -9,8 +11,19 @@ export const metadata: Metadata = {
 
 const index = () => {
   return (
-    <div className="flex items-center justify-center min-h-screen text-[34px] w-full text-center">
-      <h1 className="text-center">ffcadmin</h1>
+    <div className="min-h-screen w-[90%] max-w-[640px] mx-auto flex flex-col items-center justify-center text-center gap-[20px]">
+      <h1 className="text-[34px] font-[600] text-[#333]">FFC Admin</h1>
+      <p className="text-[16px] leading-[26px] font-[500] text-[#555]">
+        The Free For Charity administration and training portal—covering the current GitHub Pages +
+        AI-driven development workflow, charity onboarding, and volunteer guides—lives at FFC Admin.
+      </p>
+      <div className="w-full max-w-[480px]">
+        <AdminGuideLink
+          href={ffcAdminUrl(adminLinks.ffcadmin.newModel)}
+          label="Go to the FFC Admin portal"
+          description="All step-by-step admin, developer, and onboarding guides are maintained here."
+        />
+      </div>
     </div>
   )
 }

--- a/src/app/free-for-charitys-tools-for-success/page.tsx
+++ b/src/app/free-for-charitys-tools-for-success/page.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from 'next'
 import React from 'react'
 import HeroSection from '@/components/ui/HeroSection'
 import CardSection from '@/components/free-for-charitys-tools-for-success-components/Card-section'
+import AdminGuideLink from '@/components/ui/AdminGuideLink'
+import { adminLinks, ffcAdminUrl } from '@/data/admin-links'
 
 export const metadata: Metadata = {
   title: 'Tools for Success',
@@ -29,6 +31,12 @@ const index = () => {
         lineHeight={40}
         imageContainerWidth="w-[55%]"
       />
+      <div className="w-[90%] max-w-[720px] mx-auto mt-[32px]">
+        <AdminGuideLink
+          href={ffcAdminUrl(adminLinks['tools-for-success'].newModel)}
+          description="Find the full set of FFC guides and recommended tools on the FFC Admin portal."
+        />
+      </div>
       <CardSection />
       <RescueTime />
       <TwoCards />

--- a/src/app/help-for-charities/page.tsx
+++ b/src/app/help-for-charities/page.tsx
@@ -7,6 +7,8 @@ import AccordionSection from '@/components/help-for-charities-components/Accordi
 import ReadyToGetStarted from '@/components/help-for-charities-components/Ready-to-Get-Started-Now'
 import CharityNonprofitDirectorFaq from '@/components/ui/Charity-Nonprofit-Director-Faq'
 import CallSection from '@/components/help-for-charities-components/call-section'
+import AdminGuideLink from '@/components/ui/AdminGuideLink'
+import { adminLinks, ffcAdminUrl } from '@/data/admin-links'
 
 const Page: React.FC = () => {
   return (
@@ -16,6 +18,13 @@ const Page: React.FC = () => {
         paragraph="If you are representing a charity or you currently work for a charity and want to improve your own skills start here to get help for your organization. You get instant access to many of our free tools and products right away!"
         heroImg="/Images/volunteer.webp"
       />
+
+      <div className="w-[90%] max-w-[720px] mx-auto mt-[32px]">
+        <AdminGuideLink
+          href={ffcAdminUrl(adminLinks['help-for-charities'].newModel)}
+          description="See everything FFC delivers—including your free, AI-built GitHub Pages website—on the FFC Admin portal."
+        />
+      </div>
 
       <div className="w-full h-[80px]" />
 

--- a/src/data/admin-links.ts
+++ b/src/data/admin-links.ts
@@ -104,7 +104,11 @@ export const adminLinks = {
     newModel: '/',
   },
   'cpanel-backup-sop': {
-    newModel: '/legacy-wordpress-administration/wordpress-cpanel-backup-sop/',
+    // No current-model equivalent: cPanel backups are a legacy WordPress-hosting
+    // concern, so newModel points at the FFC Admin portal home and the SOP lives
+    // under legacy (keeps the newModel = current / legacy = WordPress contract).
+    newModel: '/',
+    legacy: '/legacy-wordpress-administration/wordpress-cpanel-backup-sop/',
   },
 } satisfies Record<string, AdminLink>
 


### PR DESCRIPTION
## Summary

Phase E — the final phase — of repositioning **freeforcharity.org** as the marketing frontend for the new product line (free GitHub Pages static sites built with AI development agents), with **ffcadmin.org** as the canonical step-by-step source. This phase covers the **admin pointer, directories, consulting, and tools** pages. Disjoint route dirs from Phases D (#320), B (#321), and C (#322).

### What changed
- **`/ffcadmin`** — replaces the bare placeholder with a real pointer card linking the FFC Admin portal (the current GitHub Pages + AI-driven workflow). Stays `noindex`.
- **`/ffcadmin-free-for-charity-cpanel-backup-sop`** — adds a labeled **legacy** `AdminGuideLink` to the canonical WordPress/cPanel backup SOP on FFC Admin. Stays `noindex`.
- **`/charity-and-nonprofit-technology-directory`** — the *Charity Websites* category now leads with GitHub Pages static hosting + AI-assisted development (Claude, GitHub Copilot), with the WordPress items labeled legacy; adds an `AdminGuideLink`. Metadata modernized.
- **`/help-for-charities`**, **`/consulting`**, **`/free-for-charitys-tools-for-success`** — add `AdminGuideLink` deep-links to the matching FFC Admin guides.

### SEO
All routes, slugs, and canonicals retained — no deletes, no redirects. Keyword coverage kept for both new ("GitHub Pages", "static site", "AI") and legacy ("WordPress") terms. The two admin pages remain intentionally `noindex`.

### Accessibility
New `AdminGuideLink` instances use the WCAG-AA-compliant `#9a3412` link color. Verified against the Playwright axe spec.

## Test plan
- [x] `npm run lint` — clean (prettier formatted)
- [x] `npm run build` — static export succeeds, all routes prerendered (incl. the two noindex admin pages)
- [x] `npm test` — 362 Jest tests pass
- [x] `npx playwright test tests/accessibility.spec.ts` — `/charity-and-nonprofit-technology-directory`, `/help-for-charities`, `/consulting`, `/free-for-charitys-tools-for-success` all pass

Refs #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014W4FydyhP3fnKxSYJMG5eP)_