### PR TITLE
feat: deep-link the homepage program pillars to their pages

### DIFF
--- a/src/components/home-page/Our-Programs/index.tsx
+++ b/src/components/home-page/Our-Programs/index.tsx
@@ -37,7 +37,7 @@ const index = () => {
             className="inline-flex items-center gap-[8px] mt-[16px] text-[20px] font-[500] text-[#b35000] hover:underline"
             data-font="lato-font"
           >
-            Learn more about FFC Domains
+            <span>Learn more about FFC Domains</span>
             <span aria-hidden="true">→</span>
           </Link>
         </div>
@@ -101,7 +101,7 @@ const index = () => {
             className="inline-flex items-center gap-[8px] mt-[16px] text-[20px] font-[500] text-[#b35000] hover:underline"
             data-font="lato-font"
           >
-            Learn more about FFC Hosting
+            <span>Learn more about FFC Hosting</span>
             <span aria-hidden="true">→</span>
           </Link>
         </div>
@@ -185,7 +185,7 @@ const index = () => {
             className="inline-flex items-center gap-[8px] mt-[16px] text-[20px] font-[500] text-[#b35000] hover:underline"
             data-font="lato-font"
           >
-            Learn more about FFC Consulting
+            <span>Learn more about FFC Consulting</span>
             <span aria-hidden="true">→</span>
           </Link>
         </div>

--- a/src/components/home-page/Our-Programs/index.tsx
+++ b/src/components/home-page/Our-Programs/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Image from 'next/image'
+import Link from 'next/link'
 import OrangeFaqItem from '@/components/ui/OrangeFaqItem'
 import AdminGuideLink from '@/components/ui/AdminGuideLink'
 import { adminLinks, ffcAdminUrl } from '@/data/admin-links'
@@ -31,6 +32,14 @@ const index = () => {
             Provides free .org domain names, Microsoft 365 with Outlook email, & Microsoft Teams to
             501c3 charities.
           </p>
+          <Link
+            href="/domains/"
+            className="inline-flex items-center gap-[8px] mt-[16px] text-[20px] font-[500] text-[#b35000] hover:underline"
+            data-font="lato-font"
+          >
+            Learn more about FFC Domains
+            <span aria-hidden="true">→</span>
+          </Link>
         </div>
 
         {/* faqs  */}
@@ -87,6 +96,14 @@ const index = () => {
             Free static-site hosting for nonprofits on GitHub Pages, with modern websites built by
             AI development agents (Claude and GitHub Copilot):
           </p>
+          <Link
+            href="/free-charity-web-hosting/"
+            className="inline-flex items-center gap-[8px] mt-[16px] text-[20px] font-[500] text-[#b35000] hover:underline"
+            data-font="lato-font"
+          >
+            Learn more about FFC Hosting
+            <span aria-hidden="true">→</span>
+          </Link>
         </div>
 
         {/* faqs  */}
@@ -163,6 +180,14 @@ const index = () => {
             sponsored organizations. We benefit when you use these services as well as your
             organization benefiting.
           </p>
+          <Link
+            href="/consulting/"
+            className="inline-flex items-center gap-[8px] mt-[16px] text-[20px] font-[500] text-[#b35000] hover:underline"
+            data-font="lato-font"
+          >
+            Learn more about FFC Consulting
+            <span aria-hidden="true">→</span>
+          </Link>
         </div>
 
         {/* faqs  */}


### PR DESCRIPTION
## What
Adds a "Learn more about FFC … →" deep link under each of the three "Our Programs" pillars, which previously had no link despite each having a full page.

| Pillar | Link |
|---|---|
| FFC Domains | `/domains/` |
| FFC Hosting | `/free-charity-web-hosting/` |
| FFC Consulting | `/consulting/` |

`next/link` for basePath correctness. The existing "Ready to Get Started Now?" CTAs (`/501c3`, `/pre501c3`) and the FFC Admin guide link are untouched.

## Verification
- Built `out/index.html` contains `/domains/`, `/free-charity-web-hosting/`, `/consulting/`.
- `npm run lint` 0 errors · `npm run build` OK · `npm test` 371 pass.

Fixes #351 · part of #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014W4FydyhP3fnKxSYJMG5eP)_