### PR TITLE
feat: full volunteer-role taxonomy on /volunteer + Idealist posting kit

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -103,6 +103,13 @@ https://help.candid.org/**
 https://www.zeffy.com/**
 https://zeffy.com/**
 
+# Idealist volunteer postings (linked from /volunteer). The deep
+# /volunteer-opportunity/ URLs rate-limit/redirect CI crawlers even though
+# they return 200 in browsers and via curl; pin the host to avoid flaky
+# failures on the role "Apply on Idealist" links.
+https://www.idealist.org/**
+https://idealist.org/**
+
 # Microsoft Tech Community intermittently 403s CI crawlers (same bot-block as
 # privacy.microsoft.com / microsoft.com/nonprofits, already pinned). Real URL.
 https://techcommunity.microsoft.com/**

--- a/docs/volunteer-roles-and-idealist-postings.md
+++ b/docs/volunteer-roles-and-idealist-postings.md
@@ -90,7 +90,7 @@ split "Time Commitment" / "Commitment Details"):
 - **Participation Requirements / Skills:** GitHub + MFA, a password manager, an AI
   assistant, and a Microsoft 365 account (setup guide provided); interest in
   identity & security. No prior admin experience required.
-- **Benefits:** **MS-900 certification — FFC sponsors the exam**; real Microsoft 365
+- **Benefits:** **AB-900 certification (Microsoft 365 Copilot & Agent Administration Fundamentals) — FFC sponsors the exam**; real Microsoft 365
   tenant administration experience (MFA, Conditional Access, compliance);
   contributor-ladder progression.
 - **Description:** Run email, identity, and security for the charities FFC supports —

