### PR TITLE
feat: add a Free-Domain donate button to the footer (site-wide Zeffy pop-up)

### DIFF
--- a/__tests__/components/footer.test.tsx
+++ b/__tests__/components/footer.test.tsx
@@ -2,16 +2,17 @@ import React from 'react'
 import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import Footer from '@/components/footer/index'
-import { campaigns, zeffyHostedUrl } from '@/data/donation-campaigns'
+import { freeDomainCampaign, zeffyHostedUrl } from '@/data/donation-campaigns'
 
 describe('Footer', () => {
   it('renders the Free Domains Zeffy donate button', () => {
+    // Explicit check (no `!`): fail with a clear message and narrow the type.
+    if (!freeDomainCampaign) throw new Error('free-domain campaign missing from the registry')
     render(<Footer />)
-    const freeDomain = campaigns.find((c) => c.key === 'free-domain')!
     const btn = screen.getByRole('link', { name: /Donate Free Domains/i })
     // Opens the free-domain campaign as a Zeffy pop-up; degrades to the hosted form.
-    expect(btn).toHaveAttribute('zeffy-form-link', freeDomain.zeffyFormLink)
-    expect(btn).toHaveAttribute('href', zeffyHostedUrl(freeDomain.zeffyFormLink))
+    expect(btn).toHaveAttribute('zeffy-form-link', freeDomainCampaign.zeffyFormLink)
+    expect(btn).toHaveAttribute('href', zeffyHostedUrl(freeDomainCampaign.zeffyFormLink))
     expect(btn.getAttribute('zeffy-form-link')).toContain('zeffy.com')
   })
 

--- a/__tests__/components/footer.test.tsx
+++ b/__tests__/components/footer.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import Footer from '@/components/footer/index'
+import { campaigns, zeffyHostedUrl } from '@/data/donation-campaigns'
+
+describe('Footer', () => {
+  it('renders the Free Domains Zeffy donate button', () => {
+    render(<Footer />)
+    const freeDomain = campaigns.find((c) => c.key === 'free-domain')!
+    const btn = screen.getByRole('link', { name: /Donate Free Domains/i })
+    // Opens the free-domain campaign as a Zeffy pop-up; degrades to the hosted form.
+    expect(btn).toHaveAttribute('zeffy-form-link', freeDomain.zeffyFormLink)
+    expect(btn).toHaveAttribute('href', zeffyHostedUrl(freeDomain.zeffyFormLink))
+    expect(btn.getAttribute('zeffy-form-link')).toContain('zeffy.com')
+  })
+
+  it('keeps the Donate quick link to /donate', () => {
+    render(<Footer />)
+    expect(screen.getByRole('link', { name: /^Donate$/i })).toHaveAttribute('href', '/donate')
+  })
+
+  it('contains no PayPal links', () => {
+    const { container } = render(<Footer />)
+    expect(container.querySelector('a[href*="paypal.com"]')).toBeNull()
+  })
+})

--- a/src/app/donate/page.tsx
+++ b/src/app/donate/page.tsx
@@ -4,7 +4,6 @@ import HeroSection from '@/components/ui/HeroSection'
 import Measurableimpact from '@/components/donate-components/measurable-impact'
 import FreeForCharityDonationOptions from '@/components/donate-components/Free-for-Charity-Donation-Options'
 import DonationCampaigns from '@/components/donate-components/Donation-Campaigns'
-import ZeffyEmbedScript from '@/components/ui/ZeffyEmbedScript'
 
 export const metadata: Metadata = {
   title: 'Donate',
@@ -27,8 +26,7 @@ const index = () => {
         <Measurableimpact />
         <FreeForCharityDonationOptions />
         <DonationCampaigns />
-        {/* Powers every Zeffy pop-up button on this page. */}
-        <ZeffyEmbedScript />
+        {/* Zeffy pop-up engine is loaded globally in src/app/layout.tsx. */}
       </div>
     </div>
   )

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import './globals.css'
 import Header from '@/components/header'
 import Footer from '@/components/footer'
 import CookieConsent from '@/components/cookie-consent'
+import ZeffyEmbedScript from '@/components/ui/ZeffyEmbedScript'
 
 // Get basePath for GitHub Pages deployment
 const basePath = process.env.NEXT_PUBLIC_BASE_PATH || ''
@@ -93,6 +94,11 @@ export default function RootLayout({
         {children}
         <Footer />
         <CookieConsent />
+        {/* Global Zeffy pop-up engine: wires every `zeffy-form-link` element
+            (incl. the footer donate button) to open its campaign in a modal,
+            site-wide. Next.js dedupes the <Script>, so pages that also use
+            Zeffy buttons don't double-load it. */}
+        <ZeffyEmbedScript />
         {/* <PopupsRootClient /> */}
         {/* </PopupProvider> */}
       </body>

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -4,6 +4,8 @@ import React from 'react'
 import Link from 'next/link'
 import { Mail, Phone, MapPin, ArrowRight } from 'lucide-react'
 import { hubUrl } from '@/lib/config'
+import ZeffyPopupButton from '@/components/ui/ZeffyPopupButton'
+import { campaigns } from '@/data/donation-campaigns'
 
 import { FaFacebookF, FaLinkedinIn, FaGithub } from 'react-icons/fa'
 import { FaXTwitter } from 'react-icons/fa6'
@@ -12,6 +14,10 @@ import { assetPath } from '@/lib/assetPath'
 
 const Footer: React.FC = () => {
   const currentYear = React.useMemo(() => new Date().getFullYear(), [])
+  // Footer donate CTA: supports the "Free Domain Names For Charity" campaign.
+  // Opens as a Zeffy modal (the embed script is loaded globally in layout.tsx);
+  // degrades to the hosted form in a new tab when JS is unavailable.
+  const freeDomainCampaign = campaigns.find((c) => c.key === 'free-domain')
   const socialLinks = [
     { icon: FaFacebookF, href: 'https://www.facebook.com/freeforcharity', label: 'Facebook' },
     { icon: FaXTwitter, href: 'https://x.com/freeforcharity1', label: 'X (Twitter)' },
@@ -110,6 +116,24 @@ const Footer: React.FC = () => {
               )
             })}
           </ul>
+
+          {freeDomainCampaign ? (
+            <div className="space-y-2 pt-2">
+              <h4 className="text-[22px] text-white" data-font="lato-font">
+                Fund Free Domains for Charities
+              </h4>
+              <p className="text-[15px] font-[500] text-gray-300" data-font="lato-font">
+                Give a nonprofit a free .org domain &amp; DNS. 100% of your gift reaches the mission
+                (Zeffy charges 0% fees).
+              </p>
+              <ZeffyPopupButton
+                formLink={freeDomainCampaign.zeffyFormLink}
+                label="Donate Free Domains"
+                variant="primary"
+                className="w-full max-w-[260px]"
+              />
+            </div>
+          ) : null}
 
           <div className="space-y-3">
             <h4 className="text-[28px] text-white">Free For Charity Policy</h4>

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link'
 import { Mail, Phone, MapPin, ArrowRight } from 'lucide-react'
 import { hubUrl } from '@/lib/config'
 import ZeffyPopupButton from '@/components/ui/ZeffyPopupButton'
-import { campaigns } from '@/data/donation-campaigns'
+import { freeDomainCampaign } from '@/data/donation-campaigns'
 
 import { FaFacebookF, FaLinkedinIn, FaGithub } from 'react-icons/fa'
 import { FaXTwitter } from 'react-icons/fa6'
@@ -14,10 +14,6 @@ import { assetPath } from '@/lib/assetPath'
 
 const Footer: React.FC = () => {
   const currentYear = React.useMemo(() => new Date().getFullYear(), [])
-  // Footer donate CTA: supports the "Free Domain Names For Charity" campaign.
-  // Opens as a Zeffy modal (the embed script is loaded globally in layout.tsx);
-  // degrades to the hosted form in a new tab when JS is unavailable.
-  const freeDomainCampaign = campaigns.find((c) => c.key === 'free-domain')
   const socialLinks = [
     { icon: FaFacebookF, href: 'https://www.facebook.com/freeforcharity', label: 'Facebook' },
     { icon: FaXTwitter, href: 'https://x.com/freeforcharity1', label: 'X (Twitter)' },
@@ -117,7 +113,11 @@ const Footer: React.FC = () => {
             })}
           </ul>
 
-          {freeDomainCampaign ? (
+          {/* Fail-safe (mirrors /donate): only render when the campaign's Zeffy
+              link is verified, so the footer never ships a broken donate entry
+              point. Opens a Zeffy modal (embed script is global, in layout.tsx);
+              degrades to the hosted form in a new tab without JS. */}
+          {freeDomainCampaign?.confirmed ? (
             <div className="space-y-2 pt-2">
               <h4 className="text-[22px] text-white" data-font="lato-font">
                 Fund Free Domains for Charities

--- a/src/data/donation-campaigns.ts
+++ b/src/data/donation-campaigns.ts
@@ -176,3 +176,13 @@ if (primaries.length !== 1 || primaries[0].key !== 'general') {
   )
 }
 export const generalCampaign: DonationCampaign = primaries[0]
+
+/**
+ * The "Free Domain Names For Charity" campaign — surfaced as the footer donate
+ * CTA. Exported directly so the (client) footer imports just this one entry
+ * instead of the whole `campaigns` registry. `undefined` if it's ever removed,
+ * in which case the footer renders nothing (fail-safe).
+ */
+export const freeDomainCampaign: DonationCampaign | undefined = campaigns.find(
+  (c) => c.key === 'free-domain'
+)

--- a/tests/donation-flows.spec.ts
+++ b/tests/donation-flows.spec.ts
@@ -47,6 +47,25 @@ test.describe('Donation flows', () => {
     expect(await paypalLinks.count(), 'PayPal links should be fully removed from /donate').toBe(0)
   })
 
+  test('the footer donate button + Zeffy engine work on a non-/donate page', async ({ page }) => {
+    // The footer is global, so its donate button must work everywhere — which
+    // requires the embed script to be loaded globally (layout.tsx), not only on
+    // /donate. Verify both on the homepage.
+    await page.goto('/')
+
+    const footerTrigger = page.locator('footer [zeffy-form-link]').first()
+    await expect(footerTrigger).toBeAttached()
+    const formLink = await footerTrigger.getAttribute('zeffy-form-link')
+    const href = await footerTrigger.getAttribute('href')
+    expect(formLink).toContain('zeffy.com')
+    expect(href).toContain('zeffy.com')
+
+    // The global embed script powers the footer pop-up site-wide.
+    await expect(page.locator('script[src*="zeffy-scripts"]').first()).toBeAttached({
+      timeout: 15000,
+    })
+  })
+
   test('/free-for-charity-endowment-fund mounts the Zeffy donation iframe', async ({ page }) => {
     await page.goto('/free-for-charity-endowment-fund')
 


### PR DESCRIPTION
## Summary

Adds a **"Donate Free Domains"** call-to-action in the site footer, wired to the confirmed **Free Domain Names For Charity** Zeffy campaign, and makes it work as a Zeffy modal on **every page** (not just `/donate`).

This came out of a site-wide donation-flow audit (see below) which confirmed the flow is consistent and PayPal-free, and that the Zeffy embed script was only loaded on `/donate` — so a footer pop-up needed the script promoted to the global layout.

### What changed
- **`src/app/layout.tsx`** — render `<ZeffyEmbedScript />` globally so the footer pop-up (and any future global Zeffy button) opens as a modal everywhere. Next.js dedupes the `<Script>`, so no double-load.
- **`src/app/donate/page.tsx`** — drop the now-redundant page-level `ZeffyEmbedScript` (it comes from the layout).
- **`src/components/footer/index.tsx`** — add the Free-Domain `ZeffyPopupButton`, driven by the `donation-campaigns` registry (`free-domain`). With JS it opens the Zeffy modal; without JS it degrades to the hosted form in a new tab.
- **Tests** — new `footer.test.tsx` (renders the Free-Domain Zeffy button, keeps the `/donate` quick link, asserts no PayPal); `donation-flows.spec.ts` gains a check that the footer button + global embed script work on a **non-`/donate`** page (homepage).

### Donation-flow audit result (the "check the donation flow across the entire site" part)
All entry points verified consistent and working post-Zeffy-migration:
- **Header** → Donate dropdown (`/donate` + endowment) · **Footer** → Donate quick link + new Free-Domain button · **Homepage** → `/donate` link + endowment iframe · **About Us**, **Free Web Hosting**, **404** → `/donate`.
- **All 9 Zeffy campaigns** `confirmed`; `/donate` pop-ups + the endowment iframe intact.
- **No functional PayPal anywhere** — remaining `paypal` strings are prose/FAQ/partner-tool mentions only (e.g. "PayPal / Zeffy" as donor tools), not donate links.

### CSP
No change needed — the global `.htaccess` CSP already allow-lists the Zeffy script (`zeffy-scripts.s3…`, `*.zeffy.com`) in `script-src`/`frame-src`/`connect-src`, and that header is site-wide.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run build` — static export succeeds
- [x] `npm test` — 371 Jest tests pass (incl. new footer suite)
- [x] `npx playwright test tests/donation-flows.spec.ts` — pass (incl. the new footer-on-homepage check)
- [x] `npx playwright test tests/accessibility.spec.ts -g "Homepage|Donate"` — WCAG AA pass
- [x] Built HTML: homepage carries the footer Free-Domain trigger + the global Zeffy script; `/donate` loads the script once (no double-load)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014W4FydyhP3fnKxSYJMG5eP)_