### PR TITLE
feat: data-driven homepage impact metrics + metrics playbook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ src/
       Endowment-Features/
       Our-Programs/
       Volunteer-with-Us/
-      Results-2023/
+      Results/
       VoicesofGratitude/
       TheFreeForCharityTeam/
       FrequentlyAskedQuestions/

--- a/__tests__/components/all-sections.test.tsx
+++ b/__tests__/components/all-sections.test.tsx
@@ -217,7 +217,7 @@ const sectionComponents: [string, string][] = [
   ['home-page/Hero', '../../src/components/home-page/Hero/index'],
   ['home-page/Mission', '../../src/components/home-page/Mission/index'],
   ['home-page/Our-Programs', '../../src/components/home-page/Our-Programs/index'],
-  ['home-page/Results-2023', '../../src/components/home-page/Results-2023/index'],
+  ['home-page/Results', '../../src/components/home-page/Results/index'],
   ['home-page/SupportFreeForCharity', '../../src/components/home-page/SupportFreeForCharity/index'],
   ['home-page/TheFreeForCharityTeam', '../../src/components/home-page/TheFreeForCharityTeam/index'],
   ['home-page/VoicesofGratitude', '../../src/components/home-page/VoicesofGratitude/index'],

--- a/__tests__/data/impact.test.ts
+++ b/__tests__/data/impact.test.ts
@@ -1,0 +1,34 @@
+import { impact, reportingYear, yearsServing, resultCards, metric } from '../../src/data/impact'
+
+describe('impact data', () => {
+  it('exposes a numeric reporting year and IRS designation year', () => {
+    expect(typeof reportingYear).toBe('number')
+    expect(typeof impact.irsDesignationYear).toBe('number')
+    expect(reportingYear).toBeGreaterThanOrEqual(impact.irsDesignationYear)
+  })
+
+  it('computes years serving from the IRS designation year', () => {
+    expect(yearsServing).toBe(reportingYear - impact.irsDesignationYear)
+  })
+
+  it('renders exactly four headline result cards with concrete values', () => {
+    expect(resultCards).toHaveLength(4)
+    for (const card of resultCards) {
+      expect(card.title).toBeTruthy()
+      expect(card.title).not.toBe('null')
+      expect(card.title).not.toBe('undefined')
+      expect(card.description).toBeTruthy()
+    }
+  })
+
+  it('gives every metric a provenance and confidence', () => {
+    for (const m of Object.values(impact.metrics)) {
+      expect(m.source).toBeTruthy()
+      expect(['high', 'medium', 'low', 'unknown']).toContain(m.confidence)
+    }
+  })
+
+  it('throws for an unknown metric key', () => {
+    expect(() => metric('does-not-exist')).toThrow()
+  })
+})

--- a/__tests__/data/impact.test.ts
+++ b/__tests__/data/impact.test.ts
@@ -17,6 +17,10 @@ describe('impact data', () => {
       expect(card.title).toBeTruthy()
       expect(card.title).not.toBe('null')
       expect(card.title).not.toBe('undefined')
+      // a missing value must never leak through a formatter as "null+", nor
+      // should an already-"+"-suffixed value double up to "++"
+      expect(card.title).not.toContain('null')
+      expect(card.title).not.toContain('++')
       expect(card.description).toBeTruthy()
     }
   })

--- a/__tests__/data/impact.test.ts
+++ b/__tests__/data/impact.test.ts
@@ -7,6 +7,10 @@ import {
   volunteerHours,
   volunteerHoursBreakdown,
   volunteerHoursPending,
+  textMetrics,
+  textSupportHoursByYear,
+  textSupportHours,
+  reachoutVelocityByYear,
 } from '../../src/data/impact'
 
 describe('impact data', () => {
@@ -69,6 +73,36 @@ describe('impact data', () => {
         .filter((l) => l.hours === null)
         .map((l) => l.key)
       expect(volunteerHoursPending).toEqual(pendingFromBreakdown)
+    })
+  })
+
+  describe('text-derived metrics (2025 template)', () => {
+    const y2025 = textMetrics.years['2025']
+
+    it('2025 byParty sums to the total thread count', () => {
+      expect(y2025.byParty).not.toBeNull()
+      const p = y2025.byParty!
+      expect(p.volunteer + p.newCharity + p.existingCharity + p.noise).toBe(y2025.totalThreads)
+    })
+
+    it('2025 category split sums to charityThreads', () => {
+      expect(y2025.charityThreadsByCategory).not.toBeNull()
+      const sum = Object.values(y2025.charityThreadsByCategory!).reduce((s, n) => s + n, 0)
+      expect(sum).toBe(y2025.charityThreads)
+    })
+
+    it('derives a positive 2025 text-support hour figure and surfaces velocity', () => {
+      expect(textSupportHoursByYear['2025']).toBeGreaterThan(0)
+      expect(textSupportHours).toBeGreaterThanOrEqual(textSupportHoursByYear['2025'])
+      expect(reachoutVelocityByYear['2025']).toEqual({ volunteer: 34, newCharity: 42 })
+    })
+
+    it('leaves pending years null (no fabricated splits)', () => {
+      for (const yr of ['2023', '2024', '2026']) {
+        expect(textMetrics.years[yr].byParty).toBeNull()
+        expect(textMetrics.years[yr].charityThreadsByCategory).toBeNull()
+        expect(textSupportHoursByYear[yr]).toBeUndefined()
+      }
     })
   })
 })

