### PR TITLE
feat: deep-link homepage Volunteer / Support / Mission sections

### DIFF
--- a/src/components/home-page/Mission/index.tsx
+++ b/src/components/home-page/Mission/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import Link from 'next/link'
 import { assetPath } from '@/lib/assetPath'
 
 const index = () => {
@@ -39,6 +40,16 @@ const index = () => {
             <source src={assetPath('/videos/mission-video.mp4')} type="video/mp4" />
             Your browser does not support the video tag.
           </video>
+        </div>
+        <div className="mt-[40px] text-center">
+          <Link
+            href="/about-us/"
+            className="inline-flex items-center gap-[8px] text-[20px] font-[500] text-[#b35000] hover:underline"
+            data-font="lato-font"
+          >
+            Learn more about us
+            <span aria-hidden="true">→</span>
+          </Link>
         </div>
       </div>
 

--- a/src/components/home-page/Mission/index.tsx
+++ b/src/components/home-page/Mission/index.tsx
@@ -47,7 +47,7 @@ const index = () => {
             className="inline-flex items-center gap-[8px] text-[20px] font-[500] text-[#b35000] hover:underline"
             data-font="lato-font"
           >
-            Learn more about us
+            <span>Learn more about us</span>
             <span aria-hidden="true">→</span>
           </Link>
         </div>

--- a/src/components/home-page/SupportFreeForCharity/index.tsx
+++ b/src/components/home-page/SupportFreeForCharity/index.tsx
@@ -1,5 +1,6 @@
 import React, { CSSProperties, IframeHTMLAttributes } from 'react'
 import Image from 'next/image'
+import Link from 'next/link'
 import { assetPath } from '@/lib/assetPath'
 
 interface ExtendedIframeProps extends IframeHTMLAttributes<HTMLIFrameElement> {
@@ -47,6 +48,14 @@ const Index = () => {
               By donating you help drive our mission and allow us to support more charities with our
               Domain, Website, and other services.
             </p>
+            <Link
+              href="/donate/"
+              className="inline-flex items-center gap-[8px] mb-[20px] text-[20px] font-[500] text-[#b35000] hover:underline lg:justify-start justify-center"
+              data-font="lato-font"
+            >
+              See all donation campaigns
+              <span aria-hidden="true">→</span>
+            </Link>
             {/* Pointing hands image - flipped horizontally to point toward the form on the right */}
             <div className="w-full flex justify-center lg:justify-end">
               <div className="relative w-full max-w-[400px] aspect-[578/386]">

--- a/src/components/home-page/SupportFreeForCharity/index.tsx
+++ b/src/components/home-page/SupportFreeForCharity/index.tsx
@@ -53,7 +53,7 @@ const Index = () => {
               className="inline-flex items-center gap-[8px] mb-[20px] text-[20px] font-[500] text-[#b35000] hover:underline lg:justify-start justify-center"
               data-font="lato-font"
             >
-              See all donation campaigns
+              <span>See all donation campaigns</span>
               <span aria-hidden="true">→</span>
             </Link>
             {/* Pointing hands image - flipped horizontally to point toward the form on the right */}

--- a/src/components/home-page/Volunteer-with-Us/index.tsx
+++ b/src/components/home-page/Volunteer-with-Us/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Image from 'next/image'
+import Link from 'next/link'
 import { assetPath } from '@/lib/assetPath'
 
 const index = () => {
@@ -20,17 +21,15 @@ const index = () => {
           providing technical expertise, or supporting our programs, your contributions are
           invaluable to our mission.
         </p>
-        <a
-          href="https://www.idealist.org/en/nonprofit/356bfc8e2ae64f83beea4a4e677e99d7-free-for-charity-state-college#opportunities"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="w-[216px] h-[62px] top-[261px] left-[611px] rounded-[27px] 
-             flex items-center justify-center px-[32px] py-[18px] gap-[10px] 
+        <Link
+          href="/volunteer/"
+          className="w-[216px] h-[62px] top-[261px] left-[611px] rounded-[27px]
+             flex items-center justify-center px-[32px] py-[18px] gap-[10px]
              text-[#113563] mx-auto mt-[30px] bg-white text-[20px] font-[400] font-sans text-center"
           data-font="lato-font"
         >
           Volunteer
-        </a>
+        </Link>
 
         <Image
           src={assetPath('/Images/Volunteer-with-Us.webp')}

--- a/src/components/home-page/Volunteer-with-Us/index.tsx
+++ b/src/components/home-page/Volunteer-with-Us/index.tsx
@@ -23,7 +23,7 @@ const index = () => {
         </p>
         <Link
           href="/volunteer/"
-          className="w-[216px] h-[62px] top-[261px] left-[611px] rounded-[27px]
+          className="w-[216px] h-[62px] rounded-[27px]
              flex items-center justify-center px-[32px] py-[18px] gap-[10px]
              text-[#113563] mx-auto mt-[30px] bg-white text-[20px] font-[400] font-sans text-center"
           data-font="lato-font"


### PR DESCRIPTION
## What
Routes three more homepage sections into the site (all via `next/link`):

- **Volunteer-with-Us CTA**: external Idealist board → `/volunteer/`. The on-site page surfaces the **mandatory Core-Competencies prerequisite** *and* links out to Idealist, so this keeps the funnel on-site and stops the homepage from bypassing the required first step.
- **Support section**: add "See all donation campaigns →" → `/donate/` (the inline Zeffy form stays).
- **Mission section**: add "Learn more about us →" → `/about-us/`.

## Verification
- Built `out/index.html` emits the new `/volunteer/`, `/donate/`, `/about-us/` hrefs and no longer links Idealist directly.
- `npm run lint` 0 errors · `npm run build` OK · `npm test` 371 pass.

## Note
Swapping the volunteer CTA from the external Idealist board to the internal `/volunteer/` page is a small UX judgment (surfaces the prerequisite, keeps users on-site — the Idealist link still lives on `/volunteer`). Flag if you'd rather keep a direct Idealist link in the homepage section too.

Fixes #353 · part of #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014W4FydyhP3fnKxSYJMG5eP)_