### PR TITLE
fix: resync package-lock.json after dependency merges (unblock deploy)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3685,9 +3685,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3705,9 +3702,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3725,9 +3719,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3745,9 +3736,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3899,6 +3887,35 @@
         "@tailwindcss/oxide": "4.3.1",
         "postcss": "8.5.15",
         "tailwindcss": "4.3.1"
+      }
+    },
+    "node_modules/@tailwindcss/postcss/node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -8013,6 +8030,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -11468,9 +11486,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11492,9 +11507,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11516,9 +11528,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11540,9 +11549,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [


### PR DESCRIPTION
## What

Regenerates `package-lock.json` so it is back in sync with `package.json`. Only the lockfile changes — no manifest or source edits.

## Why

Merging several Dependabot npm PRs from independent bases left the manifest and lockfile out of sync on `main`:

- #332 — postcss 8.5.15 → 8.5.16
- #326 — production-dependencies group
- #327 — development-dependencies group
- #284 — undici 7.25.0 → 7.28.0

As a result `npm ci` failed on `main` with `Missing: postcss@8.5.15 from lock file`, so the "CI - Build and Test" job never reached the build step and **every deploy was correctly skipped by the CI-green gate**. Production stayed safely on the last good build (#328, `d7b3b72`), but the merged footer **Free-Domain donate button (#333)** could not deploy.

## Fix

Ran `npm install` to regenerate the lockfile against the merged `package.json`. `git diff` touches only `package-lock.json` (30 insertions / 24 deletions).

## Verification (local)

- `npm ci` — clean (was failing with EUSAGE)
- `npm run lint` — 0 errors
- `npm run build` — static export succeeds
- `npm test` — 23 suites / 371 tests pass

Once CI is green here and this merges, the auto-deploy fires and the footer Free-Domain donate button goes live.

Refs #333, #332, #326, #327, #284

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014W4FydyhP3fnKxSYJMG5eP)_