### PR TITLE
refactor: use hubUrl()/SITE_ORIGIN/relative links in vuln-disclosure page

### DIFF
--- a/src/app/vulnerability-disclosure-policy/page.tsx
+++ b/src/app/vulnerability-disclosure-policy/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import { hubUrl, SITE_ORIGIN } from '@/lib/config'
 
 export const metadata: Metadata = {
   title: 'Vulnerability Disclosure Policy',
@@ -54,20 +55,20 @@ export default function VulnerabilityDisclosurePolicy() {
           </p>
           <ul className="list-disc pl-[40px] pb-[23px] leading-[26px] mb-[20px] space-y-[10px] text-[14px]">
             <li>
-              <a href="https://freeforcharity.org" className="text-[#0056B3] underline">
+              <a href={SITE_ORIGIN} className="text-[#0056B3] underline">
                 freeforcharity.org
               </a>{' '}
               (WordPress)
             </li>
             <li>
-              <a href="https://freeforcharity.org/hub/" className="text-[#0056B3] underline">
+              <a href={hubUrl('/')} className="text-[#0056B3] underline">
                 freeforcharity.org/hub/
               </a>{' '}
               (WHMCS)
             </li>
             <li>
               Any other publicly accessible services hosted under{' '}
-              <a href="https://freeforcharity.org" className="text-[#0056B3] underline">
+              <a href={SITE_ORIGIN} className="text-[#0056B3] underline">
                 freeforcharity.org
               </a>
             </li>
@@ -193,10 +194,7 @@ export default function VulnerabilityDisclosurePolicy() {
             We believe in recognizing the valuable work of security researchers who help keep our
             services safe. For valid and responsibly disclosed vulnerabilities, we are pleased to
             offer a public acknowledgment on our{' '}
-            <a
-              href="https://freeforcharity.org/security-acknowledgements/"
-              className="text-[#0056B3] underline"
-            >
+            <a href="/security-acknowledgements/" className="text-[#0056B3] underline">
               Security Acknowledgements
             </a>{' '}
             page, with your permission.

--- a/src/app/vulnerability-disclosure-policy/page.tsx
+++ b/src/app/vulnerability-disclosure-policy/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import Link from 'next/link'
 import { hubUrl, SITE_ORIGIN } from '@/lib/config'
 
 export const metadata: Metadata = {
@@ -194,9 +195,9 @@ export default function VulnerabilityDisclosurePolicy() {
             We believe in recognizing the valuable work of security researchers who help keep our
             services safe. For valid and responsibly disclosed vulnerabilities, we are pleased to
             offer a public acknowledgment on our{' '}
-            <a href="/security-acknowledgements/" className="text-[#0056B3] underline">
+            <Link href="/security-acknowledgements/" className="text-[#0056B3] underline">
               Security Acknowledgements
-            </a>{' '}
+            </Link>{' '}
             page, with your permission.
           </p>
 


### PR DESCRIPTION
## What
Replaces hardcoded absolute `freeforcharity.org` URLs in `src/app/vulnerability-disclosure-policy/page.tsx` with the shared `@/lib/config` helpers used everywhere else.

## Changes
- `/hub/` link → `hubUrl('/')` (the WHMCS cross-origin helper).
- The two in-scope production-origin links → `SITE_ORIGIN` (still absolute — appropriate for a security *scope* declaration — but no longer a hardcoded literal, and honors `NEXT_PUBLIC_SITE_ORIGIN` for staging).
- Internal Security Acknowledgements link → relative `/security-acknowledgements/`, like other internal nav.

## Verification
- Built HTML is identical in final URLs (only the source of truth changed); the relative internal link now renders as `/security-acknowledgements/`.
- `npm run lint` 0 errors · `npm run build` OK · `npm test` 23 suites / 371 tests pass.

Fixes #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014W4FydyhP3fnKxSYJMG5eP)_