### PR TITLE
test: read-only WHMCS /hub form-processing verification (order funnel + login/ticket forms)

### DIFF
--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -38,7 +38,10 @@ function record(name, ok, detail) {
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
 
-async function request(path, { followRedirects = true, readBody = false, retries = 2 } = {}) {
+async function request(
+  path,
+  { followRedirects = true, readBody = false, retries = 2, cookie } = {}
+) {
   const url = path.startsWith('http') ? path : `${BASE_URL}${path}`
   // Retry transient failures — a network blip (DNS/TLS/timeout) or an
   // upstream 5xx (Cloudflare/origin) on any one of ~90 checks would otherwise
@@ -60,6 +63,9 @@ async function request(path, { followRedirects = true, readBody = false, retries
           // pre-deploy HTML and report green on a regression.
           'Cache-Control': 'no-cache',
           Pragma: 'no-cache',
+          // Thread a session cookie when the caller maintains one (the WHMCS
+          // /hub order funnel needs the cart session to persist across hops).
+          ...(cookie ? { Cookie: cookie } : {}),
         },
       })
       let body
@@ -126,6 +132,171 @@ async function checkBodyContains(name, path, expectedSubstrings) {
     ? `${path} → ${r.status} (${r.error})`
     : `${path} → ${r.status}${matched ? ` (body matches "${matched}")` : ' (no marker found)'}`
   record(name, ok, detail)
+}
+
+// ---------------------------------------------------------------------------
+// WHMCS /hub helpers (read-only billing-funnel verification)
+//
+// /hub sits behind Cloudflare bot-protection that intermittently challenges CI
+// runner IPs (the cause of the 06:05 deploy 415). A challenge must NOT red the
+// run — it's an infra artifact of the runner, not a broken site — so the hub
+// checks below treat a bot-challenge as a non-failing skip (the deploy guard
+// uses the same asymmetric logic). A real 2xx-but-broken response still fails.
+// Nothing here POSTs: the funnel stops at the rendered checkout/login form, and
+// cart.php?a=add via GET only creates an ephemeral anonymous session cart (no
+// order, no account, no payment).
+const CF_CHALLENGE_MARKERS = [
+  'just a moment',
+  'attention required',
+  'cf-chl',
+  'cf-mitigated',
+  'cdn-cgi/challenge',
+  'enable javascript and cookies',
+]
+
+function isBotChallenge(status, body) {
+  if ([403, 415, 429, 503].includes(status)) return true
+  if (body) {
+    const b = body.toLowerCase()
+    return CF_CHALLENGE_MARKERS.some((m) => b.includes(m))
+  }
+  return false
+}
+
+// Accumulate Set-Cookie name=value pairs into a jar (fetch has no cookie store).
+function mergeSetCookie(jar, res) {
+  const raw =
+    res.headers && typeof res.headers.getSetCookie === 'function' ? res.headers.getSetCookie() : []
+  for (const line of raw) {
+    const first = line.split(';')[0]
+    const eq = first.indexOf('=')
+    if (eq > 0) jar[first.slice(0, eq).trim()] = first.slice(eq + 1).trim()
+  }
+  return jar
+}
+
+function jarToHeader(jar) {
+  return Object.entries(jar)
+    .map(([k, v]) => `${k}=${v}`)
+    .join('; ')
+}
+
+// Bot-tolerant body-marker check for /hub endpoints. PASS on 2xx + a marker;
+// SKIP (non-failing) on a Cloudflare challenge; FAIL on a real broken response.
+async function checkHubBody(name, path, markers) {
+  const r = await request(path, { readBody: true })
+  if (r.error) {
+    record(name, false, `${path} → ${r.status} (${r.error})`)
+    return
+  }
+  if (isBotChallenge(r.status, r.body)) {
+    record(name, true, `${path} → skipped (Cloudflare challenge of CI runner, HTTP ${r.status})`)
+    return
+  }
+  const matched = r.body
+    ? markers.find((s) => r.body.toLowerCase().includes(s.toLowerCase()))
+    : null
+  const ok = r.status >= 200 && r.status < 300 && Boolean(matched)
+  record(
+    name,
+    ok,
+    `${path} → ${r.status}${matched ? ` (matches "${matched}")` : ' (no marker found)'}`
+  )
+}
+
+// Read-only walk of the charity-onboarding order funnel: product → add-to-cart
+// → checkout/account form. Proves the *processing* side of the primary Apply
+// CTA renders, not just that the pages 200. Never submits.
+async function checkHubOrderFunnel() {
+  const label = (s) => `/hub order funnel — ${s}`
+  const jar = {}
+
+  // 1) Product page: establish the session and find the add-to-cart link.
+  const prod = await request('/hub/store/ffc-consulting/nonprofit-charity-onboarding', {
+    readBody: true,
+  })
+  if (isBotChallenge(prod.status, prod.body)) {
+    record(label('product page'), true, `skipped (Cloudflare challenge, HTTP ${prod.status})`)
+    return
+  }
+  mergeSetCookie(jar, prod)
+  // Prefer the product's own "Order Now" link (cart.php?a=add&pid=N) over any
+  // generic add link on the page (e.g. the storefront's domain-search box,
+  // cart.php?a=add&domain=register), so the funnel exercises the onboarding
+  // product. Fall back to any add link if the product uses a non-pid format.
+  const addMatch =
+    (prod.body && prod.body.match(/cart\.php\?a=add&pid=\d+[^"'\s)]*/i)) ||
+    (prod.body && prod.body.match(/cart\.php\?a=add[^"'\s)]*/i))
+  const prodOk =
+    prod.status >= 200 &&
+    prod.status < 300 &&
+    Boolean(prod.body && /whmcs|cart\.php|order|onboarding/i.test(prod.body))
+  record(
+    label('onboarding product renders + order CTA'),
+    Boolean(prodOk && addMatch),
+    `→ ${prod.status}${addMatch ? ` (add: ${addMatch[0].slice(0, 60)})` : ' (no add-to-cart link found)'}`
+  )
+  if (!addMatch) return
+
+  // 2) Add to cart (GET only → ephemeral anonymous session cart, no order).
+  //    Follow the redirect manually so the session cookie carries (fetch's
+  //    redirect:'follow' has no cookie jar).
+  let addPath = addMatch[0].replace(/&amp;/g, '&')
+  if (!addPath.startsWith('/')) addPath = `/hub/${addPath}`
+  const add = await request(addPath, {
+    readBody: true,
+    followRedirects: false,
+    cookie: jarToHeader(jar),
+  })
+  if (isBotChallenge(add.status, add.body)) {
+    record(label('add to cart'), true, `skipped (Cloudflare challenge, HTTP ${add.status})`)
+    return
+  }
+  mergeSetCookie(jar, add)
+  let cart = add
+  if (add.status >= 300 && add.status < 400 && add.location) {
+    let loc = add.location
+    try {
+      const u = new URL(loc, `${BASE_URL}/hub/`)
+      loc = u.pathname + (u.search || '')
+    } catch {
+      /* use Location as-is */
+    }
+    cart = await request(loc, { readBody: true, cookie: jarToHeader(jar) })
+    if (isBotChallenge(cart.status, cart.body)) {
+      record(label('cart'), true, `skipped (Cloudflare challenge, HTTP ${cart.status})`)
+      return
+    }
+    mergeSetCookie(jar, cart)
+  }
+  const cartOk =
+    cart.status >= 200 &&
+    cart.status < 300 &&
+    Boolean(
+      cart.body && /checkout|order summary|view cart|shopping cart|cart\.php/i.test(cart.body)
+    )
+  record(label('add-to-cart reaches the cart'), cartOk, `→ ${cart.status}`)
+
+  // 3) Checkout page: the account / login form must render. GET only — we never
+  //    submit, so no order or account is created.
+  const checkout = await request('/hub/cart.php?a=checkout', {
+    readBody: true,
+    cookie: jarToHeader(jar),
+  })
+  if (isBotChallenge(checkout.status, checkout.body)) {
+    record(label('checkout'), true, `skipped (Cloudflare challenge, HTTP ${checkout.status})`)
+    return
+  }
+  const coOk =
+    checkout.status >= 200 &&
+    checkout.status < 300 &&
+    Boolean(
+      checkout.body &&
+      /type="password"|already registered|checkout|clientarea|account|order summary/i.test(
+        checkout.body
+      )
+    )
+  record(label('checkout/account form renders'), coOk, `→ ${checkout.status}`)
 }
 
 // Verify the hashed Next.js JS bundle is actually on the server. A partial
@@ -368,24 +539,35 @@ async function main() {
 
   console.log(`\n-- WHMCS billing portal (/hub — third-party PHP app via symlink)`)
   // Every /hub endpoint must serve real WHMCS, not a Next.js 404 or a
-  // placeholder — proves the public_html_next/hub symlink and the WHMCS app
-  // survived the deploy. These are live customer flows: store, cart, login,
-  // announcements, and the admin console.
+  // placeholder — proves the public_html/hub symlink and the WHMCS app survived
+  // the deploy. These are live customer flows: store, cart, login, ticket,
+  // announcements, and the admin console. All bot-challenge-tolerant (see
+  // checkHubBody) so a Cloudflare challenge of the runner skips rather than reds.
   const WHMCS_MARKERS = ['whmcs', 'WHMCompleteSolution', 'cart.php', 'clientarea']
-  await checkBodyContains(`/hub/ storefront`, '/hub/', WHMCS_MARKERS)
-  await checkBodyContains(`/hub/cart.php (order/cart)`, '/hub/cart.php', WHMCS_MARKERS)
-  await checkBodyContains(
-    `/hub/clientarea.php (client login)`,
-    '/hub/clientarea.php',
-    WHMCS_MARKERS
-  )
-  await checkBodyContains(`/hub/announcements.php`, '/hub/announcements.php', WHMCS_MARKERS)
-  await checkBodyContains(
+  await checkHubBody(`/hub/ storefront`, '/hub/', WHMCS_MARKERS)
+  await checkHubBody(`/hub/cart.php (order/cart)`, '/hub/cart.php', WHMCS_MARKERS)
+  await checkHubBody(`/hub/announcements.php`, '/hub/announcements.php', WHMCS_MARKERS)
+  await checkHubBody(
     `/hub/store product page`,
     '/hub/store/ffc-consulting/nonprofit-charity-onboarding',
     WHMCS_MARKERS
   )
-  await checkBodyContains(`/hub/globaladmin (admin login)`, '/hub/globaladmin', WHMCS_MARKERS)
+  await checkHubBody(`/hub/globaladmin (admin login)`, '/hub/globaladmin', WHMCS_MARKERS)
+  // Form-level checks: the client login and ticket forms must actually render
+  // their inputs, not just be a WHMCS-branded page.
+  await checkHubBody(`/hub/clientarea.php renders the login form`, '/hub/clientarea.php', [
+    'type="password"',
+    'name="username"',
+    'name="password"',
+  ])
+  await checkHubBody(`/hub/submitticket.php renders the ticket form`, '/hub/submitticket.php', [
+    'name="subject"',
+    'department',
+    'open ticket',
+    'submitticket',
+  ])
+  // Read-only walk of the charity-onboarding order → checkout funnel (no POST).
+  await checkHubOrderFunnel()
 
   const failed = results.filter((r) => !r.ok)
   console.log(`\n${results.length - failed.length}/${results.length} passed`)

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -148,19 +148,25 @@ async function checkBodyContains(name, path, expectedSubstrings) {
 const CF_CHALLENGE_MARKERS = [
   'just a moment',
   'attention required',
+  'checking your browser',
   'cf-chl',
-  'cf-mitigated',
   'cdn-cgi/challenge',
+  'challenge-platform',
   'enable javascript and cookies',
 ]
 
-function isBotChallenge(status, body) {
-  if ([403, 415, 429, 503].includes(status)) return true
-  if (body) {
-    const b = body.toLowerCase()
-    return CF_CHALLENGE_MARKERS.some((m) => b.includes(m))
-  }
-  return false
+// True only with POSITIVE evidence of a Cloudflare interstitial — a challenge
+// body marker or a `cf-mitigated: challenge` header. We deliberately do NOT
+// treat a bare 403/415/429/503 as a challenge: a real origin 503 or a
+// misconfigured 403 on /hub must FAIL, not be masked as a skippable challenge.
+// A genuine Cloudflare challenge always ships the interstitial body (or header),
+// so this still catches the runner-IP challenges it's meant to tolerate.
+function isBotChallenge(res) {
+  if (!res) return false
+  const cfMitigated = (res.headers && res.headers.get && res.headers.get('cf-mitigated')) || ''
+  if (/challenge/i.test(cfMitigated)) return true
+  const b = (res.body || '').toLowerCase()
+  return CF_CHALLENGE_MARKERS.some((m) => b.includes(m))
 }
 
 // Accumulate Set-Cookie name=value pairs into a jar (fetch has no cookie store).
@@ -189,7 +195,7 @@ async function checkHubBody(name, path, markers) {
     record(name, false, `${path} → ${r.status} (${r.error})`)
     return
   }
-  if (isBotChallenge(r.status, r.body)) {
+  if (isBotChallenge(r)) {
     record(name, true, `${path} → skipped (Cloudflare challenge of CI runner, HTTP ${r.status})`)
     return
   }
@@ -215,7 +221,7 @@ async function checkHubOrderFunnel() {
   const prod = await request('/hub/store/ffc-consulting/nonprofit-charity-onboarding', {
     readBody: true,
   })
-  if (isBotChallenge(prod.status, prod.body)) {
+  if (isBotChallenge(prod)) {
     record(label('product page'), true, `skipped (Cloudflare challenge, HTTP ${prod.status})`)
     return
   }
@@ -223,9 +229,10 @@ async function checkHubOrderFunnel() {
   // Prefer the product's own "Order Now" link (cart.php?a=add&pid=N) over any
   // generic add link on the page (e.g. the storefront's domain-search box,
   // cart.php?a=add&domain=register), so the funnel exercises the onboarding
-  // product. Fall back to any add link if the product uses a non-pid format.
+  // product. The `&` is usually HTML-escaped to `&amp;` in markup, so accept
+  // both. Fall back to any add link if the product uses a non-pid format.
   const addMatch =
-    (prod.body && prod.body.match(/cart\.php\?a=add&pid=\d+[^"'\s)]*/i)) ||
+    (prod.body && prod.body.match(/cart\.php\?a=add(?:&|&amp;)pid=\d+[^"'\s)]*/i)) ||
     (prod.body && prod.body.match(/cart\.php\?a=add[^"'\s)]*/i))
   const prodOk =
     prod.status >= 200 &&
@@ -248,7 +255,7 @@ async function checkHubOrderFunnel() {
     followRedirects: false,
     cookie: jarToHeader(jar),
   })
-  if (isBotChallenge(add.status, add.body)) {
+  if (isBotChallenge(add)) {
     record(label('add to cart'), true, `skipped (Cloudflare challenge, HTTP ${add.status})`)
     return
   }
@@ -263,7 +270,7 @@ async function checkHubOrderFunnel() {
       /* use Location as-is */
     }
     cart = await request(loc, { readBody: true, cookie: jarToHeader(jar) })
-    if (isBotChallenge(cart.status, cart.body)) {
+    if (isBotChallenge(cart)) {
       record(label('cart'), true, `skipped (Cloudflare challenge, HTTP ${cart.status})`)
       return
     }
@@ -283,7 +290,7 @@ async function checkHubOrderFunnel() {
     readBody: true,
     cookie: jarToHeader(jar),
   })
-  if (isBotChallenge(checkout.status, checkout.body)) {
+  if (isBotChallenge(checkout)) {
     record(label('checkout'), true, `skipped (Cloudflare challenge, HTTP ${checkout.status})`)
     return
   }


### PR DESCRIPTION
## Summary

Deepens `scripts/smoke-test.mjs` to verify the **critical WHMCS `/hub` form-processing pathways** — the charity-onboarding order/checkout (the processing side of the primary Apply CTA) and the login/ticket forms. Until now these were only GET + marker *reachability* checks; nothing verified the **forms actually render**, so a WHMCS template break, a removed product, or a broken cart could pass every check.

### Safety
- **No POST, no order, no account, no payment.** The funnel stops at the rendered checkout/login form. `cart.php?a=add` via GET only creates an **ephemeral anonymous session cart** — the same action a visitor's "Order Now" click makes. Verified against production: no order or client is created.
- **Cloudflare-tolerant.** `/hub` sits behind bot-protection that intermittently 403/415/503-challenges CI runner IPs (the cause of the 06:05 deploy 415). A challenge is now a **non-failing SKIP** (mirroring the deploy guard's asymmetric logic); a real `2xx`-but-broken response still **FAILS**. This also hardens the existing six `/hub` checks against runner challenges.

### What changed (all in `scripts/smoke-test.mjs`)
- `request()` gains an optional `cookie` to thread a session across the funnel hops.
- `isBotChallenge()` classifier → bot-tolerant `checkHubBody()` for all `/hub` marker checks.
- `checkHubOrderFunnel()`: product page → add-to-cart (cookie-threaded, manual redirect follow) → checkout, asserting each step renders. Prefers the product's `&pid=` order link, falls back to any add link.
- Strengthened `clientarea.php` to assert the **login form** (`type="password"`); added a `submitticket.php` **ticket-form** check.

## Test plan
- [x] `npm run lint` — clean
- [x] `node --check scripts/smoke-test.mjs` — syntax OK
- [x] `BASE_URL=https://freeforcharity.org node scripts/smoke-test.mjs` — **102/102 pass**, including:
  - `/hub/clientarea.php renders the login form` (matched `type="password"`)
  - `/hub/submitticket.php renders the ticket form` (matched `name="subject"`)
  - order funnel: product renders + order CTA → add-to-cart reaches the cart → checkout/account form renders
- [x] Confirmed the run creates **no order and no client** (the funnel never submits)

Independent of #328 (disjoint sections of the same file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014W4FydyhP3fnKxSYJMG5eP)_