--- a/docs/volunteer-roles-and-idealist-postings.md
+++ b/docs/volunteer-roles-and-idealist-postings.md
@@ -1,0 +1,231 @@
+# Volunteer Roles — FFC Admin details, Idealist applications & posting kit
+
+This is the operational companion to the **Volunteer Roles** section on
+`/volunteer` (`src/components/volunteer/Free-For-Charity/index.tsx`). It covers:
+
+1. The role → links matrix (what's live vs. pending)
+2. A ready-to-paste **Idealist posting kit** (exact fields) for all 7 roles
+3. The **FFC Admin (ffcadmin.org) supporting docs** to create — including the
+   full content for the missing "Volunteer Recruiter & Onboarding Manager" page
+   and the cross-links to add
+
+> Roles and details are sourced from the live ffcadmin.org `/volunteer/<role>/`
+> pages and the two live Idealist postings. Where a field wasn't stated on the
+> source, the **house defaults** in §2 are used and flagged.
+
+---
+
+## 1. Role → links matrix
+
+| #   | Role                                         | FFC Admin details                                        | Idealist application                                                                                                                                                                                    | Status                 |
+| --- | -------------------------------------------- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- |
+| 1   | **Web Developer** ⭐                         | `https://ffcadmin.org/volunteer/web-developer/`          | [Charity Web Developer](https://www.idealist.org/en/volunteer-opportunity/c3d5f8b143224d4dbe7074d138a63370-charity-web-developer-state-college-pa-free-for-charity-state-college)                       | ✅ both live           |
+| 2   | Microsoft 365 Administrator                  | `https://ffcadmin.org/volunteer/microsoft-365-admin/`    | _general board_                                                                                                                                                                                         | ⚠️ needs posting       |
+| 3   | Google Workspace Administrator               | `https://ffcadmin.org/volunteer/google-workspace-admin/` | _general board_                                                                                                                                                                                         | ⚠️ needs posting       |
+| 4   | Data & Analytics                             | `https://ffcadmin.org/volunteer/data-analytics/`         | _general board_                                                                                                                                                                                         | ⚠️ needs posting       |
+| 5   | Canva Designer                               | `https://ffcadmin.org/volunteer/canva-designer/`         | _general board_                                                                                                                                                                                         | ⚠️ needs posting       |
+| 6   | Military Volunteers (MOVSM)                  | `https://ffcadmin.org/volunteer/military-volunteers/`    | _general board_                                                                                                                                                                                         | ⚠️ needs posting       |
+| 7   | **Volunteer Recruiter & Onboarding Manager** | _page pending — see §3_                                  | [Recruiter & Onboarding](https://www.idealist.org/en/volunteer-opportunity/685f715b4d294936898237da5d2649a6-volunteer-recruiter-and-onboarding-manager-state-college-pa-free-for-charity-state-college) | ⚠️ needs ffcadmin page |
+
+- ⭐ = the headline "most needed" ask (new-model AI web development).
+- **General board:** `https://www.idealist.org/en/nonprofit/356bfc8e2ae64f83beea4a4e677e99d7-free-for-charity-state-college#opportunities`
+- The `/volunteer` cards already point each role at its FFC Admin page (where it
+  exists) and its best available Idealist link. Once postings #2–#6 exist, swap
+  those cards' `idealistUrl` from `IDEALIST_BOARD` to the specific posting URL.
+
+---
+
+## 2. Idealist posting kit (exact fields, ready to paste)
+
+Idealist's **volunteer-opportunity** form uses these labels (verbatim from the
+two live FFC postings — note it's "Cause Areas", not "Areas of Focus", and a
+split "Time Commitment" / "Commitment Details"):
+
+`Title` · `Recurrence` · `Time Commitment` · `Commitment Details` ·
+`Volunteers Needed` · `Cause Areas` · `Benefits` · `Participation Requirements` ·
+`Requirements` · `Age Requirement` · `Long-term opportunity` · `Description` ·
+`Location` · `Associated Location` · application form ("Please fill out this form")
+
+### House defaults (apply to every role unless the role overrides them)
+
+| Field                                   | Default value                                                                                                                                  |
+| --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| Recurrence                              | Recurring                                                                                                                                      |
+| Time Commitment                         | A few hours per week                                                                                                                           |
+| Commitment Details                      | At least 100 hours per year; flexible, self-scheduled; long-term encouraged.                                                                   |
+| Volunteers Needed                       | Multiple                                                                                                                                       |
+| Age Requirement                         | 18 or older                                                                                                                                    |
+| Long-term opportunity                   | Yes                                                                                                                                            |
+| Location                                | Remote (United States) — FFC operates hybrid from State College, PA                                                                            |
+| Associated Location                     | Free For Charity, 301 Science Park Road, Suite 119, State College, PA 16803                                                                    |
+| Cause Areas                             | Science & Technology (+ role-specific below)                                                                                                   |
+| How to apply                            | Apply through Idealist                                                                                                                         |
+| Prerequisite (put in every Description) | "Before starting, all volunteers complete the free **Core Competencies Training** (our proving ground): https://freeforcharity.org/volunteer/" |
+
+---
+
+### Posting 1 — Web Developer _(live; values to keep/refresh)_
+
+- **Title:** Charity Web Developer
+- **Cause Areas:** Science & Technology; Community Development
+- **Participation Requirements / Skills:** Personal GitHub account with MFA;
+  willingness to use an AI coding agent (Claude / GitHub Copilot) responsibly and
+  review its output; basic web familiarity (HTML/CSS helpful); confidentiality of
+  FFC & charity data; contributions donated under an open-source license. Client
+  web-design / theme / SEO experience preferred.
+- **Benefits:** Hands-on Next.js + React + Tailwind + AI-agent workflow; GitHub
+  Foundations certification path; a portfolio of shipped charity sites; progression
+  on the FFC contributor ladder.
+- **Description:** Build and maintain free, fast, secure GitHub Pages websites for
+  nonprofits using AI development agents. You'll work the Issue → PR → merge flow
+  with your AI agent, keep sites accessible and secure, and help charity owners
+  hand off to self-service editing. _Prerequisite (above)._ Details:
+  https://ffcadmin.org/volunteer/web-developer/ · Training:
+  https://ffcadmin.org/training/web-developer/
+
+### Posting 2 — Microsoft 365 Administrator
+
+- **Title:** Microsoft 365 Administrator (Volunteer)
+- **Cause Areas:** Science & Technology
+- **Participation Requirements / Skills:** GitHub + MFA, a password manager, an AI
+  assistant, and a Microsoft 365 account (setup guide provided); interest in
+  identity & security. No prior admin experience required.
+- **Benefits:** **MS-900 certification — FFC sponsors the exam**; real Microsoft 365
+  tenant administration experience (MFA, Conditional Access, compliance);
+  contributor-ladder progression.
+- **Description:** Run email, identity, and security for the charities FFC supports —
+  provision mailboxes and licenses, enforce MFA and Conditional Access, and manage
+  compliance and data retention. _Prerequisite (above)._ Details:
+  https://ffcadmin.org/volunteer/microsoft-365-admin/
+
+### Posting 3 — Google Workspace Administrator
+
+- **Title:** Google Workspace Administrator (Volunteer)
+- **Cause Areas:** Science & Technology
+- **Participation Requirements / Skills:** GitHub + MFA, a password manager, an AI
+  assistant, and a Google Workspace account (setup guide provided). Personal account,
+  real name, MFA on.
+- **Benefits:** Google Workspace administration experience (users, groups, shared
+  drives, security controls); contributor-ladder progression.
+- **Description:** Manage Google Workspace for charities — provision users, groups,
+  and shared drives, configure security and sharing controls, and support charity
+  staff on Workspace tools, coordinating with the web and analytics roles.
+  _Prerequisite (above)._ Details:
+  https://ffcadmin.org/volunteer/google-workspace-admin/ · Training:
+  https://ffcadmin.org/training/google-workspace-admin/
+
+### Posting 4 — Data & Analytics
+
+- **Title:** Data & Analytics Volunteer
+- **Cause Areas:** Science & Technology
+- **Participation Requirements / Skills:** GitHub + MFA, a password manager, and an AI
+  assistant (setup guide provided); interest in analytics, dashboards, and SEO.
+- **Benefits:** Hands-on analytics (consent-gated tracking, dashboards, impact
+  reporting) and on-page SEO experience; contributor-ladder progression.
+- **Description:** Measure impact for the charities FFC supports — configure
+  consent-gated analytics and event tracking, build dashboards and impact reports,
+  maintain on-page SEO, and partner with web developers during site builds.
+  _Prerequisite (above)._ Details:
+  https://ffcadmin.org/volunteer/data-analytics/ · Training:
+  https://ffcadmin.org/training/data-analytics/
+
+### Posting 5 — Canva Designer
+
+- **Title:** Canva Designer Volunteer
+- **Cause Areas:** Science & Technology; Arts & Culture
+- **Participation Requirements / Skills:** GitHub + MFA, a password manager, an AI
+  assistant, and a Canva account (setup guide provided); an eye for clean,
+  on-brand design.
+- **Benefits:** Canva Pro access; Canva Design School courses; a brand-design
+  portfolio; contributor-ladder progression.
+- **Description:** Create brand identities and marketing materials for nonprofits
+  using Canva Pro — build complete brand kits and style guides, social media and
+  email templates, and print/marketing collateral. _Prerequisite (above)._ Details:
+  https://ffcadmin.org/volunteer/canva-designer/ · Training:
+  https://ffcadmin.org/canva-designer-path/
+
+### Posting 6 — Volunteer Recruiter & Onboarding Manager _(live; values to keep/refresh)_
+
+- **Title:** Volunteer Recruiter and Onboarding Manager (State College PA)
+- **Cause Areas:** Economic Development; Housing & Homelessness; Science & Technology
+- **Time Commitment / Commitment Details:** Full-time volunteer — **minimum 8 hours/week
+  for 10 months, or 800 hours/year** (heavier than the 100-hr house default).
+- **Requirements:** Self-motivated and able to work proactively; full-time volunteer
+  status; valid Driver's License; attend Orientation; 18+.
+- **Responsibilities (Description body):** Develop and refine volunteer opportunities
+  as new projects launch; set up opportunities in VolunteerMatch and on the website;
+  perform initial sorting of applicants to verify requirements; enter all contacts
+  into the charity CRM and other systems. _Prerequisite (above)._
+- **Languages:** English (posting also offered in Spanish and Portuguese).
+- **Location:** Remote, or the State College, PA office; volunteer must be in the US.
+
+### Posting 7 — Military Volunteers (MOVSM)
+
+- **Title:** Military Volunteers — earn MOVSM recognition
+- **Cause Areas:** Science & Technology; (add Veterans if available)
+- **Participation Requirements / Skills:** Open to service members and veterans;
+  contribute in any FFC role (development, administration, design, analytics) — bring
+  the skills for whichever track you pick.
+- **Benefits:** Eligibility toward the **Military Outstanding Volunteer Service Medal
+  (MOVSM)** plus all the benefits of your chosen role; hours tracked via self-report +
+  board attestation.
+- **Description:** Serving or a veteran? Contribute in any FFC role and track
+  qualifying volunteer hours toward MOVSM recognition. Text FFC at 520-222-8104 to find
+  your fit. _Prerequisite (above)._ Details:
+  https://ffcadmin.org/volunteer/military-volunteers/ · Eligibility:
+  https://ffcadmin.org/movsm/
+
+---
+
+## 3. FFC Admin (ffcadmin.org) supporting docs to create
+
+> These live in the **ffcadmin.org repository**, not this one. They're specified
+> here as ready-to-apply content; create them in that repo (this session's GitHub
+> access is scoped to `freeforcharity.org`).
+
+### 3a. NEW page — `/volunteer/volunteer-recruiter-onboarding/`
+
+Match the existing `/volunteer/<role>/` page pattern. Suggested content:
+
+- **Title:** Volunteer Recruiter & Onboarding Manager
+- **Summary:** Manage Free For Charity's volunteer pipeline — post opportunities,
+  screen applicants, and onboard new volunteers so every other role can grow.
+- **What you'll do:**
+  - Develop and refine volunteer opportunities as new projects launch
+  - Set up opportunities in VolunteerMatch and on the website
+  - Perform initial screening of applicants against role requirements
+  - Enter all contacts into the charity CRM and supporting systems
+- **Commitment:** Full-time volunteer — at least 8 hours/week for 10 months
+  (≈800 hours/year). Valid Driver's License; attend Orientation; 18+.
+- **Prerequisite & setup (match sibling pages):** Core Competencies Training first;
+  personal accounts with MFA (GitHub, password manager, AI assistant); confidentiality;
+  responsible AI use; unpaid / at-will / open-source contributions.
+- **Apply:** Link to the live Idealist posting (Recruiter & Onboarding) and back to
+  `https://freeforcharity.org/volunteer/`.
+
+### 3b. Cross-links to add on ffcadmin.org
+
+- [ ] Add the new Recruiter role to the **`/volunteer/` index** role grid.
+- [ ] Add it to **`/get-involved/`** if that page lists roles.
+- [ ] Confirm the Recruiter page links out to the Idealist posting + the FFC site
+      `/volunteer/`.
+
+### 3c. Fix the Microsoft 365 training-track slug
+
+The M365 volunteer page links to **`/training-plan/`**, while Web Developer / Google
+Workspace / Data & Analytics use **`/training/<slug>/`**. Either create
+`/training/microsoft-365-admin/` for consistency, or confirm `/training-plan/` is the
+intended target. (Canva intentionally uses `/canva-designer-path/`.)
+
+---
+
+## 4. When the 5 missing Idealist postings go live
+
+After creating postings #2–#6 on Idealist, update the role cards so each links to its
+specific posting instead of the general board:
+
+- In `src/components/volunteer/Free-For-Charity/index.tsx`, change the affected
+  entries in `volunteerRoles[]` from `idealistUrl: IDEALIST_BOARD` to the new
+  posting URL.
+- For the Recruiter card, set `adminPath` to the new ffcadmin page from §3a once it
+  exists (it's `null` today so the card shows only "Apply on Idealist").

--- a/src/components/volunteer/Free-For-Charity/index.tsx
+++ b/src/components/volunteer/Free-For-Charity/index.tsx
@@ -252,7 +252,7 @@ const Index = () => {
               <span className="sr-only">(opens FFC Admin in a new tab)</span>
             </a>
             <a
-              href={ffcAdminUrl('/training/web-developer/')}
+              href={ffcAdminUrl(adminLinks['web-developer-training'].newModel)}
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center gap-[8px] text-[16px] font-[600] text-white underline-offset-4 hover:underline"
@@ -408,7 +408,7 @@ const Index = () => {
         {/* Right Column - Button */}
         <div>
           <a
-            href="https://www.idealist.org/en/nonprofit/356bfc8e2ae64f83beea4a4e677e99d7-free-for-charity-state-college#opportunities"
+            href={IDEALIST_BOARD}
             className="inline-block px-6 py-3 text-[16px] font-bold text-white bg-[#0056B3] rounded-md text-center no-underline transition-colors duration-300 ease-in-out hover:bg-[#004494]"
             data-font="aria-font"
             target="_blank"

--- a/src/components/volunteer/Free-For-Charity/index.tsx
+++ b/src/components/volunteer/Free-For-Charity/index.tsx
@@ -208,9 +208,9 @@ const Index = () => {
             Our biggest need is building free charity websites with AI development agents&mdash;but
             we staff every part of a nonprofit&rsquo;s technology: Microsoft 365 and Google
             Workspace administration, data &amp; analytics, design, and the people who recruit and
-            onboard volunteers. Every role has full details on the FFC Admin portal and an
-            application on Idealist. Pick the one that fits you&mdash;then complete the Core
-            Competencies prerequisite above to get started.
+            onboard volunteers. Most roles have full details and a free training track on the FFC
+            Admin portal, and every one links to an application on Idealist. Pick the one that fits
+            you&mdash;then complete the Core Competencies prerequisite above to get started.
           </p>
         </div>
 

--- a/src/components/volunteer/Free-For-Charity/index.tsx
+++ b/src/components/volunteer/Free-For-Charity/index.tsx
@@ -1,5 +1,8 @@
 import React from 'react'
+import Link from 'next/link'
 import Transparentbtn from '@/components/ui/Transparentbtn'
+import AdminGuideLink from '@/components/ui/AdminGuideLink'
+import { adminLinks, ffcAdminUrl } from '@/data/admin-links'
 
 const Index = () => {
   return (
@@ -49,6 +52,113 @@ const Index = () => {
             text="Click Here to Start the Core Competencies Training"
             href="/ffc-volunteer-proving-ground-core-competencies/"
             color="#fff"
+          />
+        </div>
+      </div>
+
+      {/* Volunteer Roles We're Seeking */}
+      <div className="w-full max-w-[90%] md:max-w-[80%] mx-auto pt-[20px] pb-[20px]">
+        <div className="text-center mb-[40px]">
+          <h2 className="text-[28px] md:text-[36px] font-[700] leading-[40px] text-[#b35000] mb-[14px]">
+            Volunteer Roles We&rsquo;re Seeking
+          </h2>
+          <p
+            className="text-[18px] font-[500] leading-[28px] text-black max-w-[820px] mx-auto"
+            data-font="lato-font"
+          >
+            Our biggest need is building free charity websites with AI development agents.
+            Researchers and business analysts power the decisions behind that work. Pick the track
+            that fits you&mdash;then complete the Core Competencies prerequisite above to get
+            started.
+          </p>
+        </div>
+
+        {/* Featured: AI-assisted web development (our largest workflow) */}
+        <div className="bg-[#2A6682] rounded-[20px] p-8 text-white mb-[24px]">
+          <span className="inline-block text-[13px] font-[700] uppercase tracking-wider bg-white text-[#2A6682] px-[12px] py-[4px] rounded-full mb-[14px]">
+            Most needed
+          </span>
+          <h3 className="text-[26px] font-[700] mb-[10px]" data-font="lato-font">
+            AI-Assisted Web Developers
+          </h3>
+          <p className="text-[16px] font-[500] leading-[26px] mb-[20px]" data-font="lato-font">
+            Build fast, secure GitHub Pages websites for nonprofits using AI development agents
+            (Claude and GitHub Copilot) with Next.js, React, and Tailwind CSS. This is our largest
+            and fastest-growing volunteer workflow&mdash;every site you help ship puts another
+            charity online for free.
+          </p>
+          <div className="flex flex-wrap gap-[16px] items-center">
+            <Link
+              href="/free-training-programs/"
+              className="inline-flex items-center gap-[8px] rounded-[10px] bg-white px-[24px] py-[10px] text-[16px] font-[700] text-[#2A6682] transition-opacity hover:opacity-90"
+              data-font="lato-font"
+            >
+              <span>Start web developer training</span>
+              <span aria-hidden="true">&rarr;</span>
+            </Link>
+            <a
+              href={ffcAdminUrl(adminLinks['developer-environment-setup'].newModel)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-[8px] text-[16px] font-[600] text-white underline-offset-4 hover:underline"
+              data-font="lato-font"
+            >
+              <span>Set up your AI dev environment</span>
+              <span aria-hidden="true">&rarr;</span>
+              <span className="sr-only">(opens FFC Admin in a new tab)</span>
+            </a>
+          </div>
+        </div>
+
+        {/* Supporting tracks */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-[24px]">
+          <div className="bg-white rounded-[20px] shadow-[0px_2px_18px_0px_rgba(0,0,0,0.08)] p-6">
+            <h3 className="text-[22px] font-[700] text-[#1D6E90] mb-[10px]" data-font="lato-font">
+              Researchers
+            </h3>
+            <p
+              className="text-[16px] font-[500] leading-[26px] text-[#333] mb-[16px]"
+              data-font="lato-font"
+            >
+              Move beyond Google with research and data-control projects that charities use to
+              decide how best to use their resources&mdash;skills you can use from anywhere.
+            </p>
+            <Link
+              href="/free-training-programs/"
+              className="inline-flex items-center gap-[8px] text-[16px] font-[600] text-[#b35000] hover:underline"
+              data-font="lato-font"
+            >
+              <span>Explore the research track</span>
+              <span aria-hidden="true">&rarr;</span>
+            </Link>
+          </div>
+          <div className="bg-white rounded-[20px] shadow-[0px_2px_18px_0px_rgba(0,0,0,0.08)] p-6">
+            <h3 className="text-[22px] font-[700] text-[#1D6E90] mb-[10px]" data-font="lato-font">
+              Business Analysts
+            </h3>
+            <p
+              className="text-[16px] font-[500] leading-[26px] text-[#333] mb-[16px]"
+              data-font="lato-font"
+            >
+              Compare products, services, and vendors to a professional standard so nonprofits spend
+              on their mission instead of overhead.
+            </p>
+            <Link
+              href="/free-training-programs/"
+              className="inline-flex items-center gap-[8px] text-[16px] font-[600] text-[#b35000] hover:underline"
+              data-font="lato-font"
+            >
+              <span>Explore the analyst track</span>
+              <span aria-hidden="true">&rarr;</span>
+            </Link>
+          </div>
+        </div>
+
+        <div className="max-w-[720px] mx-auto mt-[28px]">
+          <AdminGuideLink
+            href={ffcAdminUrl(adminLinks['contributor-ladder'].newModel)}
+            label="See the FFC contributor ladder"
+            description="Wondering how volunteers grow into bigger roles? Follow the contributor ladder on the FFC Admin portal."
           />
         </div>
       </div>

--- a/src/components/volunteer/Free-For-Charity/index.tsx
+++ b/src/components/volunteer/Free-For-Charity/index.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import Transparentbtn from '@/components/ui/Transparentbtn'
-import AdminGuideLink from '@/components/ui/AdminGuideLink'
 import { adminLinks, ffcAdminUrl } from '@/data/admin-links'
 
 // Free For Charity's Idealist presence. The general board lists every live
@@ -14,41 +13,55 @@ const IDEALIST_RECRUITER =
 
 // Established volunteer roles beyond the featured Web Developer track. Each
 // links to its FFC Admin detail page (`adminPath`, null where one doesn't exist
-// yet) and an Idealist application (`idealistUrl` — a specific posting where
-// one exists, otherwise the general board until a posting is created).
-const volunteerRoles: {
+// yet), a free training track (`trainingPath`, null for non-track roles), and an
+// Idealist application (`idealistUrl` — a specific posting where one exists,
+// otherwise the general board until a posting is created). `group` splits the
+// skill-based technical tracks from the cross-cutting / operations roles.
+type VolunteerRole = {
   title: string
   blurb: string
   adminPath: string | null
+  trainingPath: string | null
   idealistUrl: string
-}[] = [
+  group: 'tech' | 'other'
+}
+
+const volunteerRoles: VolunteerRole[] = [
   {
     title: 'Microsoft 365 Administrator',
     blurb:
       'Run email, identity, and security for charities—and earn your MS-900 (FFC sponsors the exam).',
     adminPath: '/volunteer/microsoft-365-admin/',
+    trainingPath: '/training-plan/',
     idealistUrl: IDEALIST_BOARD,
+    group: 'tech',
   },
   {
     title: 'Google Workspace Administrator',
     blurb:
       'Provision users, drives, and security controls, and support charity staff across Google Workspace.',
     adminPath: '/volunteer/google-workspace-admin/',
+    trainingPath: '/training/google-workspace-admin/',
     idealistUrl: IDEALIST_BOARD,
+    group: 'tech',
   },
   {
     title: 'Data & Analytics',
     blurb:
       'Measure impact with consent-gated analytics, dashboards, and on-page SEO alongside the web team.',
     adminPath: '/volunteer/data-analytics/',
+    trainingPath: '/training/data-analytics/',
     idealistUrl: IDEALIST_BOARD,
+    group: 'tech',
   },
   {
     title: 'Canva Designer',
     blurb:
       'Create brand kits, social templates, and marketing collateral for nonprofits with Canva Pro.',
     adminPath: '/volunteer/canva-designer/',
+    trainingPath: '/canva-designer-path/',
     idealistUrl: IDEALIST_BOARD,
+    group: 'tech',
   },
   {
     title: 'Volunteer Recruiter & Onboarding Manager',
@@ -56,18 +69,81 @@ const volunteerRoles: {
       'Manage FFC’s volunteer pipeline: post opportunities, screen applicants, and onboard new volunteers.',
     // FFC Admin detail page pending; the role details live on the Idealist posting for now.
     adminPath: null,
+    trainingPath: null,
     idealistUrl: IDEALIST_RECRUITER,
+    group: 'other',
   },
   {
     title: 'Military Volunteers (MOVSM)',
     blurb:
       'Serving or a veteran? Contribute in any FFC role and track hours toward MOVSM recognition.',
     adminPath: '/volunteer/military-volunteers/',
+    trainingPath: null,
     idealistUrl: IDEALIST_BOARD,
+    group: 'other',
   },
 ]
 
 const Index = () => {
+  const techRoles = volunteerRoles.filter((r) => r.group === 'tech')
+  const otherRoles = volunteerRoles.filter((r) => r.group === 'other')
+
+  const roleCard = (role: VolunteerRole) => (
+    <div
+      key={role.title}
+      className="flex flex-col bg-white rounded-[20px] shadow-[0px_2px_18px_0px_rgba(0,0,0,0.08)] p-6"
+    >
+      <h4 className="text-[22px] font-[700] text-[#1D6E90] mb-[10px]" data-font="lato-font">
+        {role.title}
+      </h4>
+      <p
+        className="text-[16px] font-[500] leading-[26px] text-[#333] mb-[18px] grow"
+        data-font="lato-font"
+      >
+        {role.blurb}
+      </p>
+      <div className="flex flex-wrap gap-x-[20px] gap-y-[8px]">
+        {role.adminPath ? (
+          <a
+            href={ffcAdminUrl(role.adminPath)}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-[6px] text-[15px] font-[600] text-[#1D6E90] hover:underline"
+            data-font="lato-font"
+          >
+            <span>Position details</span>
+            <span aria-hidden="true">&rarr;</span>
+            <span className="sr-only">on FFC Admin (opens in a new tab)</span>
+          </a>
+        ) : null}
+        {role.trainingPath ? (
+          <a
+            href={ffcAdminUrl(role.trainingPath)}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-[6px] text-[15px] font-[600] text-[#1D6E90] hover:underline"
+            data-font="lato-font"
+          >
+            <span>Free training</span>
+            <span aria-hidden="true">&rarr;</span>
+            <span className="sr-only">on FFC Admin (opens in a new tab)</span>
+          </a>
+        ) : null}
+        <a
+          href={role.idealistUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-[6px] text-[15px] font-[600] text-[#b35000] hover:underline"
+          data-font="lato-font"
+        >
+          <span>Apply on Idealist</span>
+          <span aria-hidden="true">&rarr;</span>
+          <span className="sr-only">(opens Idealist in a new tab)</span>
+        </a>
+      </div>
+    </div>
+  )
+
   return (
     <div className="w-full pt-[60px] pb-[40px] bg-[#FCFCFC]">
       {/* Main Content Container */}
@@ -176,6 +252,17 @@ const Index = () => {
               <span className="sr-only">(opens FFC Admin in a new tab)</span>
             </a>
             <a
+              href={ffcAdminUrl('/training/web-developer/')}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-[8px] text-[16px] font-[600] text-white underline-offset-4 hover:underline"
+              data-font="lato-font"
+            >
+              <span>Free web developer training</span>
+              <span aria-hidden="true">&rarr;</span>
+              <span className="sr-only">(opens FFC Admin in a new tab)</span>
+            </a>
+            <a
               href={ffcAdminUrl(adminLinks['developer-environment-setup'].newModel)}
               target="_blank"
               rel="noopener noreferrer"
@@ -189,58 +276,94 @@ const Index = () => {
           </div>
         </div>
 
-        {/* The rest of the established roles */}
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-[24px]">
-          {volunteerRoles.map((role) => (
-            <div
-              key={role.title}
-              className="flex flex-col bg-white rounded-[20px] shadow-[0px_2px_18px_0px_rgba(0,0,0,0.08)] p-6"
-            >
-              <h3 className="text-[22px] font-[700] text-[#1D6E90] mb-[10px]" data-font="lato-font">
-                {role.title}
-              </h3>
-              <p
-                className="text-[16px] font-[500] leading-[26px] text-[#333] mb-[18px] grow"
-                data-font="lato-font"
-              >
-                {role.blurb}
-              </p>
-              <div className="flex flex-wrap gap-x-[20px] gap-y-[8px]">
-                {role.adminPath ? (
-                  <a
-                    href={ffcAdminUrl(role.adminPath)}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center gap-[6px] text-[15px] font-[600] text-[#1D6E90] hover:underline"
-                    data-font="lato-font"
-                  >
-                    <span>Position details on FFC Admin</span>
-                    <span aria-hidden="true">&rarr;</span>
-                    <span className="sr-only">(opens FFC Admin in a new tab)</span>
-                  </a>
-                ) : null}
-                <a
-                  href={role.idealistUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-[6px] text-[15px] font-[600] text-[#b35000] hover:underline"
-                  data-font="lato-font"
-                >
-                  <span>Apply on Idealist</span>
-                  <span aria-hidden="true">&rarr;</span>
-                  <span className="sr-only">(opens Idealist in a new tab)</span>
-                </a>
-              </div>
-            </div>
-          ))}
-        </div>
+        {/* Technical tracks */}
+        <h3
+          className="text-[22px] md:text-[26px] font-[700] text-[#333] mb-[16px] mt-[8px]"
+          data-font="lato-font"
+        >
+          Build &amp; run charity technology
+        </h3>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-[24px]">{techRoles.map(roleCard)}</div>
 
-        <div className="max-w-[720px] mx-auto mt-[28px]">
-          <AdminGuideLink
-            href={ffcAdminUrl(adminLinks['contributor-ladder'].newModel)}
-            label="See the FFC contributor ladder"
-            description="Wondering how volunteers grow into bigger roles? Follow the contributor ladder on the FFC Admin portal."
-          />
+        {/* More ways to serve */}
+        <h3
+          className="text-[22px] md:text-[26px] font-[700] text-[#333] mb-[16px] mt-[40px]"
+          data-font="lato-font"
+        >
+          More ways to serve
+        </h3>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-[24px]">{otherRoles.map(roleCard)}</div>
+
+        {/* Grow with us — certifications, CE credits, advancement */}
+        <h3
+          className="text-[22px] md:text-[26px] font-[700] text-[#333] mb-[6px] mt-[44px]"
+          data-font="lato-font"
+        >
+          Grow with us
+        </h3>
+        <p
+          className="text-[16px] font-[500] leading-[26px] text-[#555] mb-[20px] max-w-[820px]"
+          data-font="lato-font"
+        >
+          Volunteering at Free For Charity is also a career on-ramp: earn industry certifications,
+          log professional continuing-education credits for your hours, and advance as you
+          contribute.
+        </p>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-[24px]">
+          <div className="rounded-[20px] border border-[#e5e5e5] bg-white p-6">
+            <h4 className="text-[18px] font-[700] text-[#1D6E90] mb-[8px]" data-font="lato-font">
+              Free certifications
+            </h4>
+            <p className="text-[15px] font-[500] leading-[24px] text-[#333]" data-font="lato-font">
+              Work toward MS-900 (FFC sponsors the exam), GitHub Foundations, and Canva Design
+              School credentials while you serve.
+            </p>
+          </div>
+          <div className="flex flex-col rounded-[20px] border border-[#e5e5e5] bg-white p-6">
+            <h4 className="text-[18px] font-[700] text-[#1D6E90] mb-[8px]" data-font="lato-font">
+              Professional CE credits
+            </h4>
+            <p
+              className="text-[15px] font-[500] leading-[24px] text-[#333] mb-[12px] grow"
+              data-font="lato-font"
+            >
+              Log your volunteer hours as ISC2 CPEs, PMI PDUs, CompTIA CEUs, or CFRE points.
+            </p>
+            <a
+              href={ffcAdminUrl('/continuing-education/')}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-[6px] text-[15px] font-[600] text-[#9a3412] hover:underline"
+              data-font="lato-font"
+            >
+              <span>See the credits you can earn</span>
+              <span aria-hidden="true">&rarr;</span>
+              <span className="sr-only">on FFC Admin (opens in a new tab)</span>
+            </a>
+          </div>
+          <div className="flex flex-col rounded-[20px] border border-[#e5e5e5] bg-white p-6">
+            <h4 className="text-[18px] font-[700] text-[#1D6E90] mb-[8px]" data-font="lato-font">
+              A path to grow
+            </h4>
+            <p
+              className="text-[15px] font-[500] leading-[24px] text-[#333] mb-[12px] grow"
+              data-font="lato-font"
+            >
+              Advance the contributor ladder: Contributor &rarr; Intern &rarr; Mentor &rarr;
+              Maintainer.
+            </p>
+            <a
+              href={ffcAdminUrl(adminLinks['contributor-ladder'].newModel)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-[6px] text-[15px] font-[600] text-[#9a3412] hover:underline"
+              data-font="lato-font"
+            >
+              <span>See the contributor ladder</span>
+              <span aria-hidden="true">&rarr;</span>
+              <span className="sr-only">on FFC Admin (opens in a new tab)</span>
+            </a>
+          </div>
         </div>
       </div>
 
@@ -291,7 +414,7 @@ const Index = () => {
             target="_blank"
             rel="noopener noreferrer"
           >
-            View Our Volunteer Opportunities on Idealist
+            Browse all volunteer opportunities on Idealist
           </a>
         </div>
       </div>

--- a/src/components/volunteer/Free-For-Charity/index.tsx
+++ b/src/components/volunteer/Free-For-Charity/index.tsx
@@ -30,7 +30,7 @@ const volunteerRoles: VolunteerRole[] = [
   {
     title: 'Microsoft 365 Administrator',
     blurb:
-      'Run email, identity, and security for charities—and earn your MS-900 (FFC sponsors the exam).',
+      'Run email, identity, and security for charities—and earn the AB-900 Microsoft 365 fundamentals certification (FFC sponsors the exam).',
     adminPath: '/volunteer/microsoft-365-admin/',
     trainingPath: '/training-plan/',
     idealistUrl: IDEALIST_BOARD,
@@ -315,8 +315,8 @@ const Index = () => {
               Free certifications
             </h4>
             <p className="text-[15px] font-[500] leading-[24px] text-[#333]" data-font="lato-font">
-              Work toward MS-900 (FFC sponsors the exam), GitHub Foundations, and Canva Design
-              School credentials while you serve.
+              Work toward AB-900 (Microsoft 365 Copilot &amp; agent fundamentals; FFC sponsors the
+              exam), GitHub Foundations, and Canva Design School credentials while you serve.
             </p>
           </div>
           <div className="flex flex-col rounded-[20px] border border-[#e5e5e5] bg-white p-6">

--- a/src/components/volunteer/Free-For-Charity/index.tsx
+++ b/src/components/volunteer/Free-For-Charity/index.tsx
@@ -1,8 +1,71 @@
 import React from 'react'
-import Link from 'next/link'
 import Transparentbtn from '@/components/ui/Transparentbtn'
 import AdminGuideLink from '@/components/ui/AdminGuideLink'
 import { adminLinks, ffcAdminUrl } from '@/data/admin-links'
+
+// Free For Charity's Idealist presence. The general board lists every live
+// opportunity; specific postings are linked where they exist.
+const IDEALIST_BOARD =
+  'https://www.idealist.org/en/nonprofit/356bfc8e2ae64f83beea4a4e677e99d7-free-for-charity-state-college#opportunities'
+const IDEALIST_WEB_DEVELOPER =
+  'https://www.idealist.org/en/volunteer-opportunity/c3d5f8b143224d4dbe7074d138a63370-charity-web-developer-state-college-pa-free-for-charity-state-college'
+const IDEALIST_RECRUITER =
+  'https://www.idealist.org/en/volunteer-opportunity/685f715b4d294936898237da5d2649a6-volunteer-recruiter-and-onboarding-manager-state-college-pa-free-for-charity-state-college'
+
+// Established volunteer roles beyond the featured Web Developer track. Each
+// links to its FFC Admin detail page (`adminPath`, null where one doesn't exist
+// yet) and an Idealist application (`idealistUrl` — a specific posting where
+// one exists, otherwise the general board until a posting is created).
+const volunteerRoles: {
+  title: string
+  blurb: string
+  adminPath: string | null
+  idealistUrl: string
+}[] = [
+  {
+    title: 'Microsoft 365 Administrator',
+    blurb:
+      'Run email, identity, and security for charities—and earn your MS-900 (FFC sponsors the exam).',
+    adminPath: '/volunteer/microsoft-365-admin/',
+    idealistUrl: IDEALIST_BOARD,
+  },
+  {
+    title: 'Google Workspace Administrator',
+    blurb:
+      'Provision users, drives, and security controls, and support charity staff across Google Workspace.',
+    adminPath: '/volunteer/google-workspace-admin/',
+    idealistUrl: IDEALIST_BOARD,
+  },
+  {
+    title: 'Data & Analytics',
+    blurb:
+      'Measure impact with consent-gated analytics, dashboards, and on-page SEO alongside the web team.',
+    adminPath: '/volunteer/data-analytics/',
+    idealistUrl: IDEALIST_BOARD,
+  },
+  {
+    title: 'Canva Designer',
+    blurb:
+      'Create brand kits, social templates, and marketing collateral for nonprofits with Canva Pro.',
+    adminPath: '/volunteer/canva-designer/',
+    idealistUrl: IDEALIST_BOARD,
+  },
+  {
+    title: 'Volunteer Recruiter & Onboarding Manager',
+    blurb:
+      'Manage FFC’s volunteer pipeline: post opportunities, screen applicants, and onboard new volunteers.',
+    // FFC Admin detail page pending; the role details live on the Idealist posting for now.
+    adminPath: null,
+    idealistUrl: IDEALIST_RECRUITER,
+  },
+  {
+    title: 'Military Volunteers (MOVSM)',
+    blurb:
+      'Serving or a veteran? Contribute in any FFC role and track hours toward MOVSM recognition.',
+    adminPath: '/volunteer/military-volunteers/',
+    idealistUrl: IDEALIST_BOARD,
+  },
+]
 
 const Index = () => {
   return (
@@ -66,10 +129,12 @@ const Index = () => {
             className="text-[18px] font-[500] leading-[28px] text-black max-w-[820px] mx-auto"
             data-font="lato-font"
           >
-            Our biggest need is building free charity websites with AI development agents.
-            Researchers and business analysts power the decisions behind that work. Pick the track
-            that fits you&mdash;then complete the Core Competencies prerequisite above to get
-            started.
+            Our biggest need is building free charity websites with AI development agents&mdash;but
+            we staff every part of a nonprofit&rsquo;s technology: Microsoft 365 and Google
+            Workspace administration, data &amp; analytics, design, and the people who recruit and
+            onboard volunteers. Every role has full details on the FFC Admin portal and an
+            application on Idealist. Pick the one that fits you&mdash;then complete the Core
+            Competencies prerequisite above to get started.
           </p>
         </div>
 
@@ -87,15 +152,29 @@ const Index = () => {
             and fastest-growing volunteer workflow&mdash;every site you help ship puts another
             charity online for free.
           </p>
-          <div className="flex flex-wrap gap-[16px] items-center">
-            <Link
-              href="/free-training-programs/"
+          <div className="flex flex-wrap gap-x-[24px] gap-y-[12px] items-center">
+            <a
+              href={IDEALIST_WEB_DEVELOPER}
+              target="_blank"
+              rel="noopener noreferrer"
               className="inline-flex items-center gap-[8px] rounded-[10px] bg-white px-[24px] py-[10px] text-[16px] font-[700] text-[#2A6682] transition-opacity hover:opacity-90"
               data-font="lato-font"
             >
-              <span>Start web developer training</span>
+              <span>Apply on Idealist</span>
               <span aria-hidden="true">&rarr;</span>
-            </Link>
+              <span className="sr-only">(opens Idealist in a new tab)</span>
+            </a>
+            <a
+              href={ffcAdminUrl('/volunteer/web-developer/')}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-[8px] text-[16px] font-[600] text-white underline-offset-4 hover:underline"
+              data-font="lato-font"
+            >
+              <span>Position details on FFC Admin</span>
+              <span aria-hidden="true">&rarr;</span>
+              <span className="sr-only">(opens FFC Admin in a new tab)</span>
+            </a>
             <a
               href={ffcAdminUrl(adminLinks['developer-environment-setup'].newModel)}
               target="_blank"
@@ -110,48 +189,50 @@ const Index = () => {
           </div>
         </div>
 
-        {/* Supporting tracks */}
+        {/* The rest of the established roles */}
         <div className="grid grid-cols-1 md:grid-cols-2 gap-[24px]">
-          <div className="bg-white rounded-[20px] shadow-[0px_2px_18px_0px_rgba(0,0,0,0.08)] p-6">
-            <h3 className="text-[22px] font-[700] text-[#1D6E90] mb-[10px]" data-font="lato-font">
-              Researchers
-            </h3>
-            <p
-              className="text-[16px] font-[500] leading-[26px] text-[#333] mb-[16px]"
-              data-font="lato-font"
+          {volunteerRoles.map((role) => (
+            <div
+              key={role.title}
+              className="flex flex-col bg-white rounded-[20px] shadow-[0px_2px_18px_0px_rgba(0,0,0,0.08)] p-6"
             >
-              Move beyond Google with research and data-control projects that charities use to
-              decide how best to use their resources&mdash;skills you can use from anywhere.
-            </p>
-            <Link
-              href="/free-training-programs/"
-              className="inline-flex items-center gap-[8px] text-[16px] font-[600] text-[#b35000] hover:underline"
-              data-font="lato-font"
-            >
-              <span>Explore the research track</span>
-              <span aria-hidden="true">&rarr;</span>
-            </Link>
-          </div>
-          <div className="bg-white rounded-[20px] shadow-[0px_2px_18px_0px_rgba(0,0,0,0.08)] p-6">
-            <h3 className="text-[22px] font-[700] text-[#1D6E90] mb-[10px]" data-font="lato-font">
-              Business Analysts
-            </h3>
-            <p
-              className="text-[16px] font-[500] leading-[26px] text-[#333] mb-[16px]"
-              data-font="lato-font"
-            >
-              Compare products, services, and vendors to a professional standard so nonprofits spend
-              on their mission instead of overhead.
-            </p>
-            <Link
-              href="/free-training-programs/"
-              className="inline-flex items-center gap-[8px] text-[16px] font-[600] text-[#b35000] hover:underline"
-              data-font="lato-font"
-            >
-              <span>Explore the analyst track</span>
-              <span aria-hidden="true">&rarr;</span>
-            </Link>
-          </div>
+              <h3 className="text-[22px] font-[700] text-[#1D6E90] mb-[10px]" data-font="lato-font">
+                {role.title}
+              </h3>
+              <p
+                className="text-[16px] font-[500] leading-[26px] text-[#333] mb-[18px] grow"
+                data-font="lato-font"
+              >
+                {role.blurb}
+              </p>
+              <div className="flex flex-wrap gap-x-[20px] gap-y-[8px]">
+                {role.adminPath ? (
+                  <a
+                    href={ffcAdminUrl(role.adminPath)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-[6px] text-[15px] font-[600] text-[#1D6E90] hover:underline"
+                    data-font="lato-font"
+                  >
+                    <span>Position details on FFC Admin</span>
+                    <span aria-hidden="true">&rarr;</span>
+                    <span className="sr-only">(opens FFC Admin in a new tab)</span>
+                  </a>
+                ) : null}
+                <a
+                  href={role.idealistUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-[6px] text-[15px] font-[600] text-[#b35000] hover:underline"
+                  data-font="lato-font"
+                >
+                  <span>Apply on Idealist</span>
+                  <span aria-hidden="true">&rarr;</span>
+                  <span className="sr-only">(opens Idealist in a new tab)</span>
+                </a>
+              </div>
+            </div>
+          ))}
         </div>
 
         <div className="max-w-[720px] mx-auto mt-[28px]">


### PR DESCRIPTION
## What
Turns `/volunteer` into the real recruiting hub: the seven volunteer roles **established on FFC Admin**, grouped and surfaced with the new-model headline ask up front.

### Cards (7 roles, grouped)
Each role card shows **up to three actions** — *Position details* · *Free training* · *Apply on Idealist* (Details/Training appear only where the FFC Admin page/track exists; every role always has an Apply link).

- **Featured "Most needed" — Web Developer** (AI dev with Claude + GitHub Copilot): Apply on Idealist (live posting) + Position details + Free web developer training + Set up your AI dev environment.
- **Build & run charity technology:** Microsoft 365 Administrator, Google Workspace Administrator, Data & Analytics, Canva Designer — each with Details + Free training + Apply.
- **More ways to serve:** Volunteer Recruiter & Onboarding Manager (live Idealist posting; FFC Admin page pending → no Details link), Military Volunteers (MOVSM).

Roles without a dedicated Idealist posting fall back to the general FFC Idealist board until one exists.

### "Grow with us" benefits strip
Three cards surfacing FFC's career on-ramp: **free certifications** (MS-900 sponsored, GitHub Foundations, Canva Design School), **professional CE credits** (ISC2 CPE / PMI PDU / CompTIA CEU / CFRE points → `ffcadmin.org/continuing-education/`), and the **contributor ladder**.

The mandatory Core-Competencies prerequisite stays front-and-center above the grid.

## Idealist posting kit + ffcadmin hand-off
Adds **`docs/volunteer-roles-and-idealist-postings.md`**: the role → links matrix, a **ready-to-paste Idealist posting kit** (exact Idealist field labels with values filled for all 7 roles), and the **FFC Admin supporting docs to create** (the missing Recruiter page content, `/volunteer/` + `/get-involved/` cross-links, and the M365 training-slug fix). The ffcadmin repo is out of scope for this session, so it's delivered as ready-to-apply content.

## Notes / follow-ups
- Pinned `idealist.org/**` in `.lycheeignore` (deep posting URLs rate-limit CI crawlers though they 200 in browsers/curl — mirrors the Zeffy pin).
- Once postings #2–#6 go live, repoint those cards' `idealistUrl` from `IDEALIST_BOARD` to the specific URL (documented in the doc §4).

## Verification
All ffcadmin.org links verified **200**; built `out/volunteer/index.html` renders the grouped roles, training/CE/ladder links, and the two specific Idealist postings + general board. `npm run lint` 0 errors · `npm run build` OK · `npm test` 371 pass.

Fixes #358 · refs #353, #357

🤖 Generated with [Claude Code](https://claude.com/claude-code)