### PR TITLE
feat: add endowment CTA linking the homepage section to its page

### DIFF
--- a/src/components/home-page/Endowment-Features/index.tsx
+++ b/src/components/home-page/Endowment-Features/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import Link from 'next/link'
 import { SustainableFundingCard } from '@/components/ui/SustainableFundingCard'
 
 const Home: React.FC = () => {
@@ -33,6 +34,16 @@ const Home: React.FC = () => {
               title="Be a Champion for Change"
               text="By taking donations on our behalf, you become an essential part of our mission, creating a ripple effect of generosity and support."
             />
+          </div>
+          <div className="text-center mt-[40px]">
+            <Link
+              href="/free-for-charity-endowment-fund/"
+              className="inline-flex items-center gap-[8px] rounded-[27px] bg-[#2A6682] px-[36px] py-[16px] text-[20px] font-[500] text-white transition-colors hover:bg-[#22556b]"
+              data-font="lato-font"
+            >
+              Support the Endowment Fund
+              <span aria-hidden="true">→</span>
+            </Link>
           </div>
         </div>
       </div>

--- a/src/components/home-page/Endowment-Features/index.tsx
+++ b/src/components/home-page/Endowment-Features/index.tsx
@@ -41,7 +41,7 @@ const Home: React.FC = () => {
               className="inline-flex items-center gap-[8px] rounded-[27px] bg-[#2A6682] px-[36px] py-[16px] text-[20px] font-[500] text-white transition-colors hover:bg-[#22556b]"
               data-font="lato-font"
             >
-              Support the Endowment Fund
+              <span>Support the Endowment Fund</span>
               <span aria-hidden="true">→</span>
             </Link>
           </div>


### PR DESCRIPTION
## What
The homepage "Endowment Features" section described the endowment (four cards + the $1,000,000 goal) but had no path to the dedicated `/free-for-charity-endowment-fund/` page (which hosts the Zeffy endowment form). Adds a **"Support the Endowment Fund →"** CTA via `next/link`.

## Verification
- Built `out/index.html` contains `href="/free-for-charity-endowment-fund/"`.
- `npm run lint` 0 errors · `npm run build` OK · `npm test` 371 pass.

Fixes #352 · part of #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014W4FydyhP3fnKxSYJMG5eP)_