### PR TITLE
fix: stop the post-deploy reachability probe from false-failing on Cloudflare runner bot-challenges

### DIFF
--- a/.github/workflows/deploy-cpanel.yml
+++ b/.github/workflows/deploy-cpanel.yml
@@ -525,11 +525,17 @@ jobs:
           # bot-challenges the GitHub-runner IP (seen as HTTP 415/403 on the apex
           # AND /hub, while real users get 200). With `--fail` that challenge
           # aborted the whole job and false-failed an otherwise-healthy deploy —
-          # the upload + parity check had already succeeded. Mirror the /hub
-          # guard's asymmetric logic: only a clean 2xx/3xx runs the smoke suite;
-          # a challenged runner WARNs and skips it (it can't smoke-test reliably
-          # from behind a challenge) and never fails the deploy. A real smoke
-          # regression (when the apex IS reachable) still fails the job below.
+          # the upload + parity check had already succeeded. Gate on the status
+          # after 3 retries:
+          #   * 2xx/3xx     -> apex reachable: run the full smoke suite (a real
+          #                    content/redirect/asset regression still fails it).
+          #   * 403/415/429 -> bot-challenge / WAF / rate-limit codes hitting the
+          #                    runner IP: WARN and skip the smoke suite (a
+          #                    challenged runner can't smoke-test), do NOT fail —
+          #                    the upload + parity check already verified the mirror.
+          #   * anything else (4xx/5xx/network 000) -> the apex itself looks
+          #                    unhealthy, not a known challenge code: FAIL so a
+          #                    genuinely broken deploy still opens an incident.
           code=""
           for attempt in 1 2 3; do
             code=$(curl --show-error --silent --location --max-time 20 \
@@ -543,8 +549,12 @@ jobs:
             2??|3??)
               npm run smoke-test
               ;;
+            403|415|429)
+              echo "::warning::Post-deploy reachability probe got HTTP ${code} from the runner — a Cloudflare bot-challenge / WAF block of the GitHub-runner IP (real users are typically unaffected). Skipping the smoke suite (it can't run from behind a challenge); the upload + parity check already verified the mirror. Verify manually if unsure: curl -sSIL ${URL}"
+              ;;
             *)
-              echo "::warning::Post-deploy reachability probe got HTTP ${code} from the runner — almost certainly a transient Cloudflare bot-challenge of the runner IP (real users are unaffected). The upload + parity check already verified the mirror, so NOT failing the deploy; skipping the smoke suite (it would false-fail from a challenged runner). Verify manually if concerned: curl -sSIL ${URL}"
+              echo "::error::Post-deploy reachability probe got HTTP ${code} on ${URL} after 3 attempts — not a recognized bot-challenge code, so the apex looks unhealthy. Failing the deploy."
+              exit 1
               ;;
           esac
 

--- a/.github/workflows/deploy-cpanel.yml
+++ b/.github/workflows/deploy-cpanel.yml
@@ -519,15 +519,34 @@ jobs:
         env:
           BASE_URL: ${{ inputs.public_url_base || 'https://freeforcharity.org' }}
         run: |
-          # Quick reachability first -- bust Cloudflare cache so we observe
-          # the freshly-deployed origin, not an edge-cached old response.
-          curl --fail --show-error --silent --location \
-            --max-time 20 \
-            -H "Cache-Control: no-cache" \
-            -o /dev/null \
-            -w "Home: %{http_code} on %{url_effective} in %{time_total}s\n" \
-            "${BASE_URL%/}/"
-          npm run smoke-test
+          set -uo pipefail
+          URL="${BASE_URL%/}/"
+          # Reachability probe WITHOUT `curl --fail`. Cloudflare intermittently
+          # bot-challenges the GitHub-runner IP (seen as HTTP 415/403 on the apex
+          # AND /hub, while real users get 200). With `--fail` that challenge
+          # aborted the whole job and false-failed an otherwise-healthy deploy —
+          # the upload + parity check had already succeeded. Mirror the /hub
+          # guard's asymmetric logic: only a clean 2xx/3xx runs the smoke suite;
+          # a challenged runner WARNs and skips it (it can't smoke-test reliably
+          # from behind a challenge) and never fails the deploy. A real smoke
+          # regression (when the apex IS reachable) still fails the job below.
+          code=""
+          for attempt in 1 2 3; do
+            code=$(curl --show-error --silent --location --max-time 20 \
+              -H "Cache-Control: no-cache" \
+              -o /dev/null -w "%{http_code}" "$URL" || echo "000")
+            echo "Reachability attempt ${attempt}: HTTP ${code} on ${URL}"
+            case "$code" in 2??|3??) break ;; esac
+            [ "$attempt" -lt 3 ] && sleep 10
+          done
+          case "$code" in
+            2??|3??)
+              npm run smoke-test
+              ;;
+            *)
+              echo "::warning::Post-deploy reachability probe got HTTP ${code} from the runner — almost certainly a transient Cloudflare bot-challenge of the runner IP (real users are unaffected). The upload + parity check already verified the mirror, so NOT failing the deploy; skipping the smoke suite (it would false-fail from a challenged runner). Verify manually if concerned: curl -sSIL ${URL}"
+              ;;
+          esac
 
       # Purge the Cloudflare edge cache after a verified-good deploy so visitors
       # see the new build immediately instead of waiting out the edge TTL. The


### PR DESCRIPTION
## Summary

The production deploy's inline **"Quick reachability"** step used `curl --fail` against the apex. Cloudflare intermittently **bot-challenges the GitHub-runner IP** (observed as HTTP `415`/`403` on the apex *and* `/hub`, while real users get `200`), and `--fail` made that challenge abort the whole job — **false-failing an otherwise-healthy deploy** whose upload + parity check had already succeeded.

This exact flake has opened a spurious **deploy-failure incident three times**: 2026-06-28 05:29 & 06:05, and 2026-06-30 00:41 (#330, just closed with evidence). Each time the deploy actually landed ("Parity OK: all 58 build entries present") and production was healthy.

## Fix
Mirror the asymmetric logic the adjacent **`/hub` guard** in this same workflow already uses:
- Probe **without `curl --fail`** (3 retries, 10s apart).
- Run the smoke suite **only on a clean 2xx/3xx**.
- On any other status, emit a **`::warning::`** that the runner is being bot-challenged and **skip the smoke suite without failing the deploy** (a challenged runner can't smoke-test reliably anyway).
- A **real smoke regression** — when the apex *is* reachable — still fails the job.

The parity check remains the authoritative deploy gate; real-user production health is verified out-of-band.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — workflow YAML parses
- [x] `bash -n` on the new step — shell syntax valid
- [x] Dry-run the probe against production → `HTTP 200` → "would run smoke-test" (clean path proceeds normally)
- [ ] Next real deploy: a challenged runner now warns + skips instead of opening an incident; a clean runner runs the full smoke suite as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014W4FydyhP3fnKxSYJMG5eP)_