### PR TITLE
fix: replace retired MS-900 cert with AB-900 (proving ground + FAQs)

### DIFF
--- a/src/components/ffc-volunteer-proving-ground-core-competencies/ContentSection/index.tsx
+++ b/src/components/ffc-volunteer-proving-ground-core-competencies/ContentSection/index.tsx
@@ -68,7 +68,8 @@ export default function Home() {
           </li>
           <li>
             <a href="#module3" className="text-blue-600 leading-[28px] underline">
-              <span className="font-[700]">Module 3:</span> MS-900 Microsoft 365 Fundamentals
+              <span className="font-[700]">Module 3:</span> AB-900 Microsoft 365 Copilot and Agent
+              Administration Fundamentals
             </a>{' '}
             (12 - 16 Hours)
           </li>

--- a/src/components/ffc-volunteer-proving-ground-core-competencies/Modules-section/index.tsx
+++ b/src/components/ffc-volunteer-proving-ground-core-competencies/Modules-section/index.tsx
@@ -178,11 +178,14 @@ const index = () => {
         </div>
       </Modulecard>
 
-      <Modulecard title="Module 3: MS-900 Microsoft 365 Fundamentals" id="module3">
+      <Modulecard
+        title="Module 3: AB-900 Microsoft 365 Copilot and Agent Administration Fundamentals"
+        id="module3"
+      >
         <p className="font-[500]">
-          <span className="font-[700]">Objective:</span> To gain a foundational knowledge of
-          Microsoft 365 cloud services, including its apps, security, compliance, and pricing
-          models.
+          <span className="font-[700]">Objective:</span> To gain foundational knowledge of Microsoft
+          365 cloud services&mdash;its core apps, security, and compliance&mdash;plus the
+          administration of Microsoft 365 Copilot and AI agents.
         </p>
 
         <p className="mt-6 font-[500]">
@@ -203,23 +206,23 @@ const index = () => {
         <ul className="list-disc list-inside space-y-2 text-gray-700 font-[500]">
           <li>
             <a
-              href="https://learn.microsoft.com/en-us/training/courses/ms-900t01"
+              href="https://learn.microsoft.com/en-us/credentials/certifications/exams/ab-900"
               target="_blank"
               rel="noopener noreferrer"
               className="text-blue-600 underline"
             >
-              Microsoft Learn Self-Paced Course (Official)
+              Microsoft Learn Training &amp; Exam Page (Official)
             </a>{' '}
-            - This is the primary, self-paced learning path provided directly by Microsoft.
+            - The official AB-900 page with Microsoft&rsquo;s recommended self-paced learning paths.
           </li>
           <li>
             <a
-              href="https://learn.microsoft.com/en-us/credentials/certifications/resources/study-guides/ms-900"
+              href="https://learn.microsoft.com/en-us/credentials/certifications/resources/study-guides/ab-900"
               target="_blank"
               rel="noopener noreferrer"
               className="text-blue-600 underline"
             >
-              Official MS-900 Study Guide
+              Official AB-900 Study Guide
             </a>{' '}
             - A detailed guide from Microsoft that outlines all exam objectives.
           </li>

--- a/src/components/home-page/FrequentlyAskedQuestions/index.tsx
+++ b/src/components/home-page/FrequentlyAskedQuestions/index.tsx
@@ -50,7 +50,7 @@ const index = () => {
               without staff input.
             </p>
             <p>
-              For our training programs we help charities navigate through the MS-900 Microsoft
+              For our training programs we help charities navigate through the AB-900 Microsoft 365
               training and certification program while pursuing their Microsoft 365 Grants. We
               further provide access to the Divi and WPMUDEV website design and maintenance product
               that each come with their own vendor provided training.

--- a/src/components/home-page/FrequentlyAskedQuestions/index.tsx
+++ b/src/components/home-page/FrequentlyAskedQuestions/index.tsx
@@ -50,10 +50,10 @@ const index = () => {
               without staff input.
             </p>
             <p>
-              For our training programs we help charities navigate through the AB-900 Microsoft 365
-              training and certification program while pursuing their Microsoft 365 Grants. We
-              further provide access to the Divi and WPMUDEV website design and maintenance product
-              that each come with their own vendor provided training.
+              For our training programs we help charities navigate through the AB-900 (Microsoft 365
+              Copilot and Agent Administration Fundamentals) certification program while pursuing
+              their Microsoft 365 Grants. We further provide access to the Divi and WPMUDEV website
+              design and maintenance product that each come with their own vendor provided training.
             </p>
           </FrequentlyAskedQuestions>
 

--- a/src/data/faqs.ts
+++ b/src/data/faqs.ts
@@ -17,7 +17,7 @@ FFC is also employing a premium subscription to volunteer match to source additi
     question: "What are the organization's capabilities for doing this?",
     answer: `We already have the accounts set up in eNOM to provide enterprise level domain procurement and by using WHMCS with coupon codes specifically for our 501c3 and pre 501c3 organizations we can provision full hosting and domain names automatically without staff input.
 
-For our training programs we help charities navigate through the AB-900 Microsoft 365 training and certification program while pursuing their "Microsoft 365 Grants". We further provide access to the Divi and WPMUDEV website design and maintenance product that each come with their own vendor provided training.`,
+For our training programs we help charities navigate through the AB-900 (Microsoft 365 Copilot and Agent Administration Fundamentals) certification program while pursuing their "Microsoft 365 Grants". We further provide access to the Divi and WPMUDEV website design and maintenance product that each come with their own vendor provided training.`,
   },
   {
     question: "What have and haven't they accomplished so far?",

--- a/src/data/faqs.ts
+++ b/src/data/faqs.ts
@@ -17,7 +17,7 @@ FFC is also employing a premium subscription to volunteer match to source additi
     question: "What are the organization's capabilities for doing this?",
     answer: `We already have the accounts set up in eNOM to provide enterprise level domain procurement and by using WHMCS with coupon codes specifically for our 501c3 and pre 501c3 organizations we can provision full hosting and domain names automatically without staff input.
 
-For our training programs we help charities navigate through the MS-900 Microsoft training and certification program while pursuing their "Microsoft 365 Grants". We further provide access to the Divi and WPMUDEV website design and maintenance product that each come with their own vendor provided training.`,
+For our training programs we help charities navigate through the AB-900 Microsoft 365 training and certification program while pursuing their "Microsoft 365 Grants". We further provide access to the Divi and WPMUDEV website design and maintenance product that each come with their own vendor provided training.`,
   },
   {
     question: "What have and haven't they accomplished so far?",


### PR DESCRIPTION
## Why
Microsoft **retired MS-900 (Microsoft 365 Fundamentals) on 2026-03-31**. The entry-level replacement is **AB-900 — Microsoft 365 Copilot and Agent Administration Fundamentals**. This completes the main-site sweep tracked in #360 (the `/volunteer` references were done in #359).

## Changes
- **Proving-ground Module 3** (`…/Modules-section/index.tsx`): retitled to AB-900, objective now covers M365 fundamentals **+ Copilot/agent administration**, and the Microsoft Learn links point to the **AB-900 exam page** and **AB-900 study guide** (the dead `ms-900t01` course / `ms-900` study guide are removed).
- **Table-of-contents** (`…/ContentSection/index.tsx`): Module 3 entry retitled to match.
- **FAQ data** (`src/data/faqs.ts`) and **homepage FAQ** (`…/FrequentlyAskedQuestions/index.tsx`): reference the AB-900 program instead of MS-900.

## Verification
- Repo is **grep-clean** of `MS-900` / `ms-900` (src + docs).
- AB-900 exam + study-guide links verified **200**; built proving-ground page emits both.
- `npm run lint` 0 errors · `npm run build` OK · `npm test` 371 pass.

## Out of scope (tracked in #360)
The **ffcadmin.org** repo also references MS-900 (its `/volunteer/microsoft-365-admin/` page + M365 training); those are listed in #360 for that repo.

Fixes #360 · refs #358, #359

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014W4FydyhP3fnKxSYJMG5eP)_