### PR TITLE
feat: route homepage hero CTAs to their full pages

### DIFF
--- a/src/components/home-page/Hero/index.tsx
+++ b/src/components/home-page/Hero/index.tsx
@@ -40,7 +40,7 @@ const CharityHeroBackground = () => {
           </p>
           <Link
             href="/volunteer/"
-            className="top-[378px] w-[300px] lg:w-[351px] h-[54px] opacity-100 rounded-[27px] px-[32px] py-[18px] flex items-center justify-center gap-[10px] bg-[#FFFFFF] text-[#113563] text-[20px] font-[400] leading-[100%] mb-[10px] whitespace-nowrap"
+            className="w-[300px] lg:w-[351px] h-[54px] opacity-100 rounded-[27px] px-[32px] py-[18px] flex items-center justify-center gap-[10px] bg-[#FFFFFF] text-[#113563] text-[20px] font-[400] leading-[100%] mb-[10px] whitespace-nowrap"
             data-font="lato-font"
           >
             Volunteer
@@ -48,14 +48,14 @@ const CharityHeroBackground = () => {
           <div className="flex gap-[5px]">
             <Link
               href="/donate/"
-              className="top-[442px] w-[130px] lg:w-[173px] h-[54px] opacity-100 rounded-[27px] px-[32px] py-[18px] flex items-center justify-center gap-[10px] bg-[#FFFFFF] text-[#113563] text-[20px] font-[400] leading-[100%] whitespace-nowrap"
+              className="w-[130px] lg:w-[173px] h-[54px] opacity-100 rounded-[27px] px-[32px] py-[18px] flex items-center justify-center gap-[10px] bg-[#FFFFFF] text-[#113563] text-[20px] font-[400] leading-[100%] whitespace-nowrap"
               data-font="lato-font"
             >
               Donate
             </Link>
             <Link
               href="/help-for-charities/"
-              className="top-[442px] w-[173px] h-[54px] opacity-100 rounded-[27px] px-[32px] py-[18px] flex items-center justify-center gap-[10px] bg-[#FFFFFF] text-[#113563] text-[20px] font-[400] leading-[100%] whitespace-nowrap"
+              className="w-[173px] h-[54px] opacity-100 rounded-[27px] px-[32px] py-[18px] flex items-center justify-center gap-[10px] bg-[#FFFFFF] text-[#113563] text-[20px] font-[400] leading-[100%] whitespace-nowrap"
               data-font="lato-font"
             >
               Help for Charities

--- a/src/components/home-page/Hero/index.tsx
+++ b/src/components/home-page/Hero/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Image from 'next/image'
+import Link from 'next/link'
 import { assetPath } from '@/lib/assetPath'
 
 const CharityHeroBackground = () => {
@@ -37,28 +38,28 @@ const CharityHeroBackground = () => {
           >
             Connecting Students, Professionals, & Businesses with Charities in Need
           </p>
-          <a
-            href="#volunteer"
+          <Link
+            href="/volunteer/"
             className="top-[378px] w-[300px] lg:w-[351px] h-[54px] opacity-100 rounded-[27px] px-[32px] py-[18px] flex items-center justify-center gap-[10px] bg-[#FFFFFF] text-[#113563] text-[20px] font-[400] leading-[100%] mb-[10px] whitespace-nowrap"
             data-font="lato-font"
           >
             Volunteer
-          </a>
+          </Link>
           <div className="flex gap-[5px]">
-            <a
-              href="#donate"
+            <Link
+              href="/donate/"
               className="top-[442px] w-[130px] lg:w-[173px] h-[54px] opacity-100 rounded-[27px] px-[32px] py-[18px] flex items-center justify-center gap-[10px] bg-[#FFFFFF] text-[#113563] text-[20px] font-[400] leading-[100%] whitespace-nowrap"
               data-font="lato-font"
             >
               Donate
-            </a>
-            <a
-              href="#programs"
+            </Link>
+            <Link
+              href="/help-for-charities/"
               className="top-[442px] w-[173px] h-[54px] opacity-100 rounded-[27px] px-[32px] py-[18px] flex items-center justify-center gap-[10px] bg-[#FFFFFF] text-[#113563] text-[20px] font-[400] leading-[100%] whitespace-nowrap"
               data-font="lato-font"
             >
               Help for Charities
-            </a>
+            </Link>
           </div>
         </div>
 


### PR DESCRIPTION
## What
Routes the homepage hero's three clicked CTAs to the dedicated pages that exist for each, instead of scrolling to on-page anchors.

| Button | Before | After |
|---|---|---|
| Volunteer | `#volunteer` | `/volunteer/` |
| Donate | `#donate` | `/donate/` |
| Help for Charities | `#programs` | `/help-for-charities/` |

Uses `next/link` so the GitHub Pages `basePath` is applied (the same correctness fix Copilot flagged on #344). The on-page section ids (`#volunteer`, `#donate`, `#programs`) are left intact, so natural scrolling still works — only the buttons change.

## Verification
- Built `out/index.html` now contains `href="/volunteer/"`, `href="/donate/"`, `href="/help-for-charities/"`.
- `npm run lint` 0 errors · `npm run build` OK · `npm test` 371 pass.

Fixes #350 · part of #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014W4FydyhP3fnKxSYJMG5eP)_