### PR TITLE
style: move imports above metadata + normalize lowercase page export names

### DIFF
--- a/src/app/501c3/page.tsx
+++ b/src/app/501c3/page.tsx
@@ -3,6 +3,8 @@ import HeroSection from '@/components/ui/HeroSection'
 import HelpForCharitiesandNonprofit from '@/components/501c3-components/Help-For-Charities-and-Nonprofit'
 import AdminGuideLink from '@/components/ui/AdminGuideLink'
 import { adminLinks, ffcAdminUrl } from '@/data/admin-links'
+import ReadyToGetStartedAndFaq from '@/components/501c3-components/Ready-to-get-started-and-faqs'
+import CallSection from '@/components/help-for-charities-components/call-section'
 
 export const metadata: Metadata = {
   title: '501(c)(3) Onboarding Guide',
@@ -10,10 +12,8 @@ export const metadata: Metadata = {
     'Apply to get a free website for your 501(c)(3)—a fast, secure GitHub Pages site built with AI—plus free domains, Microsoft 365 email, and technology tools from Free For Charity.',
   alternates: { canonical: '/501c3/' },
 }
-import ReadyToGetStartedAndFaq from '@/components/501c3-components/Ready-to-get-started-and-faqs'
-import CallSection from '@/components/help-for-charities-components/call-section'
 
-const page = () => {
+const index = () => {
   return (
     <div>
       <HeroSection
@@ -34,4 +34,4 @@ const page = () => {
   )
 }
 
-export default page
+export default index

--- a/src/app/about-us/page.tsx
+++ b/src/app/about-us/page.tsx
@@ -4,6 +4,7 @@ import HeroSection from '@/components/ui/HeroSection'
 import Content from '@/components/about-us-components/content'
 import CardSection from '@/components/about-us-components/Card-section'
 import ParaText from '@/components/about-us-components/ParaText'
+import CallToAction from '@/components/about-us-components/CallToAction'
 
 export const metadata: Metadata = {
   title: 'About Us',
@@ -11,7 +12,6 @@ export const metadata: Metadata = {
     "Learn about Free For Charity's mission to reduce costs and increase revenues for nonprofits by connecting students, professionals, and businesses with charities in need.",
   alternates: { canonical: '/about-us/' },
 }
-import CallToAction from '@/components/about-us-components/CallToAction'
 
 const index = () => {
   return (

--- a/src/app/domains/page.tsx
+++ b/src/app/domains/page.tsx
@@ -4,6 +4,12 @@ import Hero from '@/components/domains/Hero'
 import DearProspective from '@/components/domains/Dear-Prospective'
 import OrderYourDomain from '@/components/domains/Order-Your-Domain'
 import CardsSection from '@/components/domains/Cards-Section'
+import VerifyYourDomain from '@/components/domains/Verify-Your-Domain'
+import Seperater from '@/components/domains/Seperater'
+import SetupEmailHosting from '@/components/domains/Setup-Email-Hosting'
+import CurvedBlueSection from '@/components/domains/Curved-Blue-Section'
+import CurvedBlackSection from '@/components/domains/Curved-Black-Section'
+import GetNewWebsite from '@/components/domains/Get-New-Website'
 
 export const metadata: Metadata = {
   title: 'Free Domains for Nonprofits',
@@ -11,12 +17,6 @@ export const metadata: Metadata = {
     'Free For Charity provides free domain registration, DNS management, and email setup for verified 501(c)(3) nonprofit organizations.',
   alternates: { canonical: '/domains/' },
 }
-import VerifyYourDomain from '@/components/domains/Verify-Your-Domain'
-import Seperater from '@/components/domains/Seperater'
-import SetupEmailHosting from '@/components/domains/Setup-Email-Hosting'
-import CurvedBlueSection from '@/components/domains/Curved-Blue-Section'
-import CurvedBlackSection from '@/components/domains/Curved-Black-Section'
-import GetNewWebsite from '@/components/domains/Get-New-Website'
 
 const index = () => {
   return (

--- a/src/app/ffc-volunteer-proving-ground-core-competencies/page.tsx
+++ b/src/app/ffc-volunteer-proving-ground-core-competencies/page.tsx
@@ -3,6 +3,9 @@ import React from 'react'
 import Header from '@/components/ffc-volunteer-proving-ground-core-competencies/Header'
 import AdminGuideLink from '@/components/ui/AdminGuideLink'
 import { adminLinks, ffcAdminUrl } from '@/data/admin-links'
+import ContentSection from '@/components/ffc-volunteer-proving-ground-core-competencies/ContentSection'
+import Modulessection from '@/components/ffc-volunteer-proving-ground-core-competencies/Modules-section'
+import Footer from '@/components/ffc-volunteer-proving-ground-core-competencies/Footer'
 
 export const metadata: Metadata = {
   title: 'Volunteer Proving Ground: Core Competencies',
@@ -10,9 +13,6 @@ export const metadata: Metadata = {
     'Mandatory first step for FFC volunteers. Learn foundational tools for security and effective collaboration in nonprofit technology services—and the path into our AI-driven static-site development workflow.',
   alternates: { canonical: '/ffc-volunteer-proving-ground-core-competencies/' },
 }
-import ContentSection from '@/components/ffc-volunteer-proving-ground-core-competencies/ContentSection'
-import Modulessection from '@/components/ffc-volunteer-proving-ground-core-competencies/Modules-section'
-import Footer from '@/components/ffc-volunteer-proving-ground-core-competencies/Footer'
 
 const index = () => {
   return (

--- a/src/app/free-charity-web-hosting/page.tsx
+++ b/src/app/free-charity-web-hosting/page.tsx
@@ -1,13 +1,6 @@
 import type { Metadata } from 'next'
 import React from 'react'
 import Hero from '@/components/free-charity-web-hosting/Hero'
-
-export const metadata: Metadata = {
-  title: 'Free Nonprofit Web Hosting',
-  description:
-    'Free website hosting for nonprofits—fast, secure GitHub Pages static sites built with AI development agents—plus free domain registration and Microsoft 365 email, with legacy WordPress hosting still available. Powered by Free For Charity volunteers.',
-  alternates: { canonical: '/free-charity-web-hosting/' },
-}
 import Hosting from '@/components/free-charity-web-hosting/hosting'
 import AboutFFCHosting from '@/components/free-charity-web-hosting/About-FFC-Hosting'
 import ThreeCards from '@/components/free-charity-web-hosting/ThreeCards'
@@ -15,6 +8,13 @@ import BecomePartOfOurMission from '@/components/free-charity-web-hosting/Become
 import ReadyToGetStarted from '@/components/free-charity-web-hosting/ReadyToGetStarted'
 import ClientTestimonials from '@/components/free-charity-web-hosting/ClientTestimonials'
 import FAQs from '@/components/free-charity-web-hosting/FAQs'
+
+export const metadata: Metadata = {
+  title: 'Free Nonprofit Web Hosting',
+  description:
+    'Free website hosting for nonprofits—fast, secure GitHub Pages static sites built with AI development agents—plus free domain registration and Microsoft 365 email, with legacy WordPress hosting still available. Powered by Free For Charity volunteers.',
+  alternates: { canonical: '/free-charity-web-hosting/' },
+}
 
 const index = () => {
   return (

--- a/src/app/free-for-charity-endowment-fund/page.tsx
+++ b/src/app/free-for-charity-endowment-fund/page.tsx
@@ -1,13 +1,6 @@
 import type { Metadata } from 'next'
 import React from 'react'
 import Hero from '@/components/free-for-charity-endowment-fund-components/Hero'
-
-export const metadata: Metadata = {
-  title: 'Endowment Fund',
-  description:
-    'Support the Free For Charity Endowment Fund to sustain free domain and hosting services for nonprofits long-term.',
-  alternates: { canonical: '/free-for-charity-endowment-fund/' },
-}
 import TextSection from '@/components/free-for-charity-endowment-fund-components/Text-Section'
 import OurMission from '@/components/free-for-charity-endowment-fund-components/Our-Mission'
 import EndowmentFeatures from '@/components/free-for-charity-endowment-fund-components/Endowment-Features'
@@ -15,6 +8,13 @@ import EmpoweringCharities from '@/components/free-for-charity-endowment-fund-co
 import SupportOurMission from '@/components/free-for-charity-endowment-fund-components/Support-Our-Mission'
 import VoicesofGratitude from '@/components/free-for-charity-endowment-fund-components/Voices-of-Gratitude'
 import EmpowerCharities from '@/components/free-for-charity-endowment-fund-components/Empower-Charities'
+
+export const metadata: Metadata = {
+  title: 'Endowment Fund',
+  description:
+    'Support the Free For Charity Endowment Fund to sustain free domain and hosting services for nonprofits long-term.',
+  alternates: { canonical: '/free-for-charity-endowment-fund/' },
+}
 
 const index = () => {
   return (

--- a/src/app/free-for-charitys-tools-for-success/page.tsx
+++ b/src/app/free-for-charitys-tools-for-success/page.tsx
@@ -4,13 +4,6 @@ import HeroSection from '@/components/ui/HeroSection'
 import CardSection from '@/components/free-for-charitys-tools-for-success-components/Card-section'
 import AdminGuideLink from '@/components/ui/AdminGuideLink'
 import { adminLinks, ffcAdminUrl } from '@/data/admin-links'
-
-export const metadata: Metadata = {
-  title: 'Tools for Success',
-  description:
-    'Free productivity, educational, and business tools curated by Free For Charity to help nonprofits and volunteers succeed.',
-  alternates: { canonical: '/free-for-charitys-tools-for-success/' },
-}
 import RescueTime from '@/components/free-for-charitys-tools-for-success-components/Rescue-Time'
 import TwoCards from '@/components/free-for-charitys-tools-for-success-components/Two-Cards'
 import EducationalSites from '@/components/free-for-charitys-tools-for-success-components/Educational-Sites'
@@ -19,6 +12,13 @@ import TwoFlexCards from '@/components/free-for-charitys-tools-for-success-compo
 import SixGridCards from '@/components/free-for-charitys-tools-for-success-components/Six-Grid-Cards'
 import ToolsForBusinesses from '@/components/free-for-charitys-tools-for-success-components/Tools-For-Businesses'
 import FiveCardsGridSection from '@/components/free-for-charitys-tools-for-success-components/Five-Cards-Grid-Section'
+
+export const metadata: Metadata = {
+  title: 'Tools for Success',
+  description:
+    'Free productivity, educational, and business tools curated by Free For Charity to help nonprofits and volunteers succeed.',
+  alternates: { canonical: '/free-for-charitys-tools-for-success/' },
+}
 
 const index = () => {
   return (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
   alternates: { canonical: '/' },
 }
 
-const page = () => {
+const index = () => {
   return (
     <div>
       {/* <HomePage /> */}
@@ -19,4 +19,4 @@ const page = () => {
   )
 }
 
-export default page
+export default index

--- a/src/app/pre501c3/page.tsx
+++ b/src/app/pre501c3/page.tsx
@@ -6,6 +6,8 @@ import CharityNonprofitDirectorFaq from '@/components/help-for-charities-compone
 import CallSection from '@/components/help-for-charities-components/call-section'
 import AdminGuideLink from '@/components/ui/AdminGuideLink'
 import { adminLinks, ffcAdminUrl } from '@/data/admin-links'
+import Faqs from '@/components/pre501c3-components/Faqs'
+import Charity from '@/components/pre501c3-components/charity'
 
 export const metadata: Metadata = {
   title: 'Pre-501(c)(3) Onboarding Guide',
@@ -13,8 +15,6 @@ export const metadata: Metadata = {
     'For charities pending 501(c)(3) status: apply to get a free website—a fast, secure GitHub Pages site built with AI—plus free tools and services from Free For Charity while your application is in progress.',
   alternates: { canonical: '/pre501c3/' },
 }
-import Faqs from '@/components/pre501c3-components/Faqs'
-import Charity from '@/components/pre501c3-components/charity'
 
 const index = () => {
   return (


### PR DESCRIPTION
## What
Two style-consistency fixes from the page audit, across `src/app/**/page.tsx`.

### #339 — imports above metadata (8 files)
Eight pages placed component imports *after* the `export const metadata` block. Moved every import above the metadata export so each file reads **imports → metadata → component**, matching the rest of the routes. Pure reordering — no import added or removed.

Files: `about-us`, `pre501c3`, `501c3`, `domains`, `free-charity-web-hosting`, `free-for-charitys-tools-for-success`, `free-for-charity-endowment-fund`, `ffc-volunteer-proving-ground-core-competencies`.

### #340 (scoped) — lowercase page export names
Renamed the two lowercase `const page` default exports (homepage `page.tsx` and `/501c3`) to the majority `const index` pattern.

**Deliberately *not* done:** mass-renaming the descriptive PascalCase page components (`PrivacyPolicy`, `BlogPage`, `CookiePolicy`, etc.) to generic `index`. Descriptive names aid debugging/stack traces and are a reasonable convention; only the lowercase outliers that clashed with `index` were normalized. See the note on #340 — happy to do the full rename if preferred.

## Verification
- A sanity scan confirms **no** page has an import after its metadata export.
- `npm run lint` 0 errors · `npm run build` OK (static export byte-identical) · `npm test` 23 suites / 371 tests pass.

Fixes #339
Refs #340

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014W4FydyhP3fnKxSYJMG5eP)_