--- a/__tests__/data/impact.test.ts
+++ b/__tests__/data/impact.test.ts
@@ -1,4 +1,13 @@
-import { impact, reportingYear, yearsServing, resultCards, metric } from '../../src/data/impact'
+import {
+  impact,
+  reportingYear,
+  yearsServing,
+  resultCards,
+  metric,
+  volunteerHours,
+  volunteerHoursBreakdown,
+  volunteerHoursPending,
+} from '../../src/data/impact'
 
 describe('impact data', () => {
   it('exposes a numeric reporting year and IRS designation year', () => {
@@ -36,5 +45,30 @@ describe('impact data', () => {
 
   it('throws for an unknown metric key', () => {
     expect(() => metric('does-not-exist')).toThrow()
+  })
+
+  describe('modeled volunteer hours', () => {
+    it('computes hours = hoursPerUnit x unit count for resolved lines', () => {
+      for (const line of volunteerHoursBreakdown) {
+        if (line.unitCount === null) {
+          expect(line.hours).toBeNull()
+        } else {
+          expect(line.hours).toBe(line.hoursPerUnit * line.unitCount)
+        }
+      }
+    })
+
+    it('totals only the resolved lines and is a non-negative number', () => {
+      const expected = volunteerHoursBreakdown.reduce((s, l) => s + (l.hours ?? 0), 0)
+      expect(volunteerHours).toBe(expected)
+      expect(volunteerHours).toBeGreaterThanOrEqual(0)
+    })
+
+    it('reports pending engagement types (no double counting)', () => {
+      const pendingFromBreakdown = volunteerHoursBreakdown
+        .filter((l) => l.hours === null)
+        .map((l) => l.key)
+      expect(volunteerHoursPending).toEqual(pendingFromBreakdown)
+    })
   })
 })

--- a/__tests__/data/impact.test.ts
+++ b/__tests__/data/impact.test.ts
@@ -13,7 +13,9 @@ describe('impact data', () => {
 
   it('renders exactly four headline result cards with concrete values', () => {
     expect(resultCards).toHaveLength(4)
+    expect(new Set(resultCards.map((c) => c.key)).size).toBe(resultCards.length)
     for (const card of resultCards) {
+      expect(card.key).toBeTruthy()
       expect(card.title).toBeTruthy()
       expect(card.title).not.toBe('null')
       expect(card.title).not.toBe('undefined')

--- a/docs/METRICS-PLAYBOOK.md
+++ b/docs/METRICS-PLAYBOOK.md
@@ -296,3 +296,54 @@ assumption tied to a concrete deliverable (not a guess about individuals), and
 the estimate is reproducible from committed data. Ratify or adjust the
 coefficients in one place (`volunteer-hours-model.json`, bump `version`); the
 total and the Candid figure follow.
+
+---
+
+## 12. Text-derived metrics system (per calendar year)
+
+Text messages are not just counted — they are a managed metrics source. Each
+Google Voice thread (a personal account; pulled **human-in-the-loop**, see the
+FFC-Cloudflare-Automation runbook) is classified along three dimensions and
+bucketed by **calendar year** in `src/data/text-metrics.json`:
+
+- **Party** — `volunteer` · `newCharity` · `existingCharity` · `noise`
+  (`existingCharity` = matches an `FFC-EX-*` repo; `newCharity` = a nonprofit
+  with no repo yet). `charityThreads` = newCharity + existingCharity.
+- **Product category** (charity-org threads) — website · domain · m365 ·
+  onboarding · migration · maintenance · general.
+- **Net-new reach-out** — a sender's first-ever contact, split volunteer vs
+  new-charity → the **reach-out velocity** per year.
+
+### Derived metrics (computed in `impact.ts`)
+
+1. **Volume** per year: `totalThreads`, `charityThreads`, `byParty`.
+2. **Reach-out velocity** per year: `reachoutVelocityByYear` (net-new volunteer
+   vs new-charity contacts) — the cadence of new reach into the community.
+3. **Texts → volunteer hours**: `textSupport` in `volunteer-hours-model.json`
+   gives per-category minutes for charity-org texts plus a flat rate for
+   volunteer-coordination texts; `textSupportHoursByYear` /`textSupportHours`
+   compute the implied hours (separate from the §11 engagement total, since text
+   support is per-year rather than cumulative).
+
+### 2025 (template — fully classified)
+
+| Metric                         | Value                                                                                         |
+| ------------------------------ | --------------------------------------------------------------------------------------------- |
+| Total threads                  | **2,079** (exact)                                                                             |
+| Noise                          | 1,440                                                                                         |
+| Volunteer                      | 253                                                                                           |
+| New charity / Existing charity | 237 / 149 (charity-org = **386**)                                                             |
+| Net-new reach-outs             | **42 new charities, 34 volunteers**                                                           |
+| Charity threads by category    | migration 94 · general 95 · website 83 · maintenance 59 · onboarding 28 · m365 14 · domain 13 |
+| Implied text-support hours     | **≈ 95 hrs**                                                                                  |
+
+Splits are ~95%-calibrated (a 40-thread deep-read sample); the largest single
+uncertainty is one high-volume contributor (~94 threads) classed as volunteer.
+
+### Replicating to other years
+
+2024, 2023 (full-year bucket; data begins ~Jun 2023), and 2026-YTD are
+`pending-classification` (null splits — never fabricated). Re-run the same pass
+per year (totals are exact once pagination is exhausted; splits calibrated on a
+sample) and drop the numbers into `text-metrics.json`; the derived metrics and
+the Candid figures follow automatically.

--- a/docs/METRICS-PLAYBOOK.md
+++ b/docs/METRICS-PLAYBOOK.md
@@ -255,9 +255,44 @@ WHMCS clients  <  true reach    (the deficit ≈ legacy WP + uncaptured comms)
 
 - The **Gmail sender/label** for SMS-to-email forwards (unblocks Gmail/text counting).
 - The **definition of "charity partner"** and whether to add the WHMCS field/group.
-- A lightweight method to log **volunteer hours** (the one metric with no API).
+- Ratify the **volunteer-hours model** coefficients (§11) and wire the pending
+  engagement counts (M365 email, onboarding) once their WHMCS/M365 exports land.
 - Which mailboxes to mine for discovery, and the reporting window.
 - Confirm `endowmentRaisedUsd` comes from the Zeffy export (vs. manual figure).
 - Whether metric derivation lives in `FFC-Cloudflare-Automation` (next to the
   data) or in this repo (next to the consumer). Recommendation: derive next to
   the data, commit only the small `impact.json` here.
+
+---
+
+## 11. Volunteer hours — modeled per engagement, not per person
+
+Per-person hour logging is ineffective and, in practice, no more valid than a
+structured assumption. So volunteer hours are **estimated per engagement /
+product type**: `hours = hoursPerUnit × unit count`, summed across engagements.
+The coefficients live in `src/data/volunteer-hours-model.json` and are computed
+in `src/data/impact.ts` (`volunteerHours`, `volunteerHoursBreakdown`,
+`volunteerHoursPending`); the unit counts come from the same `impact.json`
+metrics, so the estimate refreshes automatically as those numbers do.
+
+**Proposed coefficients (pending org ratification):**
+
+| Engagement / product                        | Hours/unit | Unit count source       |
+| ------------------------------------------- | ---------: | ----------------------- |
+| Charity website built (GitHub Pages)        |         20 | `sitesBuilt`            |
+| Legacy WordPress → static migration         |         12 | `migratedStable`        |
+| Domain registration + Cloudflare DNS        |          1 | `domainsManaged`        |
+| Ongoing hosting & maintenance (per site/yr) |          3 | `sitesBuilt`            |
+| Microsoft 365 email + grant assistance      |          4 | _pending_ (M365/WHMCS)  |
+| 501c3 / Pre-501c3 onboarding + Candid       |          3 | _pending_ (WHMCS gid-6) |
+
+With the current counts (41 sites, 6 migrations, 376 domains) the resolved lines
+total **≈ 1,391 volunteer hours**; the two _pending_ engagements are excluded
+from the total until their counts are wired, and are reported via
+`volunteerHoursPending` so the figure is never silently undercounted.
+
+**Why this is defensible:** each coefficient is a transparent, reviewable
+assumption tied to a concrete deliverable (not a guess about individuals), and
+the estimate is reproducible from committed data. Ratify or adjust the
+coefficients in one place (`volunteer-hours-model.json`, bump `version`); the
+total and the Candid figure follow.

--- a/docs/METRICS-PLAYBOOK.md
+++ b/docs/METRICS-PLAYBOOK.md
@@ -2,236 +2,257 @@
 
 A repeatable plan for refreshing the impact metrics shown on freeforcharity.org
 and the matching figures on Free For Charity's Candid (GuideStar) Platinum
-profile, by capturing each number programmatically from the system that is its
-real source of truth.
+profile — built on the data pipelines FFC **already operates**, and closing the
+two gaps that keep the real numbers from being knowable today.
 
-> **Why this exists.** Every metric on the site is hardcoded in components (there
-> is no CMS). Numbers were typed by hand in different places and drifted out of
-> date — the homepage still says **"Results – 2023"**. The same figures feed the
-> Candid Platinum profile, which only gets touched once a year. This playbook
-> turns "remember to update the numbers" into "run the collector, review the PR."
+> **Why this exists.** Every metric on the site is hardcoded in components (no
+> CMS). Numbers were typed by hand and drifted — the homepage still says
+> **"Results – 2023."** The same figures feed the Candid Platinum profile, which
+> is touched once a year. The goal: derive each number from an authoritative
+> system on a schedule, review it in a PR, and reuse it for the annual Candid
+> update.
 
 ---
 
 ## 1. Current state — the metrics audit
 
-### 1.1 Impact / mission metrics (the ones this playbook automates)
+### 1.1 Impact / mission metrics (in scope for automation)
 
-| #   | Metric (as shown on site)               | Current value | Location                                                                         | Note                |
-| --- | --------------------------------------- | ------------- | -------------------------------------------------------------------------------- | ------------------- |
-| 1   | "Results – **2023**" header             | 2023          | `src/components/home-page/Results-2023/index.tsx:12`                             | 3 years stale       |
-| 2   | Organizational partners                 | 221           | `…/Results-2023/index.tsx:15`                                                    | stale               |
-| 3   | Total volunteers                        | 3             | `…/Results-2023/index.tsx:16`                                                    | stale               |
-| 4   | Orgs accessing technical assistance     | 221           | `…/Results-2023/index.tsx:19`                                                    | stale               |
-| 5   | Volunteer hours contributed             | 25            | `…/Results-2023/index.tsx:21`                                                    | stale               |
-| 6   | "over **200** charitable organizations" | 200+          | `…/free-for-charity-endowment-fund-components/Empowering-Charities/index.tsx:37` | stale               |
-| 7   | "**100** new charities annually"        | 100           | `…/Empowering-Charities/index.tsx:40`                                            | aspirational target |
-| 8   | Progress bars (95% / 85% / 75%)         | 95/85/75      | `…/Empowering-Charities/index.tsx:44-46`                                         | decorative          |
-| 9   | "$**1,000,000** endowment goal"         | $1M           | endowment components (3 files)                                                   | goal, not progress  |
-| 10  | "~$**16.50** per charity per year"      | $16.50        | `src/data/faqs.ts:12` + home FAQ                                                 | verify vs. actual   |
-| 11  | "IRS designation **since 2014**"        | 2014          | `src/data/faqs/are-you-really-a-charity.json` + FAQs                             | static fact (OK)    |
+| #   | Metric (as shown on site)               | Current value | Location                                             | Note                |
+| --- | --------------------------------------- | ------------- | ---------------------------------------------------- | ------------------- |
+| 1   | "Results – **2023**" header             | 2023          | `src/components/home-page/Results-2023/index.tsx:12` | 3 years stale       |
+| 2   | Organizational partners                 | 221           | `…/Results-2023/index.tsx:15`                        | stale + ill-defined |
+| 3   | Total volunteers                        | 3             | `…/Results-2023/index.tsx:16`                        | stale               |
+| 4   | Orgs accessing technical assistance     | 221           | `…/Results-2023/index.tsx:19`                        | stale               |
+| 5   | Volunteer hours contributed             | 25            | `…/Results-2023/index.tsx:21`                        | stale               |
+| 6   | "over **200** charitable organizations" | 200+          | `…/Empowering-Charities/index.tsx:37`                | stale               |
+| 7   | "**100** new charities annually"        | 100           | `…/Empowering-Charities/index.tsx:40`                | aspirational target |
+| 8   | Progress bars (95% / 85% / 75%)         | 95/85/75      | `…/Empowering-Charities/index.tsx:44-46`             | decorative          |
+| 9   | "$**1,000,000** endowment goal"         | $1M           | endowment components (3 files)                       | goal, not progress  |
+| 10  | "~$**16.50** per charity per year"      | $16.50        | `src/data/faqs.ts:12` + home FAQ                     | verify vs. actual   |
+| 11  | "IRS designation **since 2014**"        | 2014          | `src/data/faqs/are-you-really-a-charity.json`        | static fact (OK)    |
 
-### 1.2 Non-impact numbers (intentionally OUT of scope)
+### 1.2 Out of scope (policy/legal constants)
 
-These are policy/legal constants, not impact metrics, and must **not** be on an
-automated refresh: cookie/privacy retention durations (`cookie-policy/page.tsx`,
-`privacy-policy/page.tsx`), training-program salary ranges
-(`free-training-programs/page.tsx`), and policy "last updated" dates. They change
-only when the underlying policy changes.
-
-### 1.3 Reality check from a live source
-
-The GitHub org `FreeForCharity` currently has **~41 active `FFC-EX-*` repos**
-(`FFC-EX-` = an external charity client site; `FFC-IN-` = internal infra). That
-is far fewer than "221 partners" — which confirms **partners ≠ sites built**.
-"Partners" is the broader WHMCS client base (domain-only + hosting + email
-clients); "sites built" is the GitHub `FFC-EX` count. This playbook treats them
-as **distinct metrics**, never conflated.
+Cookie/privacy retention durations, training-program salary ranges, and policy
+"last updated" dates are **not** impact metrics and must not be on an automated
+refresh. They change only when the underlying policy changes.
 
 ---
 
-## 2. Architecture — one source of truth, two consumers
+## 2. What already exists natively (do not rebuild)
+
+FFC already runs a multi-source reconciliation pipeline. The metrics work should
+**consume** it, not duplicate it.
+
+### 2.1 `FFC-Cloudflare-Automation` — the data backbone
+
+A large set of numbered GitHub Actions already export every source the metrics
+need (outputs are CSV/JSON artifacts or committed files):
+
+| Workflow                      | Source                                      | Produces                                     |
+| ----------------------------- | ------------------------------------------- | -------------------------------------------- |
+| `04-domain-export-inventory`  | Cloudflare + M365 + WHMCS + WPMUDEV         | Combined domain inventory CSV                |
+| `4-export-summary` / `08` DNS | Cloudflare zones                            | Zone summary CSV                             |
+| `7-whmcs-export-domains`      | WHMCS                                       | Domain list                                  |
+| `8-whmcs-export-products`     | WHMCS                                       | Hosting/products catalog                     |
+| `13-wpmudev-export-sites`     | **WPMUDEV Hub API**                         | **Legacy WordPress sites** inventory         |
+| `5/6/7-m365-*`                | Microsoft 365                               | Tenant domains, DKIM status                  |
+| `34-whmcs-charity-onboard`    | WHMCS                                       | Onboarding                                   |
+| `37/38-whmcs-tickets-*`       | WHMCS                                       | Support tickets export + triage              |
+| `41/42-whmcs-orders-*`        | WHMCS                                       | Orders triage                                |
+| `44/45/46-zeffy-*`            | Zeffy API                                   | Campaigns / payments / contacts (PII-masked) |
+| `sites-list-generate`         | WHMCS + Cloudflare + WPMUDEV + health probe | **`sites-list/sites_list.json` + `.csv`**    |
+
+### 2.2 `sites_list.json` — the existing authoritative inventory
+
+`sites-list-generate.yml` merges WHMCS + Cloudflare + WPMUDEV + per-domain HTTP
+health checks into **`sites-list/sites_list.json`**, opened as a PR (protected
+branch), **weekly on Mondays 08:00 UTC**, and rendered at
+[ffcadmin.org/sites-list](https://ffcadmin.org/sites-list).
+
+As of the last snapshot it tracks **376 domains** across five work tiers, each
+with health (live/redirect/error/unreachable), hosting server (GitHub Pages,
+HostPapa, Hostinger, InterServer, Krystal.io, Cloudflare Proxy), status, and a
+migration-progress score (0–4 from Cloudflare + GitHub repo + deployment):
+
+| Tier | Meaning                                 | Count (last snapshot) |
+| ---- | --------------------------------------- | --------------------- |
+| 1    | Active development                      | 35                    |
+| 2    | Stalled                                 | 1                     |
+| 3    | **Needs migration from legacy hosting** | **64**                |
+| 4    | Fully migrated & stable                 | 6                     |
+| 5    | Triage / inactive                       | remainder             |
+
+> **This is the key realization:** the "domains managed / legacy vs. migrated"
+> reconciliation is already built and already layers WPMUDEV (legacy WP) and
+> Cloudflare on top of the incomplete WHMCS data. freeforcharity.org should read
+> figures derived from `sites_list.json`, not re-query the APIs.
+
+### 2.3 Other relevant repos
+
+- **`FFC-Static-Site-Capture-Tools`** (Python) — captures legacy WordPress / Wix
+  / Wayback sites for migration. Operational tooling; keeps no registry.
+- **`FFC-IN-AI-Management`** — org-wide AI-agent config only; no business data.
+- **`FFC-IN-ffcadmin.org`** — renders the sites-list page; `repos.json` there is
+  just a 21-entry internal-repo list (not the charity data).
+
+---
+
+## 3. Why these numbers are hard (the real constraints)
+
+1. **WHMCS is not a complete source of truth.** Many charities are still on
+   legacy WordPress hosting and are not fully represented in WHMCS. Coverage only
+   becomes accurate after layering WPMUDEV + Cloudflare + health probes — which
+   `sites_list.json` already does.
+2. **"Charity partner" is not yet a defined field in WHMCS.** There is no clean
+   flag to count. Any "partners" number today is therefore a derived estimate,
+   not a direct query (see §5 for the interim definition and the fix).
+3. **Communications live outside WHMCS.** Charity inquiries arrive by email
+   (M365 + Gmail) and text message, and many never become WHMCS records — so the
+   true reach (and the onboarding pipeline) is undercounted (see §6).
+4. **Sync lag.** The live sites-list snapshot was ~22 days behind the weekly
+   generator (the PR likely sat unmerged). Freshness needs a guard.
+
+---
+
+## 4. Architecture — consume the reconciled inventory, two consumers
 
 ```
-Authoritative systems ──► collector ──► src/data/impact.json ──┬─► website components
-  (WHMCS, Cloudflare,                                          └─► candid-update.md
-   GitHub, M365, Gmail,                                            (GuideStar paste-sheet)
-   Zeffy)
+FFC-Cloudflare-Automation  ──►  sites_list.json  ──►  metrics derivation  ──►  src/data/impact.json ──┬─► website
+  (+ email/text discovery, §6)   (+ pipeline.json)                                                     └─► candid-update.md
 ```
 
-- **`src/data/impact.json`** is the single source of truth. Components stop
-  hardcoding numbers and read from it (same pattern the sister repo
-  technologyadoptionbarriers.org already uses for `src/data/impact.json`).
-- **Candid/GuideStar has no public _write_ API** — updating the Platinum profile
-  is a manual web form (the documented "30 minutes a year"). So the collector
-  also emits **`candid-update.md`**, a paste-ready sheet of exactly the impact
-  figures Candid asks for, so the annual update is copy-paste, not re-research.
+- **`src/data/impact.json`** = single source of truth the site reads (replacing
+  hardcoded numbers). Each metric carries value **+ provenance + confidence +
+  verifiedAt**, so a reviewer can see where it came from and an unverified
+  precise figure never ships as if it were current (fall back to "200+" phrasing).
+- **`candid-update.md`** = generated paste-sheet for the annual Candid Platinum
+  update (Candid has no public _write_ API; the profile is a manual web form).
 
-### 2.1 Proposed `impact.json` schema
-
-Every metric carries its value **and its provenance** so reviewers can see where
-it came from and when it was last confirmed.
+### 4.1 `impact.json` (illustrative)
 
 ```jsonc
 {
   "generatedAt": "2026-06-30T00:00:00Z",
   "reportingYear": 2026,
   "metrics": {
-    "charityPartners": {
-      "value": 221,
-      "source": "whmcs",
-      "verifiedAt": "2026-06-30",
-      "confidence": "high",
-    },
-    "sitesBuilt": {
-      "value": 41,
-      "source": "github",
-      "verifiedAt": "2026-06-30",
-      "confidence": "high",
-    },
     "domainsManaged": {
-      "value": 0,
-      "source": "cloudflare",
-      "verifiedAt": null,
-      "confidence": "unknown",
+      "value": 376,
+      "source": "sites_list.json",
+      "verifiedAt": "2026-06-08",
+      "confidence": "high",
     },
-    "hostingAccounts": {
-      "value": 0,
-      "source": "whmcs",
-      "verifiedAt": null,
-      "confidence": "unknown",
-    },
-    "mailboxesProvisioned": {
-      "value": 0,
-      "source": "m365",
-      "verifiedAt": null,
-      "confidence": "unknown",
-    },
-    "volunteers": {
-      "value": 3,
-      "source": "github+manual",
-      "verifiedAt": null,
+    "legacyToMigrate": { "value": 64, "source": "sites_list.json (tier 3)", "confidence": "high" },
+    "migratedStable": { "value": 6, "source": "sites_list.json (tier 4)", "confidence": "high" },
+    "sitesBuilt": { "value": 41, "source": "github (FFC-EX-*)", "confidence": "high" },
+    "charityPartners": {
+      "value": null,
+      "source": "derived",
       "confidence": "low",
+      "note": "no WHMCS partner flag yet — see §5",
     },
-    "volunteerHours": { "value": 25, "source": "manual", "verifiedAt": null, "confidence": "low" },
-    "textMessagesHandled": {
-      "value": 0,
-      "source": "gmail",
-      "verifiedAt": null,
-      "confidence": "unknown",
-    },
+    "volunteers": { "value": null, "source": "github+manual", "confidence": "low" },
+    "volunteerHours": { "value": null, "source": "manual", "confidence": "low" },
+    "uncapturedLeads": { "value": null, "source": "email/text discovery", "confidence": "low" },
     "endowmentGoalUsd": { "value": 1000000, "source": "static" },
-    "endowmentRaisedUsd": {
-      "value": 0,
-      "source": "zeffy-manual",
-      "verifiedAt": null,
-      "confidence": "unknown",
-    },
-    "costPerCharityUsd": { "value": 16.5, "source": "whmcs-computed", "verifiedAt": null },
+    "endowmentRaisedUsd": { "value": null, "source": "zeffy export", "confidence": "low" },
   },
 }
 ```
 
-> Display rule: if `confidence` is `low`/`unknown` or `verifiedAt` is stale, the
-> component should fall back to a rounded "200+"-style phrasing rather than a
-> precise number — never show an unverified precise figure as if it were current.
+---
+
+## 5. Gap A — defining "charity partner" in WHMCS
+
+Until there is a real field, "partners" is an estimate. Two-part fix:
+
+- **Interim (now):** derive a defensible number from `sites_list.json` — e.g.
+  distinct charity domains that are live and not internal/test (`FFC-IN-*`, the
+  `.com` towing/test sites). Publish it with `confidence: "medium"` and the
+  derivation noted, rather than a precise-but-unfounded "221."
+- **Permanent (process):** add a **WHMCS client group or custom field**
+  (e.g. `FFC Charity Partner = yes/no`, plus `partner_stage`). Once that exists,
+  `7-whmcs-export-domains` (or a small companion export) yields a clean partner
+  count, and `sites_list.json` can carry a `partnerStatus` column. This is an
+  org-process decision, not a code change to this repo — flagged here so the
+  metric can graduate from "derived" to "high confidence."
 
 ---
 
-## 3. Metric → source map (the core of the plan)
+## 6. Gap B — email/text discovery (the net-new piece)
 
-| Metric                             | Primary source (system of record)                                                           | Cross-check with                | Capture method                                     |
-| ---------------------------------- | ------------------------------------------------------------------------------------------- | ------------------------------- | -------------------------------------------------- |
-| **Charity partners**               | **WHMCS** clients (ffchosting.org/hub)                                                      | Cloudflare zones, GitHub FFC-EX | WHMCS API `GetClients` (active, by client group)   |
-| **Sites built / live**             | **GitHub** `FFC-EX-*` repos (non-archived)                                                  | HTTP 200 liveness per domain    | GitHub API repo list, filter prefix, drop archived |
-| **Domains / DNS managed**          | **Cloudflare** zones in the _Free For Charity_ account (`0fa33828a8a294ba7c3e945cec827f12`) | WHMCS domain list               | Cloudflare API list zones                          |
-| **Hosting accounts**               | **WHMCS** products/services (cPanel)                                                        | —                               | WHMCS API `GetClientsProducts`                     |
-| **Mailboxes provisioned**          | **Microsoft 365 / Graph** (nonprofit tenant)                                                | WHMCS email products            | Graph `GET /users` + license SKUs                  |
-| **Volunteers / contributors**      | **GitHub** org members + unique commit authors                                              | WHMCS staff/admin list          | GitHub org members + contributor stats             |
-| **Volunteer hours**                | Time log (Google Sheet / Calendar) — no clean API                                           | GitHub commit activity (proxy)  | Semi-manual (see §4)                               |
-| **Text messages handled**          | **Gmail** (Google Voice / SMS-to-email trail)                                               | —                               | Gmail API search by sender/label, count in window  |
-| **Donations / endowment progress** | **Zeffy** dashboard — no public API                                                         | bank statement                  | Manual CSV export → impact.json                    |
-| **Cost per charity (~$16.50)**     | **WHMCS** domain billing ÷ domain count                                                     | Cloudflare registrar pricing    | Compute from WHMCS invoices                        |
+**Goal:** surface FFC charity communications that are **not yet in WHMCS**, so we
+(a) feed the onboarding pipeline and (b) stop undercounting reach.
 
----
+No existing workflow mines mailboxes or SMS for this. Proposed design:
 
-## 4. Per-source capture notes (auth + gotchas)
+| Step | Source                                                                                 | Method                                                                                |
+| ---- | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| 1    | **Microsoft 365** shared mailboxes (`contact@`, `support@`, `info@freeforcharity.org`) | Graph `messages` search over a window; extract sender domain, org name, intent        |
+| 2    | **Gmail** (FFC inbox + **SMS-to-email** forwards from Google Voice)                    | Gmail API search by the texting sender/label; count threads, extract phone + org      |
+| 3    | **Onboarding form** submissions                                                        | Wherever they land (email/sheet) — normalize to the same shape                        |
+| 4    | **Reconcile**                                                                          | Diff candidate orgs/domains against `sites_list.json` + WHMCS export                  |
+| 5    | **Output**                                                                             | `pipeline.json` (leads not in the system) + `uncapturedLeads` count for `impact.json` |
 
-- **GitHub** — _no new credentials_ (org is already reachable via the GitHub
-  integration). Sites-built, contributors, members. The cleanest signal.
-- **Cloudflare** — _no new credentials_ (Free For Charity account is in scope).
-  Zone count = authoritative "domains/DNS managed." The existing
-  `FFC-Cloudflare-Automation` (Terraform) repo is an alternate zone source.
-- **WHMCS** — the real system of record for "partners." Needs an **API
-  Identifier + Secret** (WHMCS admin → Setup → Staff Management → API
-  Credentials) plus an IP allowlist. Highest-value credential: it unlocks
-  partners, hosting, domains, and cost in one place. Store as GitHub Environment
-  secrets — never in code.
-- **Microsoft 365 / Graph** — app registration in the nonprofit tenant (client
-  ID/secret, application permissions `User.Read.All`, `Reports.Read.All`).
-  Unlocks mailboxes provisioned and email volume.
-- **Gmail (texting)** — reachable via the Gmail integration. Needs the **sender
-  address or label** under which SMS-to-email forwards arrive, to count them in a
-  reporting window.
-- **Zeffy** — no API; relies on a periodic dashboard CSV export. `impact.json`
-  accepts a hand-dropped figure for `endowmentRaisedUsd`.
-- **Candid / GuideStar** — a _read_ API exists (pull your own profile), but
-  **writes are manual**. Output is the paste-sheet, not an API push.
+Notes:
+
+- **Privacy:** treat inbound contact data like the Zeffy exports already do —
+  PII-masked in any committed artifact; raw lists stay in retention-capped Action
+  artifacts, never in the repo, an issue body, or a PR description.
+- **The SMS detail you flagged:** texting is tracked via Gmail. The collector
+  needs the exact **sender address or label** those forwards arrive under to
+  count them — that is the one input required to wire step 2.
+- This belongs alongside the other exports in **`FFC-Cloudflare-Automation`**
+  (it already holds the M365/WHMCS/Zeffy credentials and export patterns), with
+  the masked summary count flowing into freeforcharity.org's `impact.json`.
 
 ---
 
-## 5. Reconciliation & confidence
+## 7. Reconciliation & confidence
 
-"Partners" should be sanity-checked across three independent systems each run:
+Cross-check reach across independent systems every run; large divergence is a
+data-quality signal to surface in the PR body, not silently overwrite:
 
 ```
-WHMCS active clients  ≈  Cloudflare zones (domains)  ≥  GitHub FFC-EX sites
+sites_list.json domains (376)  ≥  Cloudflare zones  ≥  GitHub FFC-EX sites (~41)
+WHMCS clients  <  true reach    (the deficit ≈ legacy WP + uncaptured comms)
 ```
 
-Large divergence (e.g. WHMCS says 221 but Cloudflare has 60 zones) is a data-
-quality signal worth a note in the PR body, not a silent overwrite. The
-collector reports all three raw counts plus the chosen headline figure.
+---
+
+## 8. Cadence
+
+- **Weekly** — `sites-list-generate` already runs Mondays 08:00 UTC. Add a
+  freshness guard so a stale (unmerged) snapshot is flagged, not silently shown.
+- **Monthly** — derive `impact.json` from the latest `sites_list.json` +
+  email/text discovery; open a review PR against freeforcharity.org.
+- **Annually** — run the derivation, open `candid-update.md`, paste into the
+  Candid Platinum form (the "30 minutes a year").
 
 ---
 
-## 6. Automation & cadence
-
-- **Collector**: a script (TypeScript or Python, matching repo conventions) that
-  reads each reachable source, writes `impact.json`, and renders
-  `candid-update.md`. Degrades gracefully — missing credentials leave that
-  metric's `confidence: "unknown"` and flag it in the run summary instead of
-  failing the whole run.
-- **Scheduled GitHub Action** (monthly cron + `workflow_dispatch`): runs the
-  collector and opens a **PR** (numbers on a public charity site get a human
-  review before going live). Secrets come from GitHub Environments.
-- **Annual GuideStar job** (the "30 minutes a year"): run the collector, open
-  `candid-update.md`, paste into the Candid Platinum form.
-
----
-
-## 7. Phased rollout
+## 9. Phased rollout
 
 1. **Refactor (no credentials):** introduce `src/data/impact.json`; rename
-   `Results-2023` → year-driven `Results`; wire the endowment text and FAQ to
-   read from it. Immediately fixes the "2023" staleness without inventing data
-   (preserve current values, mark provenance/confidence honestly).
-2. **Zero-credential collector:** GitHub + Cloudflare + Gmail → `impact.json`,
-   behind the scheduled Action.
-3. **Credentialed sources:** add WHMCS, then Microsoft 365, as their secrets
-   are provisioned.
-4. **Candid sheet + cadence:** `candid-update.md` generator + monthly/annual
-   schedule.
+   `Results-2023` → year-driven `Results`; wire endowment text + FAQ to read it.
+   Fixes the "2023" staleness without inventing data (honest provenance/confidence).
+2. **Derive from existing data:** map `sites_list.json` (+ GitHub FFC-EX count)
+   into `impact.json` — domains managed, legacy-to-migrate, migrated, sites built.
+3. **Gap A:** adopt a WHMCS partner field; graduate `charityPartners` to a clean count.
+4. **Gap B:** build the email/text discovery export in `FFC-Cloudflare-Automation`;
+   feed `uncapturedLeads` + a pipeline list.
+5. **Candid sheet + cadence:** `candid-update.md` generator + monthly/annual schedule.
 
 ---
 
-## 8. Open items requiring a decision / input
+## 10. Open items / decisions needed
 
-- Which sources to wire first (recommended: GitHub + Cloudflare + Gmail, since
-  they need no new credentials).
-- WHMCS API credentials (Identifier/Secret) into a GitHub Environment.
-- Microsoft 365 app registration for Graph.
-- The Gmail **sender/label** that SMS-to-email forwards arrive under.
-- The authoritative definition of a "partner" (any WHMCS client? active only?
-  excludes internal/test accounts like the `.com` towing sites?).
-- A lightweight method to log **volunteer hours** (the one metric with no clean
-  API today).
+- The **Gmail sender/label** for SMS-to-email forwards (unblocks Gmail/text counting).
+- The **definition of "charity partner"** and whether to add the WHMCS field/group.
+- A lightweight method to log **volunteer hours** (the one metric with no API).
+- Which mailboxes to mine for discovery, and the reporting window.
+- Confirm `endowmentRaisedUsd` comes from the Zeffy export (vs. manual figure).
+- Whether metric derivation lives in `FFC-Cloudflare-Automation` (next to the
+  data) or in this repo (next to the consumer). Recommendation: derive next to
+  the data, commit only the small `impact.json` here.

--- a/docs/METRICS-PLAYBOOK.md
+++ b/docs/METRICS-PLAYBOOK.md
@@ -6,15 +6,20 @@ profile — built on the data pipelines FFC **already operates**, and closing th
 two gaps that keep the real numbers from being knowable today.
 
 > **Why this exists.** Every metric on the site is hardcoded in components (no
-> CMS). Numbers were typed by hand and drifted — the homepage still says
-> **"Results – 2023."** The same figures feed the Candid Platinum profile, which
-> is touched once a year. The goal: derive each number from an authoritative
-> system on a schedule, review it in a PR, and reuse it for the annual Candid
-> update.
+> CMS). Numbers were typed by hand and drifted — the homepage **used to show** a
+> hardcoded **"Results – 2023"** section (replaced by a data-driven section in
+> this change). The same figures feed the Candid Platinum profile, which is
+> touched once a year. The goal: derive each number from an authoritative system
+> on a schedule, review it in a PR, and reuse it for the annual Candid update.
 
 ---
 
-## 1. Current state — the metrics audit
+## 1. Pre-refactor state — the metrics audit
+
+> The file paths in the table below describe the **pre-refactor** layout (the
+> audit that motivated this work). The homepage section is now
+> `src/components/home-page/Results/` driven by `src/data/impact.json`; the
+> `Results-2023` paths no longer exist.
 
 ### 1.1 Impact / mission metrics (in scope for automation)
 

--- a/docs/METRICS-PLAYBOOK.md
+++ b/docs/METRICS-PLAYBOOK.md
@@ -1,0 +1,237 @@
+# Metrics & GuideStar/Candid Update Playbook
+
+A repeatable plan for refreshing the impact metrics shown on freeforcharity.org
+and the matching figures on Free For Charity's Candid (GuideStar) Platinum
+profile, by capturing each number programmatically from the system that is its
+real source of truth.
+
+> **Why this exists.** Every metric on the site is hardcoded in components (there
+> is no CMS). Numbers were typed by hand in different places and drifted out of
+> date — the homepage still says **"Results – 2023"**. The same figures feed the
+> Candid Platinum profile, which only gets touched once a year. This playbook
+> turns "remember to update the numbers" into "run the collector, review the PR."
+
+---
+
+## 1. Current state — the metrics audit
+
+### 1.1 Impact / mission metrics (the ones this playbook automates)
+
+| #   | Metric (as shown on site)               | Current value | Location                                                                         | Note                |
+| --- | --------------------------------------- | ------------- | -------------------------------------------------------------------------------- | ------------------- |
+| 1   | "Results – **2023**" header             | 2023          | `src/components/home-page/Results-2023/index.tsx:12`                             | 3 years stale       |
+| 2   | Organizational partners                 | 221           | `…/Results-2023/index.tsx:15`                                                    | stale               |
+| 3   | Total volunteers                        | 3             | `…/Results-2023/index.tsx:16`                                                    | stale               |
+| 4   | Orgs accessing technical assistance     | 221           | `…/Results-2023/index.tsx:19`                                                    | stale               |
+| 5   | Volunteer hours contributed             | 25            | `…/Results-2023/index.tsx:21`                                                    | stale               |
+| 6   | "over **200** charitable organizations" | 200+          | `…/free-for-charity-endowment-fund-components/Empowering-Charities/index.tsx:37` | stale               |
+| 7   | "**100** new charities annually"        | 100           | `…/Empowering-Charities/index.tsx:40`                                            | aspirational target |
+| 8   | Progress bars (95% / 85% / 75%)         | 95/85/75      | `…/Empowering-Charities/index.tsx:44-46`                                         | decorative          |
+| 9   | "$**1,000,000** endowment goal"         | $1M           | endowment components (3 files)                                                   | goal, not progress  |
+| 10  | "~$**16.50** per charity per year"      | $16.50        | `src/data/faqs.ts:12` + home FAQ                                                 | verify vs. actual   |
+| 11  | "IRS designation **since 2014**"        | 2014          | `src/data/faqs/are-you-really-a-charity.json` + FAQs                             | static fact (OK)    |
+
+### 1.2 Non-impact numbers (intentionally OUT of scope)
+
+These are policy/legal constants, not impact metrics, and must **not** be on an
+automated refresh: cookie/privacy retention durations (`cookie-policy/page.tsx`,
+`privacy-policy/page.tsx`), training-program salary ranges
+(`free-training-programs/page.tsx`), and policy "last updated" dates. They change
+only when the underlying policy changes.
+
+### 1.3 Reality check from a live source
+
+The GitHub org `FreeForCharity` currently has **~41 active `FFC-EX-*` repos**
+(`FFC-EX-` = an external charity client site; `FFC-IN-` = internal infra). That
+is far fewer than "221 partners" — which confirms **partners ≠ sites built**.
+"Partners" is the broader WHMCS client base (domain-only + hosting + email
+clients); "sites built" is the GitHub `FFC-EX` count. This playbook treats them
+as **distinct metrics**, never conflated.
+
+---
+
+## 2. Architecture — one source of truth, two consumers
+
+```
+Authoritative systems ──► collector ──► src/data/impact.json ──┬─► website components
+  (WHMCS, Cloudflare,                                          └─► candid-update.md
+   GitHub, M365, Gmail,                                            (GuideStar paste-sheet)
+   Zeffy)
+```
+
+- **`src/data/impact.json`** is the single source of truth. Components stop
+  hardcoding numbers and read from it (same pattern the sister repo
+  technologyadoptionbarriers.org already uses for `src/data/impact.json`).
+- **Candid/GuideStar has no public _write_ API** — updating the Platinum profile
+  is a manual web form (the documented "30 minutes a year"). So the collector
+  also emits **`candid-update.md`**, a paste-ready sheet of exactly the impact
+  figures Candid asks for, so the annual update is copy-paste, not re-research.
+
+### 2.1 Proposed `impact.json` schema
+
+Every metric carries its value **and its provenance** so reviewers can see where
+it came from and when it was last confirmed.
+
+```jsonc
+{
+  "generatedAt": "2026-06-30T00:00:00Z",
+  "reportingYear": 2026,
+  "metrics": {
+    "charityPartners": {
+      "value": 221,
+      "source": "whmcs",
+      "verifiedAt": "2026-06-30",
+      "confidence": "high",
+    },
+    "sitesBuilt": {
+      "value": 41,
+      "source": "github",
+      "verifiedAt": "2026-06-30",
+      "confidence": "high",
+    },
+    "domainsManaged": {
+      "value": 0,
+      "source": "cloudflare",
+      "verifiedAt": null,
+      "confidence": "unknown",
+    },
+    "hostingAccounts": {
+      "value": 0,
+      "source": "whmcs",
+      "verifiedAt": null,
+      "confidence": "unknown",
+    },
+    "mailboxesProvisioned": {
+      "value": 0,
+      "source": "m365",
+      "verifiedAt": null,
+      "confidence": "unknown",
+    },
+    "volunteers": {
+      "value": 3,
+      "source": "github+manual",
+      "verifiedAt": null,
+      "confidence": "low",
+    },
+    "volunteerHours": { "value": 25, "source": "manual", "verifiedAt": null, "confidence": "low" },
+    "textMessagesHandled": {
+      "value": 0,
+      "source": "gmail",
+      "verifiedAt": null,
+      "confidence": "unknown",
+    },
+    "endowmentGoalUsd": { "value": 1000000, "source": "static" },
+    "endowmentRaisedUsd": {
+      "value": 0,
+      "source": "zeffy-manual",
+      "verifiedAt": null,
+      "confidence": "unknown",
+    },
+    "costPerCharityUsd": { "value": 16.5, "source": "whmcs-computed", "verifiedAt": null },
+  },
+}
+```
+
+> Display rule: if `confidence` is `low`/`unknown` or `verifiedAt` is stale, the
+> component should fall back to a rounded "200+"-style phrasing rather than a
+> precise number — never show an unverified precise figure as if it were current.
+
+---
+
+## 3. Metric → source map (the core of the plan)
+
+| Metric                             | Primary source (system of record)                                                           | Cross-check with                | Capture method                                     |
+| ---------------------------------- | ------------------------------------------------------------------------------------------- | ------------------------------- | -------------------------------------------------- |
+| **Charity partners**               | **WHMCS** clients (ffchosting.org/hub)                                                      | Cloudflare zones, GitHub FFC-EX | WHMCS API `GetClients` (active, by client group)   |
+| **Sites built / live**             | **GitHub** `FFC-EX-*` repos (non-archived)                                                  | HTTP 200 liveness per domain    | GitHub API repo list, filter prefix, drop archived |
+| **Domains / DNS managed**          | **Cloudflare** zones in the _Free For Charity_ account (`0fa33828a8a294ba7c3e945cec827f12`) | WHMCS domain list               | Cloudflare API list zones                          |
+| **Hosting accounts**               | **WHMCS** products/services (cPanel)                                                        | —                               | WHMCS API `GetClientsProducts`                     |
+| **Mailboxes provisioned**          | **Microsoft 365 / Graph** (nonprofit tenant)                                                | WHMCS email products            | Graph `GET /users` + license SKUs                  |
+| **Volunteers / contributors**      | **GitHub** org members + unique commit authors                                              | WHMCS staff/admin list          | GitHub org members + contributor stats             |
+| **Volunteer hours**                | Time log (Google Sheet / Calendar) — no clean API                                           | GitHub commit activity (proxy)  | Semi-manual (see §4)                               |
+| **Text messages handled**          | **Gmail** (Google Voice / SMS-to-email trail)                                               | —                               | Gmail API search by sender/label, count in window  |
+| **Donations / endowment progress** | **Zeffy** dashboard — no public API                                                         | bank statement                  | Manual CSV export → impact.json                    |
+| **Cost per charity (~$16.50)**     | **WHMCS** domain billing ÷ domain count                                                     | Cloudflare registrar pricing    | Compute from WHMCS invoices                        |
+
+---
+
+## 4. Per-source capture notes (auth + gotchas)
+
+- **GitHub** — _no new credentials_ (org is already reachable via the GitHub
+  integration). Sites-built, contributors, members. The cleanest signal.
+- **Cloudflare** — _no new credentials_ (Free For Charity account is in scope).
+  Zone count = authoritative "domains/DNS managed." The existing
+  `FFC-Cloudflare-Automation` (Terraform) repo is an alternate zone source.
+- **WHMCS** — the real system of record for "partners." Needs an **API
+  Identifier + Secret** (WHMCS admin → Setup → Staff Management → API
+  Credentials) plus an IP allowlist. Highest-value credential: it unlocks
+  partners, hosting, domains, and cost in one place. Store as GitHub Environment
+  secrets — never in code.
+- **Microsoft 365 / Graph** — app registration in the nonprofit tenant (client
+  ID/secret, application permissions `User.Read.All`, `Reports.Read.All`).
+  Unlocks mailboxes provisioned and email volume.
+- **Gmail (texting)** — reachable via the Gmail integration. Needs the **sender
+  address or label** under which SMS-to-email forwards arrive, to count them in a
+  reporting window.
+- **Zeffy** — no API; relies on a periodic dashboard CSV export. `impact.json`
+  accepts a hand-dropped figure for `endowmentRaisedUsd`.
+- **Candid / GuideStar** — a _read_ API exists (pull your own profile), but
+  **writes are manual**. Output is the paste-sheet, not an API push.
+
+---
+
+## 5. Reconciliation & confidence
+
+"Partners" should be sanity-checked across three independent systems each run:
+
+```
+WHMCS active clients  ≈  Cloudflare zones (domains)  ≥  GitHub FFC-EX sites
+```
+
+Large divergence (e.g. WHMCS says 221 but Cloudflare has 60 zones) is a data-
+quality signal worth a note in the PR body, not a silent overwrite. The
+collector reports all three raw counts plus the chosen headline figure.
+
+---
+
+## 6. Automation & cadence
+
+- **Collector**: a script (TypeScript or Python, matching repo conventions) that
+  reads each reachable source, writes `impact.json`, and renders
+  `candid-update.md`. Degrades gracefully — missing credentials leave that
+  metric's `confidence: "unknown"` and flag it in the run summary instead of
+  failing the whole run.
+- **Scheduled GitHub Action** (monthly cron + `workflow_dispatch`): runs the
+  collector and opens a **PR** (numbers on a public charity site get a human
+  review before going live). Secrets come from GitHub Environments.
+- **Annual GuideStar job** (the "30 minutes a year"): run the collector, open
+  `candid-update.md`, paste into the Candid Platinum form.
+
+---
+
+## 7. Phased rollout
+
+1. **Refactor (no credentials):** introduce `src/data/impact.json`; rename
+   `Results-2023` → year-driven `Results`; wire the endowment text and FAQ to
+   read from it. Immediately fixes the "2023" staleness without inventing data
+   (preserve current values, mark provenance/confidence honestly).
+2. **Zero-credential collector:** GitHub + Cloudflare + Gmail → `impact.json`,
+   behind the scheduled Action.
+3. **Credentialed sources:** add WHMCS, then Microsoft 365, as their secrets
+   are provisioned.
+4. **Candid sheet + cadence:** `candid-update.md` generator + monthly/annual
+   schedule.
+
+---
+
+## 8. Open items requiring a decision / input
+
+- Which sources to wire first (recommended: GitHub + Cloudflare + Gmail, since
+  they need no new credentials).
+- WHMCS API credentials (Identifier/Secret) into a GitHub Environment.
+- Microsoft 365 app registration for Graph.
+- The Gmail **sender/label** that SMS-to-email forwards arrive under.
+- The authoritative definition of a "partner" (any WHMCS client? active only?
+  excludes internal/test accounts like the `.com` towing sites?).
+- A lightweight method to log **volunteer hours** (the one metric with no clean
+  API today).

--- a/src/app/home-page/index.tsx
+++ b/src/app/home-page/index.tsx
@@ -5,7 +5,7 @@ import SupportFreeForCharity from '@/components/home-page/SupportFreeForCharity'
 import EndowmentFeatures from '@/components/home-page/Endowment-Features'
 import OurPrograms from '@/components/home-page/Our-Programs'
 import VolunteerwithUs from '@/components/home-page/Volunteer-with-Us'
-import Results2023 from '@/components/home-page/Results-2023'
+import Results from '@/components/home-page/Results'
 import Testimonials from '@/components/home/Testimonials'
 import TheFreeForCharityTeam from '@/components/home-page/TheFreeForCharityTeam'
 import FrequentlyAskedQuestions from '@/components/home-page/FrequentlyAskedQuestions'
@@ -19,7 +19,7 @@ const index = () => {
       <EndowmentFeatures />
       <OurPrograms />
       <VolunteerwithUs />
-      <Results2023 />
+      <Results />
       <Testimonials />
       <TheFreeForCharityTeam />
       <FrequentlyAskedQuestions />

--- a/src/components/free-for-charity-endowment-fund-components/Empowering-Charities/index.tsx
+++ b/src/components/free-for-charity-endowment-fund-components/Empowering-Charities/index.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import Image from 'next/image'
 import ProgressBar from '@/components/ui/ProgressBar'
 import { assetPath } from '@/lib/assetPath'
+import { metric } from '@/data/impact'
 
 const Index = () => {
   return (
@@ -34,10 +35,11 @@ const Index = () => {
               className="text-[15px] sm:text-[16px] text-[#000000a3] font-[500] leading-[26px] sm:leading-[28px]"
               data-font="fauna-font"
             >
-              Our Free For Charity Domain Program has already supported over 200 charitable
-              organizations, providing them with essential digital tools to enhance their outreach
-              and impact. With the establishment of the endowment we can sustainably maintain our
-              current charities and support 100 new charities annually.
+              Our Free For Charity Domain Program has already supported over{' '}
+              {metric('organizationsSupported').value} charitable organizations, providing them with
+              essential digital tools to enhance their outreach and impact. With the establishment
+              of the endowment we can sustainably maintain our current charities and support{' '}
+              {metric('newCharitiesAnnualTarget').value} new charities annually.
             </p>
 
             <div className="mt-[30px] space-y-[20px] md:space-y-[30px]">

--- a/src/components/free-for-charity-endowment-fund-components/Empowering-Charities/index.tsx
+++ b/src/components/free-for-charity-endowment-fund-components/Empowering-Charities/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import Image from 'next/image'
 import ProgressBar from '@/components/ui/ProgressBar'
 import { assetPath } from '@/lib/assetPath'
-import { metric } from '@/data/impact'
+import { requireValue } from '@/data/impact'
 
 const Index = () => {
   return (
@@ -36,10 +36,10 @@ const Index = () => {
               data-font="fauna-font"
             >
               Our Free For Charity Domain Program has already supported over{' '}
-              {metric('organizationsSupported').value} charitable organizations, providing them with
+              {requireValue('organizationsSupported')} charitable organizations, providing them with
               essential digital tools to enhance their outreach and impact. With the establishment
               of the endowment we can sustainably maintain our current charities and support{' '}
-              {metric('newCharitiesAnnualTarget').value} new charities annually.
+              {requireValue('newCharitiesAnnualTarget')} new charities annually.
             </p>
 
             <div className="mt-[30px] space-y-[20px] md:space-y-[30px]">

--- a/src/components/home-page/Results/index.tsx
+++ b/src/components/home-page/Results/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import ResultCard from '@/components/ui/ResultCard'
+import { resultCards, reportingYear } from '@/data/impact'
 
 const index = () => {
   return (
@@ -9,16 +10,12 @@ const index = () => {
           className="mt-[2px] pb-[10px] text-[30px] md:text-[48px] font-[400] leading-[46px]  text-center mb-[40px]"
           data-font="faustina-font"
         >
-          Results - 2023
+          Results - {reportingYear}
         </h2>
         <div className="pt-[30px] grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-[20px]">
-          <ResultCard title="221" description="Organizational partners" />
-          <ResultCard title="3" description="Total volunteers" />
-          <ResultCard
-            title="221"
-            description="Organizations accessing technical assistance offerings"
-          />
-          <ResultCard title="25" description="Volunteer hours contributed to the organization" />
+          {resultCards.map((card) => (
+            <ResultCard key={card.description} title={card.title} description={card.description} />
+          ))}
         </div>
       </div>
     </div>

--- a/src/components/home-page/Results/index.tsx
+++ b/src/components/home-page/Results/index.tsx
@@ -14,7 +14,7 @@ const index = () => {
         </h2>
         <div className="pt-[30px] grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-[20px]">
           {resultCards.map((card) => (
-            <ResultCard key={card.description} title={card.title} description={card.description} />
+            <ResultCard key={card.key} title={card.title} description={card.description} />
           ))}
         </div>
       </div>

--- a/src/data/impact.json
+++ b/src/data/impact.json
@@ -1,0 +1,90 @@
+{
+  "generatedAt": "2026-06-30",
+  "reportingYear": 2026,
+  "irsDesignationYear": 2014,
+  "metrics": {
+    "domainsManaged": {
+      "value": 376,
+      "label": "Charity domains under management",
+      "source": "ffcadmin.org/sites-list (FFC-Cloudflare-Automation: sites_list.json)",
+      "verifiedAt": "2026-06-08",
+      "confidence": "high"
+    },
+    "sitesBuilt": {
+      "value": 41,
+      "label": "Charity websites built",
+      "source": "GitHub FreeForCharity FFC-EX-* repositories (active, non-archived)",
+      "verifiedAt": "2026-06-30",
+      "confidence": "high"
+    },
+    "organizationsSupported": {
+      "value": 200,
+      "label": "Charitable organizations supported",
+      "source": "Free For Charity Domain Program (ffcadmin.org/sites-list)",
+      "verifiedAt": "2026-06-08",
+      "confidence": "medium"
+    },
+    "newCharitiesAnnualTarget": {
+      "value": 100,
+      "label": "New charities supported annually (with endowment)",
+      "source": "Endowment program target",
+      "confidence": "high"
+    },
+    "legacyToMigrate": {
+      "value": 64,
+      "label": "Legacy sites in migration",
+      "source": "ffcadmin.org/sites-list tier 3",
+      "verifiedAt": "2026-06-08",
+      "confidence": "high"
+    },
+    "migratedStable": {
+      "value": 6,
+      "label": "Sites fully migrated and stable",
+      "source": "ffcadmin.org/sites-list tier 4",
+      "verifiedAt": "2026-06-08",
+      "confidence": "high"
+    },
+    "volunteers": {
+      "value": null,
+      "label": "Active volunteers",
+      "source": "pending — GitHub contributors + manual roster",
+      "confidence": "unknown"
+    },
+    "volunteerHours": {
+      "value": null,
+      "label": "Volunteer hours contributed",
+      "source": "pending — manual log (no API)",
+      "confidence": "unknown"
+    },
+    "textMessagesHandled": {
+      "value": null,
+      "label": "Support text messages handled",
+      "source": "pending — Gmail Google Voice export (FFC-Cloudflare-Automation#490 Gap B)",
+      "confidence": "unknown"
+    },
+    "uncapturedLeads": {
+      "value": null,
+      "label": "Charity leads in discovery pipeline",
+      "source": "pending — email/text discovery (FFC-Cloudflare-Automation#490 Gap B)",
+      "confidence": "unknown"
+    },
+    "endowmentGoalUsd": {
+      "value": 1000000,
+      "label": "Endowment goal",
+      "source": "static program goal",
+      "confidence": "high"
+    },
+    "endowmentRaisedUsd": {
+      "value": null,
+      "label": "Endowment raised to date",
+      "source": "pending — Zeffy export (FFC-Cloudflare-Automation 45-zeffy-payments-export)",
+      "confidence": "unknown"
+    },
+    "costPerCharityUsdPerYear": {
+      "value": 16.5,
+      "label": "Cost per charity per year",
+      "source": "eNom .org domain cost",
+      "confidence": "medium"
+    }
+  }
+}

--- a/src/data/impact.json
+++ b/src/data/impact.json
@@ -53,7 +53,7 @@
     "volunteerHours": {
       "value": null,
       "label": "Volunteer hours contributed",
-      "source": "pending — manual log (no API)",
+      "source": "Not tracked per person (ineffective); modeled per engagement in volunteer-hours-model.json and computed in impact.ts (`volunteerHours`)",
       "confidence": "unknown"
     },
     "textMessagesHandled": {

--- a/src/data/impact.json
+++ b/src/data/impact.json
@@ -59,14 +59,14 @@
     "textMessagesHandled": {
       "value": null,
       "label": "Support text messages handled",
-      "source": "pending — Gmail Google Voice export (FFC-Cloudflare-Automation#490 Gap B)",
+      "source": "Gmail Google Voice: ~201 text threads, ~48% charity-related per a 2026-06-30 manual sample (~148 scanned); precise count pending the automated export (FFC-Cloudflare-Automation#492)",
       "confidence": "unknown"
     },
     "uncapturedLeads": {
-      "value": null,
+      "value": 6,
       "label": "Charity leads in discovery pipeline",
-      "source": "pending — email/text discovery (FFC-Cloudflare-Automation#490 Gap B)",
-      "confidence": "unknown"
+      "source": "Gmail Google Voice discovery, manual sample 2026-06-30 (~148 of ~201 threads); ≥6 charity orgs with no FFC site yet. Full count pending the automated export (FFC-Cloudflare-Automation#492)",
+      "confidence": "low"
     },
     "endowmentGoalUsd": {
       "value": 1000000,

--- a/src/data/impact.json
+++ b/src/data/impact.json
@@ -57,10 +57,10 @@
       "confidence": "unknown"
     },
     "textMessagesHandled": {
-      "value": null,
+      "value": 2780,
       "label": "Charity/volunteer support text messages handled (3 yrs)",
-      "source": "Gmail Google Voice human-in-the-loop scan 2026-06-30: >=3,650 total text threads confirmed (floor; pagination halted at Oct 2024, ~16 mo short), ~45% charity/volunteer => >=1,640 charity threads (floor, ~2,000 projected for full 3 yrs). Exact total pending an exhaustive re-run.",
-      "confidence": "low"
+      "source": "Gmail Google Voice exhaustive scan 2026-06-30: 6,193 total text threads over 3 yrs (pagination exhausted to the 2023-06-29 boundary; Gmail's ~201 estimate was wrong); ~45% charity/volunteer (calibrated on 2,250 classified) => ~2,780 charity/volunteer threads (estimate; threads, not individual messages)",
+      "confidence": "medium"
     },
     "uncapturedLeads": {
       "value": 6,

--- a/src/data/impact.json
+++ b/src/data/impact.json
@@ -58,9 +58,9 @@
     },
     "textMessagesHandled": {
       "value": null,
-      "label": "Support text messages handled",
-      "source": "Gmail Google Voice: ~201 text threads, ~48% charity-related per a 2026-06-30 manual sample (~148 scanned); precise count pending the automated export (FFC-Cloudflare-Automation#492)",
-      "confidence": "unknown"
+      "label": "Charity/volunteer support text messages handled (3 yrs)",
+      "source": "Gmail Google Voice human-in-the-loop scan 2026-06-30: >=3,650 total text threads confirmed (floor; pagination halted at Oct 2024, ~16 mo short), ~45% charity/volunteer => >=1,640 charity threads (floor, ~2,000 projected for full 3 yrs). Exact total pending an exhaustive re-run.",
+      "confidence": "low"
     },
     "uncapturedLeads": {
       "value": 6,

--- a/src/data/impact.ts
+++ b/src/data/impact.ts
@@ -47,23 +47,37 @@ export function metric(key: string): Metric {
 
 export type ResultCard = { title: string; description: string }
 
+// A metric's value, asserting it is actually present. Throws at module load so a
+// malformed/incomplete data file fails the build instead of silently shipping a
+// bogus card. Centralising the null/empty check here (rather than string-matching
+// the formatted title) means formatters like `approxValue` can't smuggle a
+// missing value through as "null"/"null+".
+function requireValue(key: string): number | string {
+  const v = metric(key).value
+  if (v === null || v === undefined || v === '') {
+    throw new Error(`impact: metric "${key}" has no value but is required for a result card`)
+  }
+  return v
+}
+
+// Format an "approximate" count like "200+", without doubling a "+" if the data
+// already stores the value as the string "200+".
+function approxValue(key: string): string {
+  const s = String(requireValue(key))
+  return s.endsWith('+') ? s : `${s}+`
+}
+
 // The headline cards rendered in the homepage "Results" section. Only
 // high/medium-confidence metrics with a real value are shown here; the
 // volunteer/pipeline metrics stay out until the automation backs them with a
 // source (see the playbook). `title` is a string so `ResultCard` animates the
 // numeric ones and renders the rest (e.g. "200+") as-is.
 export const resultCards: ResultCard[] = [
-  { title: String(metric('domainsManaged').value), description: metric('domainsManaged').label },
-  { title: String(metric('sitesBuilt').value), description: metric('sitesBuilt').label },
+  { title: String(requireValue('domainsManaged')), description: metric('domainsManaged').label },
+  { title: String(requireValue('sitesBuilt')), description: metric('sitesBuilt').label },
   {
-    title: `${metric('organizationsSupported').value}+`,
+    title: approxValue('organizationsSupported'),
     description: metric('organizationsSupported').label,
   },
   { title: String(yearsServing), description: 'Years serving nonprofits' },
 ]
-
-// Asserted at module load so a malformed data file fails the build instead of
-// silently shipping an empty or partial Results section.
-if (resultCards.some((c) => !c.title || c.title === 'null' || c.title === 'undefined')) {
-  throw new Error('impact: every result card must have a concrete value (check impact.json)')
-}

--- a/src/data/impact.ts
+++ b/src/data/impact.ts
@@ -1,0 +1,69 @@
+// Free For Charity impact metrics — the single source of truth for the
+// quantitative figures shown on the site.
+//
+// `impact.json` is intentionally a plain data file so it can be regenerated /
+// overwritten by the metrics automation (see docs/METRICS-PLAYBOOK.md and
+// FreeForCharity/FFC-Cloudflare-Automation#490) without touching code. This
+// module gives that data a type and derives the small, display-ready shapes the
+// components consume.
+//
+// Every metric carries provenance (`source`, `verifiedAt`, `confidence`) so a
+// reviewer can see where a number came from and how trustworthy it is. Metrics
+// whose value is `null` (confidence "unknown") are not yet wired to an
+// authoritative source — components must not render them as precise figures.
+
+import data from './impact.json'
+
+export type MetricConfidence = 'high' | 'medium' | 'low' | 'unknown'
+
+export type Metric = {
+  value: number | string | null
+  label: string
+  source: string
+  verifiedAt?: string
+  confidence: MetricConfidence
+}
+
+export type ImpactData = {
+  generatedAt: string
+  reportingYear: number
+  irsDesignationYear: number
+  metrics: Record<string, Metric>
+}
+
+export const impact = data as ImpactData
+
+export const reportingYear = impact.reportingYear
+
+/** Whole years FFC has held its IRS 501(c)(3) designation, as of the reporting year. */
+export const yearsServing = impact.reportingYear - impact.irsDesignationYear
+
+/** Look up a metric by key (throws at module load if the key is unknown). */
+export function metric(key: string): Metric {
+  const m = impact.metrics[key]
+  if (!m) throw new Error(`impact: unknown metric "${key}"`)
+  return m
+}
+
+export type ResultCard = { title: string; description: string }
+
+// The headline cards rendered in the homepage "Results" section. Only
+// high/medium-confidence metrics with a real value are shown here; the
+// volunteer/pipeline metrics stay out until the automation backs them with a
+// source (see the playbook). `title` is a string so `ResultCard` animates the
+// numeric ones and renders the rest (e.g. "200+") as-is.
+export const resultCards: ResultCard[] = [
+  { title: String(metric('domainsManaged').value), description: metric('domainsManaged').label },
+  { title: String(metric('sitesBuilt').value), description: metric('sitesBuilt').label },
+  {
+    title: `${metric('organizationsSupported').value}+`,
+    description: metric('organizationsSupported').label,
+  },
+  { title: String(yearsServing), description: 'Years serving nonprofits' },
+]
+
+// Asserted at module load so a malformed data file fails the build instead of
+// silently shipping an empty or partial Results section.
+if (resultCards.some((c) => !c.title || c.title === 'null' || c.title === 'undefined')) {
+  throw new Error('impact: every result card must have a concrete value (check impact.json)')
+}

--- a/src/data/impact.ts
+++ b/src/data/impact.ts
@@ -38,46 +38,74 @@ export const reportingYear = impact.reportingYear
 /** Whole years FFC has held its IRS 501(c)(3) designation, as of the reporting year. */
 export const yearsServing = impact.reportingYear - impact.irsDesignationYear
 
-/** Look up a metric by key (throws at module load if the key is unknown). */
+/** Look up a metric by key (throws if the key is unknown). */
 export function metric(key: string): Metric {
   const m = impact.metrics[key]
   if (!m) throw new Error(`impact: unknown metric "${key}"`)
   return m
 }
 
-export type ResultCard = { title: string; description: string }
+export type ResultCard = { key: string; title: string; description: string }
 
-// A metric's value, asserting it is actually present. Throws at module load so a
-// malformed/incomplete data file fails the build instead of silently shipping a
-// bogus card. Centralising the null/empty check here (rather than string-matching
-// the formatted title) means formatters like `approxValue` can't smuggle a
-// missing value through as "null"/"null+".
-function requireValue(key: string): number | string {
+/**
+ * A metric's value, asserting it is actually present. Throws if the value is
+ * null/empty — the result cards below call this at module load, so a
+ * malformed/incomplete data file fails the build instead of silently rendering
+ * an empty hole. Exported so prose components can require a value the same way.
+ */
+export function requireValue(key: string): number | string {
   const v = metric(key).value
   if (v === null || v === undefined || v === '') {
-    throw new Error(`impact: metric "${key}" has no value but is required for a result card`)
+    throw new Error(`impact: metric "${key}" has no value but is required for display`)
   }
   return v
+}
+
+// Confidence levels permitted on a public-facing headline card.
+const CARD_CONFIDENCE: MetricConfidence[] = ['high', 'medium']
+
+// A metric's value for a headline card: must be present AND high/medium
+// confidence. Throws otherwise, so the "only high/medium-confidence metrics are
+// shown" rule is enforced at module load (adding a low/unknown metric to
+// `resultCards` fails the build) rather than merely documented.
+function cardValue(key: string): number | string {
+  const c = metric(key).confidence
+  if (!CARD_CONFIDENCE.includes(c)) {
+    throw new Error(
+      `impact: metric "${key}" is confidence "${c}"; headline cards must be high/medium`
+    )
+  }
+  return requireValue(key)
 }
 
 // Format an "approximate" count like "200+", without doubling a "+" if the data
 // already stores the value as the string "200+".
 function approxValue(key: string): string {
-  const s = String(requireValue(key))
+  const s = String(cardValue(key))
   return s.endsWith('+') ? s : `${s}+`
 }
 
 // The headline cards rendered in the homepage "Results" section. Only
-// high/medium-confidence metrics with a real value are shown here; the
-// volunteer/pipeline metrics stay out until the automation backs them with a
-// source (see the playbook). `title` is a string so `ResultCard` animates the
-// numeric ones and renders the rest (e.g. "200+") as-is.
+// high/medium-confidence metrics with a real value are shown — enforced by
+// `cardValue`, so the volunteer/pipeline metrics (low/unknown) can't slip in
+// until the automation backs them with a source (see the playbook). `title` is a
+// string so `ResultCard` animates the numeric ones and renders the rest (e.g.
+// "200+") as-is. `key` is a stable identity independent of the display copy.
 export const resultCards: ResultCard[] = [
-  { title: String(requireValue('domainsManaged')), description: metric('domainsManaged').label },
-  { title: String(requireValue('sitesBuilt')), description: metric('sitesBuilt').label },
   {
+    key: 'domainsManaged',
+    title: String(cardValue('domainsManaged')),
+    description: metric('domainsManaged').label,
+  },
+  {
+    key: 'sitesBuilt',
+    title: String(cardValue('sitesBuilt')),
+    description: metric('sitesBuilt').label,
+  },
+  {
+    key: 'organizationsSupported',
     title: approxValue('organizationsSupported'),
     description: metric('organizationsSupported').label,
   },
-  { title: String(yearsServing), description: 'Years serving nonprofits' },
+  { key: 'yearsServing', title: String(yearsServing), description: 'Years serving nonprofits' },
 ]

--- a/src/data/impact.ts
+++ b/src/data/impact.ts
@@ -14,6 +14,7 @@
 
 import data from './impact.json'
 import vhModel from './volunteer-hours-model.json'
+import textData from './text-metrics.json'
 
 export type MetricConfidence = 'high' | 'medium' | 'low' | 'unknown'
 
@@ -172,3 +173,65 @@ export const volunteerHours = volunteerHoursBreakdown.reduce((sum, l) => sum + (
 export const volunteerHoursPending = volunteerHoursBreakdown
   .filter((l) => l.hours === null)
   .map((l) => l.key)
+
+// --- Text-derived metrics (per calendar year) -------------------------------
+// Google Voice support texts, classified per year by party + product category +
+// net-new reach-out (see docs/METRICS-PLAYBOOK.md section 12 and the FFC-Cloudflare-
+// Automation runbook). The classification is human-in-the-loop (personal account);
+// a year stays `pending-classification` (null splits) until its pass is done.
+
+export type TextParty = 'volunteer' | 'newCharity' | 'existingCharity' | 'noise'
+
+export type TextYear = {
+  coverage: string
+  status: string
+  totalThreads: number | null
+  charityThreads: number | null
+  byParty: Record<TextParty, number> | null
+  netNewReachouts: { volunteer: number; newCharity: number } | null
+  charityThreadsByCategory: Record<string, number> | null
+  confidence?: string
+}
+
+export type TextMetrics = {
+  version: string
+  categories: string[]
+  parties: string[]
+  years: Record<string, TextYear>
+}
+
+export const textMetrics = textData as unknown as TextMetrics
+
+type TextSupportModel = {
+  minutesPerCharityTextByCategory: Record<string, number>
+  minutesPerVolunteerCoordinationText: number
+}
+
+const textSupportModel = (vhModel as unknown as { textSupport: TextSupportModel }).textSupport
+
+// Per-year text-derived volunteer hours: charity-org support texts attributed by
+// product category + volunteer-coordination texts at a flat rate. Years still
+// pending classification contribute nothing.
+export const textSupportHoursByYear: Record<string, number> = {}
+for (const [yr, y] of Object.entries(textMetrics.years)) {
+  let minutes = 0
+  if (y.charityThreadsByCategory) {
+    for (const [cat, n] of Object.entries(y.charityThreadsByCategory)) {
+      const per = textSupportModel.minutesPerCharityTextByCategory[cat]
+      if (typeof n === 'number' && typeof per === 'number') minutes += n * per
+    }
+  }
+  if (y.byParty && typeof y.byParty.volunteer === 'number') {
+    minutes += y.byParty.volunteer * textSupportModel.minutesPerVolunteerCoordinationText
+  }
+  if (minutes > 0) textSupportHoursByYear[yr] = Math.round(minutes / 60)
+}
+
+/** Total text-derived volunteer hours across all classified years. */
+export const textSupportHours = Object.values(textSupportHoursByYear).reduce((s, h) => s + h, 0)
+
+/** Net-new reach-out velocity per year (first-contact charity & volunteer senders). */
+export const reachoutVelocityByYear: Record<string, { volunteer: number; newCharity: number }> = {}
+for (const [yr, y] of Object.entries(textMetrics.years)) {
+  if (y.netNewReachouts) reachoutVelocityByYear[yr] = y.netNewReachouts
+}

--- a/src/data/impact.ts
+++ b/src/data/impact.ts
@@ -13,6 +13,7 @@
 // authoritative source — components must not render them as precise figures.
 
 import data from './impact.json'
+import vhModel from './volunteer-hours-model.json'
 
 export type MetricConfidence = 'high' | 'medium' | 'low' | 'unknown'
 
@@ -109,3 +110,65 @@ export const resultCards: ResultCard[] = [
   },
   { key: 'yearsServing', title: String(yearsServing), description: 'Years serving nonprofits' },
 ]
+
+// --- Volunteer hours (modeled per engagement, not per person) ---------------
+// Per-person hour logging is ineffective and no more valid than a structured
+// assumption, so volunteer hours are estimated as `hoursPerUnit x unit count`
+// for each major engagement/product type. Coefficients live in
+// `volunteer-hours-model.json` (proposed, pending org ratification); the unit
+// counts come from the metrics above so the estimate refreshes with them.
+
+export type VolunteerHoursCoefficient = {
+  key: string
+  label: string
+  hoursPerUnit: number
+  unitMetric?: string | null
+  unitCount?: number | null
+  rationale: string
+}
+
+type VolunteerHoursModel = { version: string; coefficients: VolunteerHoursCoefficient[] }
+
+const volunteerHoursModel = vhModel as VolunteerHoursModel
+
+export const volunteerHoursModelVersion = volunteerHoursModel.version
+
+export type VolunteerHoursLine = {
+  key: string
+  label: string
+  hoursPerUnit: number
+  unitCount: number | null
+  hours: number | null
+  rationale: string
+}
+
+// One line per engagement type: resolve the unit count (explicit `unitCount`,
+// else the referenced metric's numeric value) and compute `hours`. A line with
+// no resolvable count is "pending" (hours = null) and excluded from the total.
+export const volunteerHoursBreakdown: VolunteerHoursLine[] = volunteerHoursModel.coefficients.map(
+  (c) => {
+    let unitCount: number | null = null
+    if (typeof c.unitCount === 'number') {
+      unitCount = c.unitCount
+    } else if (c.unitMetric) {
+      const v = impact.metrics[c.unitMetric]?.value
+      if (typeof v === 'number') unitCount = v
+    }
+    return {
+      key: c.key,
+      label: c.label,
+      hoursPerUnit: c.hoursPerUnit,
+      unitCount,
+      hours: unitCount === null ? null : c.hoursPerUnit * unitCount,
+      rationale: c.rationale,
+    }
+  }
+)
+
+/** Modeled total volunteer hours (sum of resolved lines; pending lines excluded). */
+export const volunteerHours = volunteerHoursBreakdown.reduce((sum, l) => sum + (l.hours ?? 0), 0)
+
+/** Engagement keys whose unit count isn't wired to an authoritative source yet. */
+export const volunteerHoursPending = volunteerHoursBreakdown
+  .filter((l) => l.hours === null)
+  .map((l) => l.key)

--- a/src/data/text-metrics.json
+++ b/src/data/text-metrics.json
@@ -1,0 +1,53 @@
+{
+  "_comment": "Text-derived metrics system (Gap B). Per CALENDAR YEAR, from the human-in-the-loop Google Voice classification (personal account; see FFC-Cloudflare-Automation docs/runbooks/google-voice-metrics.md). Each thread is classified by party; charity-org threads are tagged by product category; net-new reach-outs (first-contact senders) give the velocity. Totals are exact when a year's pagination is exhausted; party/category/velocity splits come from the classification pass (calibrated ~95% on a sample). 'charityThreads' = newCharity + existingCharity (charity orgs); volunteer threads are counted separately in byParty. 2023 is a full calendar-year bucket but forwarding began ~Jun 2023 (partial coverage). 2025 is the template; other years are pending the same pass.",
+  "version": "2026-06-30",
+  "categories": ["website", "domain", "m365", "onboarding", "migration", "maintenance", "general"],
+  "parties": ["volunteer", "newCharity", "existingCharity", "noise"],
+  "years": {
+    "2023": {
+      "coverage": "full-year bucket; data from ~Jun 2023",
+      "status": "pending-classification",
+      "totalThreads": null,
+      "charityThreads": null,
+      "byParty": null,
+      "netNewReachouts": null,
+      "charityThreadsByCategory": null
+    },
+    "2024": {
+      "coverage": "full",
+      "status": "pending-classification",
+      "totalThreads": null,
+      "charityThreads": null,
+      "byParty": null,
+      "netNewReachouts": null,
+      "charityThreadsByCategory": null
+    },
+    "2025": {
+      "coverage": "full",
+      "status": "classified",
+      "totalThreads": 2079,
+      "charityThreads": 386,
+      "byParty": { "volunteer": 253, "newCharity": 237, "existingCharity": 149, "noise": 1440 },
+      "netNewReachouts": { "volunteer": 34, "newCharity": 42 },
+      "charityThreadsByCategory": {
+        "website": 83,
+        "domain": 13,
+        "m365": 14,
+        "onboarding": 28,
+        "migration": 94,
+        "maintenance": 59,
+        "general": 95
+      },
+      "confidence": "exact total (2079); party/category splits ~95% calibrated on a 40-thread sample; main uncertainty is one high-volume contributor (~94 threads) classed as volunteer; net-new reach-outs are rate-extrapolated"
+    },
+    "2026": {
+      "coverage": "YTD",
+      "status": "pending-classification",
+      "totalThreads": null,
+      "charityThreads": null,
+      "byParty": null,
+      "netNewReachouts": null,
+      "charityThreadsByCategory": null
+    }
+  }
+}

--- a/src/data/volunteer-hours-model.json
+++ b/src/data/volunteer-hours-model.json
@@ -1,0 +1,50 @@
+{
+  "_comment": "Defensible volunteer-hours model. Per-person hour tracking is ineffective and no more valid than a structured assumption, so volunteer hours are ESTIMATED per engagement/product type: hoursPerUnit x unit count. Coefficients are proposed defaults pending org ratification; bump the version when they change. unitMetric references a key in impact.json metrics (the count is taken from that metric's value when it is a number); unitCount is an explicit override when no metric supplies the count yet (null = pending an authoritative count, contributes 0 but is reported as pending).",
+  "version": "2026-06-30",
+  "coefficients": [
+    {
+      "key": "websiteBuild",
+      "label": "Charity website built (GitHub Pages)",
+      "hoursPerUnit": 20,
+      "unitMetric": "sitesBuilt",
+      "rationale": "Discovery, template apply, content migration, accessibility/SEO review, deploy."
+    },
+    {
+      "key": "legacyMigration",
+      "label": "Legacy WordPress -> static migration",
+      "hoursPerUnit": 12,
+      "unitMetric": "migratedStable",
+      "rationale": "Capture, rebuild, verify, and cut over an existing site (on top of a build)."
+    },
+    {
+      "key": "domainDns",
+      "label": "Domain registration + Cloudflare DNS",
+      "hoursPerUnit": 1,
+      "unitMetric": "domainsManaged",
+      "rationale": "Registration/transfer, zone setup, DNS records, verification. Heavily automated, so low per-unit."
+    },
+    {
+      "key": "maintenance",
+      "label": "Ongoing hosting & maintenance (per active site / year)",
+      "hoursPerUnit": 3,
+      "unitMetric": "sitesBuilt",
+      "rationale": "Monitoring, dependency/security updates, and support per active site per year."
+    },
+    {
+      "key": "m365Email",
+      "label": "Microsoft 365 email + grant assistance",
+      "hoursPerUnit": 4,
+      "unitMetric": null,
+      "unitCount": null,
+      "rationale": "Tenant/domain setup, DKIM, MS-900 grant guidance. Count pending the M365/WHMCS export."
+    },
+    {
+      "key": "onboarding",
+      "label": "501c3 / Pre-501c3 onboarding + Candid guidance",
+      "hoursPerUnit": 3,
+      "unitMetric": null,
+      "unitCount": null,
+      "rationale": "Eligibility validation and Candid/GuideStar profile guidance. Count pending the WHMCS gid-6 (pid 16/33) export."
+    }
+  ]
+}

--- a/src/data/volunteer-hours-model.json
+++ b/src/data/volunteer-hours-model.json
@@ -46,5 +46,18 @@
       "unitCount": null,
       "rationale": "Eligibility validation and Candid/GuideStar profile guidance. Count pending the WHMCS gid-6 (pid 16/33) export."
     }
-  ]
+  ],
+  "textSupport": {
+    "_comment": "Volunteer minutes implied by each support text message (text-metrics.json). Charity-org texts are attributed by product category; volunteer-coordination texts use a flat rate. Proposed defaults, pending org ratification. hours/yr = sum_category(charityThreadsByCategory x minutes)/60 + volunteerThreads x minutesPerVolunteerCoordinationText/60.",
+    "minutesPerCharityTextByCategory": {
+      "website": 15,
+      "domain": 5,
+      "m365": 10,
+      "onboarding": 12,
+      "migration": 10,
+      "maintenance": 8,
+      "general": 5
+    },
+    "minutesPerVolunteerCoordinationText": 8
+  }
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -66,7 +66,7 @@ data-driven from `src/data/impact.json` (see `docs/METRICS-PLAYBOOK.md`).
 
 2. **`should start with numbers at 0 before scrolling into view`**
    - Ensures numbers are not pre-animated
-   - Verifies all statistics display 0 before scrolling into view
+   - Verifies a numeric card (Charity domains under management) starts at 0 before scrolling into view (the non-numeric "200+" card renders as-is and does not animate)
 
 3. **`should animate numbers only once when scrolled into view`**
    - Verifies animation triggers on scroll and does not repeat

--- a/tests/README.md
+++ b/tests/README.md
@@ -53,15 +53,16 @@ Tests image loading performance and visibility.
 
 ### `animated-numbers.spec.ts` - Animated Statistics (5 tests)
 
-Tests the Results 2023 section with animated statistics.
+Tests the homepage Results section with animated statistics. The section is
+data-driven from `src/data/impact.json` (see `docs/METRICS-PLAYBOOK.md`).
 
-**Test Suite**: `Results 2023 Animated Numbers`
+**Test Suite**: `Results Animated Numbers`
 
 **Tests:**
 
-1. **`should display the Results-2023 section with all four statistics`**
+1. **`should display the Results section with all four statistics`**
    - Verifies all four statistics cards display
-   - Checks for: Organizational partners, Total volunteers, Organizations accessing technical assistance offerings, and Volunteer hours contributed to the organization
+   - Checks for: Charity domains under management, Charity websites built, Charitable organizations supported, and Years serving nonprofits
 
 2. **`should start with numbers at 0 before scrolling into view`**
    - Ensures numbers are not pre-animated

--- a/tests/animated-numbers.spec.ts
+++ b/tests/animated-numbers.spec.ts
@@ -3,39 +3,40 @@ import { test, expect } from '@playwright/test'
 /**
  * Animated Numbers Tests
  *
- * These tests verify that the Results-2023 section numbers animate correctly
- * when scrolled into view.
+ * These tests verify that the homepage "Results" section numbers animate
+ * correctly when scrolled into view. The section is data-driven from
+ * src/data/impact.json (see docs/METRICS-PLAYBOOK.md); the values asserted
+ * here mirror the high/medium-confidence metrics surfaced as result cards.
  */
 
-test.describe('Results 2023 Animated Numbers', () => {
+test.describe('Results Animated Numbers', () => {
   // Helper selector for ResultCard components - uses the distinctive border class
   // to identify the card containing a specific description
   const getResultCard = (page: import('@playwright/test').Page, description: string) =>
     page.locator(`div.border-\\[\\#F58629\\]:has(p:text-is("${description}"))`)
 
-  test('should display the Results-2023 section with all four statistics', async ({ page }) => {
+  test('should display the Results section with all four statistics', async ({ page }) => {
     // Navigate to the homepage
     await page.goto('/')
 
-    // Find the Results-2023 section heading
-    const resultsHeading = page.locator('h2:has-text("Results - 2023")')
+    // Find the Results section heading (year is data-driven)
+    const resultsHeading = page.locator('h2:has-text("Results - ")')
     await expect(resultsHeading).toBeVisible()
 
     // Scroll to the Results section to trigger animations
     await resultsHeading.scrollIntoViewIfNeeded()
 
-    // Wait for animation to complete by checking final values
-    await expect(getResultCard(page, 'Organizational partners').locator('h1')).toContainText(
-      '221',
-      { timeout: 5000 }
-    )
-    await expect(getResultCard(page, 'Total volunteers').locator('h1')).toContainText('3')
+    // Numeric cards animate up to their final values
     await expect(
-      getResultCard(page, 'Organizations accessing technical assistance offerings').locator('h1')
-    ).toContainText('221')
+      getResultCard(page, 'Charity domains under management').locator('h1')
+    ).toContainText('376', { timeout: 5000 })
+    await expect(getResultCard(page, 'Charity websites built').locator('h1')).toContainText('41')
+    await expect(getResultCard(page, 'Years serving nonprofits').locator('h1')).toContainText('12')
+
+    // Non-numeric card renders its value verbatim (no count-up animation)
     await expect(
-      getResultCard(page, 'Volunteer hours contributed to the organization').locator('h1')
-    ).toContainText('25')
+      getResultCard(page, 'Charitable organizations supported').locator('h1')
+    ).toContainText('200+')
   })
 
   test('should start with numbers at 0 before scrolling into view', async ({ page }) => {
@@ -43,10 +44,10 @@ test.describe('Results 2023 Animated Numbers', () => {
     await page.goto('/')
 
     // Verify the numbers start at 0 before scrolling into view
-    const firstCardNumber = getResultCard(page, 'Organizational partners').locator('h1')
+    const firstCardNumber = getResultCard(page, 'Charity domains under management').locator('h1')
     await expect(firstCardNumber).toContainText('0')
 
-    const resultsSection = page.locator('h2:has-text("Results - 2023")')
+    const resultsSection = page.locator('h2:has-text("Results - ")')
     await expect(resultsSection).toBeAttached()
   })
 
@@ -54,20 +55,20 @@ test.describe('Results 2023 Animated Numbers', () => {
     // Navigate to the homepage
     await page.goto('/')
 
-    // Find and scroll to the Results-2023 section
-    const resultsHeading = page.locator('h2:has-text("Results - 2023")')
+    // Find and scroll to the Results section
+    const resultsHeading = page.locator('h2:has-text("Results - ")')
     await resultsHeading.scrollIntoViewIfNeeded()
 
     // Wait for animation to complete by checking the final value
-    const firstCardNumber = getResultCard(page, 'Organizational partners').locator('h1')
-    await expect(firstCardNumber).toContainText('221', { timeout: 5000 })
+    const firstCardNumber = getResultCard(page, 'Charity domains under management').locator('h1')
+    await expect(firstCardNumber).toContainText('376', { timeout: 5000 })
 
     // Scroll away and back
     await page.locator('h1:has-text("Welcome to")').scrollIntoViewIfNeeded()
     await resultsHeading.scrollIntoViewIfNeeded()
 
     // Value should still be the final animated value (not reset to 0)
-    await expect(firstCardNumber).toContainText('221')
+    await expect(firstCardNumber).toContainText('376')
   })
 
   test('should display correct descriptions for each statistic', async ({ page }) => {
@@ -75,12 +76,10 @@ test.describe('Results 2023 Animated Numbers', () => {
     await page.goto('/')
 
     // Verify all descriptions are present
-    await expect(page.locator('text=Organizational partners')).toBeVisible()
-    await expect(page.locator('text=Total volunteers')).toBeVisible()
-    await expect(
-      page.locator('text=Organizations accessing technical assistance offerings')
-    ).toBeVisible()
-    await expect(page.locator('text=Volunteer hours contributed to the organization')).toBeVisible()
+    await expect(page.locator('text=Charity domains under management')).toBeVisible()
+    await expect(page.locator('text=Charity websites built')).toBeVisible()
+    await expect(page.locator('text=Charitable organizations supported')).toBeVisible()
+    await expect(page.locator('text=Years serving nonprofits')).toBeVisible()
   })
 
   test('should respect prefers-reduced-motion preference', async ({ browser }) => {
@@ -95,7 +94,7 @@ test.describe('Results 2023 Animated Numbers', () => {
     // `domcontentloaded` and rely on Playwright's auto-retrying
     // `toBeVisible` to absorb hydration timing instead.
     await page.goto('/', { waitUntil: 'domcontentloaded' })
-    const resultsHeading = page.locator('h2:has-text("Results - 2023")')
+    const resultsHeading = page.locator('h2:has-text("Results - ")')
     await expect(resultsHeading).toBeVisible({ timeout: 10000 })
     // Scroll via the DOM API rather than `scrollIntoViewIfNeeded`. The
     // React tree on this page re-renders during hydration, so Playwright's
@@ -109,8 +108,8 @@ test.describe('Results 2023 Animated Numbers', () => {
     // for the React effect + CountUp to settle on slower CI runners (the
     // motion-reduced branch is still synchronous, but hydration timing
     // varies enough to flake under a 1s budget).
-    const firstCardNumber = getResultCard(page, 'Organizational partners').locator('h1')
-    await expect(firstCardNumber).toContainText('221', { timeout: 5000 })
+    const firstCardNumber = getResultCard(page, 'Charity domains under management').locator('h1')
+    await expect(firstCardNumber).toContainText('376', { timeout: 5000 })
 
     await context.close()
   })


### PR DESCRIPTION
## What & why
The homepage showed a hardcoded **"Results - 2023"** section with stale, ill-defined figures (221 partners / 3 volunteers / 221 / 25 hours). This replaces it with a single, provenance-tracked source of truth and refreshes the numbers to verifiable ones.

Fixes #347
Refs FreeForCharity/FFC-Cloudflare-Automation#490

## Changes
- **`src/data/impact.json`** — single source of truth; each metric carries `source`, `verifiedAt`, `confidence`.
- **`src/data/impact.ts`** — typed loader; derives the headline result cards and `yearsServing` (from the 2014 IRS designation); fails the build if a card lacks a concrete value.
- **`home-page/Results-2023` → `home-page/Results`** — renders a year-driven `Results - {reportingYear}`.
- Headline cards now show **verifiable** metrics:
  - **376** — charity domains under management (FFC sites-list reconciliation, snapshot 2026-06-08)
  - **41** — charity websites built (GitHub `FFC-EX-*`, active)
  - **200+** — charitable organizations supported
  - **12** — years serving nonprofits (computed)
- Wired the **Empowering-Charities** copy (200 / 100) to `impact.json`.
- **`docs/METRICS-PLAYBOOK.md`** — the repeatable capture plan (sources → `impact.json` → site + Candid paste-sheet), built on the existing `FFC-Cloudflare-Automation` pipelines.
- Tests: updated unit (`all-sections`) + e2e (`animated-numbers`) for the new content; added `__tests__/data/impact.test.ts`.

## Deliberate decisions (please review)
- Dropped the unverifiable **3 volunteers / 25 hours** cards rather than re-publish stale precise numbers on a public charity site. They remain in `impact.json` as `null`/`unknown` placeholders for the automation to fill (#490 Gap B).
- `domainsManaged = 376` is FFC's own published sites-list figure — confirm the public phrasing before merge.

## Verification
- `npm run lint` — clean
- `npm test` — **377 passed**
- `npm run build` — succeeds (all routes prerendered)
- `npx playwright test tests/animated-numbers.spec.ts` — **5 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_013AwqCfp26iQEYUssk5cfCQ)_