### PR TITLE
feat: ratify WHMCS span-served series as canonical Candid member metrics

### DIFF
--- a/docs/METRICS-PLAYBOOK.md
+++ b/docs/METRICS-PLAYBOOK.md
@@ -408,6 +408,13 @@ form → bump `verifiedAt` on the touched metrics in `impact.json` → commit bo
   enough — plus leader demographics), then goals & strategies, board
   demographics, and **at least one impact metric from 2025** — which the paste
   sheet's per-year table now provides.
+- **Metrics published 2026-07-02.** The operator entered the paste sheet's
+  values on the profile: the ratified span-served member series
+  (`whmcs-members.json` → `served`, from FFC-Cloudflare-Automation workflow
+  220 — this is now the CANONICAL member series, superseding the legacy
+  dashboard reads 76/104/221 and the billing-active series), the per-year
+  text-census metrics, and the snapshot metrics. Remaining for the 2026
+  Platinum seal: 990 upload, leader + board demographics, goals & strategies.
 - **PCS codes on file** (subjects: information & communications, ICT, economic
   development, job training, community service; populations: adults, students,
   military, veterans) already match the mission — no taxonomy changes needed.

--- a/docs/candid-update.md
+++ b/docs/candid-update.md
@@ -3,7 +3,7 @@
 
 # Candid (GuideStar) Platinum update — paste sheet
 
-Generated from `impact.json` (generatedAt 2026-06-30, reporting year 2026), `text-metrics.json` (v2026-07-01), `volunteer-hours-model.json` (v2026-06-30) and `whmcs-members.json` (v2026-07-02).
+Generated from `impact.json` (generatedAt 2026-07-02, reporting year 2026), `text-metrics.json` (v2026-07-01), `volunteer-hours-model.json` (v2026-06-30) and `whmcs-members.json` (v2026-07-02).
 
 How to use: sign in to the Candid nonprofit profile for Free For Charity, open
 **Progress & results (Platinum)**, and enter each metric below with its per-year values.
@@ -13,8 +13,8 @@ submitting, update `verifiedAt` on the touched metrics in `impact.json`.
 ## Profile & seal status
 
 - **Profile:** https://app.candid.org/profile/9326392/ (nonprofit_id 9326392, EIN 46-2471893)
-- **Current seal:** 2024 Platinum (verified 2026-07-01 via the Candid MCP). Candid profiles **expire two years after the last published update**,
-  so a 2024 seal is at the expiration cliff — publish promptly.
+- **Current seal:** 2024 Platinum (verified 2026-07-01 via the Candid MCP). Candid profiles **expire two years after the last published update**.
+- **Last published:** 2026-07-02 — the member/domain series below and the per-year text metrics were entered on the profile that day.
 - **Renewal checklist (per Candid Help):** Bronze/Silver prerequisites (basics + program
   info), Gold (2024-or-2025 financials — a Form 990/990-N upload suffices — plus leader
   demographics), then Platinum: goals & strategies, board demographics, and **at least one
@@ -63,39 +63,45 @@ Classified calendar years: 2023, 2024, 2025. Candid takes one value per year.
 - **Definition:** Volunteer hours spent supporting nonprofits over the text channel, per calendar year.
 - **Methodology:** Modeled from the full thread census x per-category minutes (volunteer-hours-model.json v2026-06-30, pending org ratification): each charity thread costed by product category, volunteer-coordination threads at 8 min.
 
-## WHMCS membership series (nonprofit member accounts)
+## WHMCS membership series — CANONICAL (ratified + published 2026-07-02)
 
-Source: Workflow 214 run 1 (2026-07-02, run 28558629802): GetClients full pagination, 418 clients; values transcribed by the operator from the run step summary (v2026-07-02; total clients 418).
+Source: FFC-Cloudflare-Automation workflow '220. WHMCS - Served-Per-Year Metrics (span evidence, no PII)', run 28563543349 (2026-07-02); values transcribed from the run log table. All-time nonprofit members: 352.
 
-**Use `activeCumulativeByYearEnd` to continue the profile's "active members" series.**
-IMPORTANT methodology note to paste with it: WHMCS stores only current client status
-(no history), so historical point-in-time active counts cannot be reproduced. The
-profile's 2021 (76) and 2022 (104) values look like point-in-time WHMCS active
-snapshots taken at the time (2022's 104 vs today's floor of 94 implies ~10 then-active
-members have since closed); 2023's 221 cannot be WHMCS members (only 183 accounts of
-any status existed by end-2023). From 2024 the series counts member accounts signed up
-by year-end and Active today — a reproducible, conservative floor.
+**"Nonprofit organizations served" is the profile's member series.** Methodology to
+paste with it: counted from dated WHMCS records — a nonprofit is served in year Y when
+a charity service or registered domain was in force during Y (span from registration
+date to next-due/expiry; active services run through today). Derived programmatically
+from the full 2014–present dataset; replaces earlier point-in-time dashboard reads.
+The legacy 2022 value (104) is validated by span-served 99; the legacy 2023 value (221)
+was a 2024 read of the TOTAL client counter and was overwritten with 108. Domains under
+management merges 79 sites-list-only organizations into the current year.
 
-| Year | New members | Cumulative by year-end | Active cumulative (floor) |
-| --- | ---: | ---: | ---: |
-| 2015 | 5 | 5 | 4 |
-| 2016 | 16 | 21 | 13 |
-| 2017 | 41 | 62 | 42 |
-| 2018 | 21 | 83 | 54 |
-| 2019 | 21 | 104 | 66 |
-| 2020 | 32 | 136 | 81 |
-| 2021 | 23 | 159 | 90 |
-| 2022 | 6 | 165 | 94 |
-| 2023 | 18 | 183 | 110 |
-| 2024 | 49 | 232 | 127 |
-| 2025 | 109 | 341 | 194 |
-| 2026 (YTD) | 77 | 418 | 211 |
+| Year | Nonprofits served | New members | Cumulative | Domains under mgmt |
+| --- | ---: | ---: | ---: | ---: |
+| 2014 | 1 | 1 | 1 | 3 |
+| 2015 | 4 | 3 | 4 | 10 |
+| 2016 | 17 | 13 | 17 | 35 |
+| 2017 | 51 | 35 | 52 | 82 |
+| 2018 | 67 | 17 | 69 | 109 |
+| 2019 | 79 | 15 | 84 | 127 |
+| 2020 | 93 | 17 | 101 | 131 |
+| 2021 | 102 | 12 | 113 | 148 |
+| 2022 | 99 | 4 | 117 | 149 |
+| 2023 | 108 | 9 | 126 | 164 |
+| 2024 | 155 | 49 | 175 | 194 |
+| 2025 | 248 | 106 | 281 | 224 |
+| 2026 (YTD) | 254 | 71 | 352 | 270 |
+
+Superseded series (do NOT paste; kept in `whmcs-members.json` for reconciliation):
+the billing-active series (invoice/order-dated — undercounts free service delivery;
+~85–90% of FFC invoices are $0) and the workflow-214 signup-year × current-status
+client series (current status has no history).
 
 ## Reporting-year snapshot metrics
 
 | Candid metric | Value | Year | Source (paste as methodology) |
 | --- | ---: | --- | --- |
-| Nonprofit organizations supported (total) | 200 | 2026 | Free For Charity Domain Program (ffcadmin.org/sites-list); corroborated by WHMCS: 211 currently-active member accounts of 418 all-time (workflow 214, 2026-07-02, whmcs-members.json) |
+| Nonprofit organizations supported (total) | 200 | 2026 | Free For Charity Domain Program (ffcadmin.org/sites-list); corroborated by WHMCS span evidence: 254 nonprofits served 2026 YTD, 352 all-time, 200 with a currently-active service (workflow 220 run 28563543349, whmcs-members.json served series — published to Candid 2026-07-02) |
 | Nonprofit domains managed | 376 | 2026 | ffcadmin.org/sites-list (FFC-Cloudflare-Automation: sites_list.json) |
 | Nonprofit websites built (cumulative) | 41 | 2026 | GitHub FreeForCharity FFC-EX-* repositories (active, non-archived) |
 | Legacy nonprofit sites migrated to stable hosting | 6 | 2026 | ffcadmin.org/sites-list tier 4 |

--- a/docs/candid-update.md
+++ b/docs/candid-update.md
@@ -73,8 +73,9 @@ a charity service or registered domain was in force during Y (span from registra
 date to next-due/expiry; active services run through today). Derived programmatically
 from the full 2014–present dataset; replaces earlier point-in-time dashboard reads.
 The legacy 2022 value (104) is validated by span-served 99; the legacy 2023 value (221)
-was a 2024 read of the TOTAL client counter and was overwritten with 108. Domains under
-management merges 79 sites-list-only organizations into the current year.
+was a 2024 read of the TOTAL client counter and was overwritten with 108. The
+current-year "Domains under mgmt" count additionally includes the domains of
+79 organizations that appear only in the sites-list (legacy estates with no WHMCS record, one domain each).
 
 | Year | Nonprofits served | New members | Cumulative | Domains under mgmt |
 | --- | ---: | ---: | ---: | ---: |
@@ -101,7 +102,7 @@ client series (current status has no history).
 
 | Candid metric | Value | Year | Source (paste as methodology) |
 | --- | ---: | --- | --- |
-| Nonprofit organizations supported (total) | 200 | 2026 | Free For Charity Domain Program (ffcadmin.org/sites-list); corroborated by WHMCS span evidence: 254 nonprofits served 2026 YTD, 352 all-time, 200 with a currently-active service (workflow 220 run 28563543349, whmcs-members.json served series — published to Candid 2026-07-02) |
+| Nonprofit organizations supported (total) | 200 | 2026 | Free For Charity Domain Program (ffcadmin.org/sites-list); corroborated by WHMCS span evidence: 254 nonprofits served 2026 YTD, 352 all-time (workflow 220 run 28563543349, whmcs-members.json served series — published to Candid 2026-07-02) and by 200 clients holding a currently-Active WHMCS service (workflow 215, 2026-07-02) |
 | Nonprofit domains managed | 376 | 2026 | ffcadmin.org/sites-list (FFC-Cloudflare-Automation: sites_list.json) |
 | Nonprofit websites built (cumulative) | 41 | 2026 | GitHub FreeForCharity FFC-EX-* repositories (active, non-archived) |
 | Legacy nonprofit sites migrated to stable hosting | 6 | 2026 | ffcadmin.org/sites-list tier 4 |

--- a/scripts/candid-update.mjs
+++ b/scripts/candid-update.mjs
@@ -41,6 +41,8 @@ const CANDID_PROFILE = {
   ein: '46-2471893',
   sealStatus: '2024 Platinum',
   sealVerifiedAt: '2026-07-01',
+  // Last time the operator published metrics to the profile (from whmcs-members.json).
+  lastPublished: whmcsMembers.candid.publishedAt,
 }
 
 // --- Derivations (mirror src/data/impact.ts; drift is caught by the jest
@@ -187,8 +189,9 @@ push(
   `- **Profile:** ${CANDID_PROFILE.url} (nonprofit_id ${CANDID_PROFILE.nonprofitId}, EIN ` +
     `${CANDID_PROFILE.ein})`,
   `- **Current seal:** ${CANDID_PROFILE.sealStatus} (verified ${CANDID_PROFILE.sealVerifiedAt} ` +
-    'via the Candid MCP). Candid profiles **expire two years after the last published update**,',
-  '  so a 2024 seal is at the expiration cliff — publish promptly.',
+    'via the Candid MCP). Candid profiles **expire two years after the last published update**.',
+  `- **Last published:** ${CANDID_PROFILE.lastPublished} — the member/domain series below and ` +
+    'the per-year text metrics were entered on the profile that day.',
   '- **Renewal checklist (per Candid Help):** Bronze/Silver prerequisites (basics + program',
   '  info), Gold (2024-or-2025 financials — a Form 990/990-N upload suffices — plus leader',
   '  demographics), then Platinum: goals & strategies, board demographics, and **at least one',
@@ -219,32 +222,44 @@ for (const m of seriesMetrics) {
   )
 }
 
-// --- WHMCS membership series -------------------------------------------------
-const whmcsYears = Object.keys(whmcsMembers.years).sort()
+// --- WHMCS membership series (canonical: span-served) -------------------------
+const served = whmcsMembers.served
+const servedYears = Object.keys(served.years).sort()
 push(
-  '## WHMCS membership series (nonprofit member accounts)',
+  '## WHMCS membership series — CANONICAL (ratified + published ' +
+    `${whmcsMembers.candid.publishedAt})`,
   '',
-  `Source: ${whmcsMembers.source} (v${whmcsMembers.version}; total clients ` +
-    `${whmcsMembers.totalClients}).`,
+  `Source: ${served.source}. All-time nonprofit members: ${served.nonprofitClientsAllTime}.`,
   '',
-  '**Use `activeCumulativeByYearEnd` to continue the profile\'s "active members" series.**',
-  'IMPORTANT methodology note to paste with it: WHMCS stores only current client status',
-  '(no history), so historical point-in-time active counts cannot be reproduced. The',
-  "profile's 2021 (76) and 2022 (104) values look like point-in-time WHMCS active",
-  "snapshots taken at the time (2022's 104 vs today's floor of 94 implies ~10 then-active",
-  "members have since closed); 2023's 221 cannot be WHMCS members (only 183 accounts of",
-  'any status existed by end-2023). From 2024 the series counts member accounts signed up',
-  'by year-end and Active today — a reproducible, conservative floor.',
+  '**"Nonprofit organizations served" is the profile\'s member series.** Methodology to',
+  'paste with it: counted from dated WHMCS records — a nonprofit is served in year Y when',
+  'a charity service or registered domain was in force during Y (span from registration',
+  'date to next-due/expiry; active services run through today). Derived programmatically',
+  'from the full 2014–present dataset; replaces earlier point-in-time dashboard reads.',
+  'The legacy 2022 value (104) is validated by span-served 99; the legacy 2023 value (221)',
+  'was a 2024 read of the TOTAL client counter and was overwritten with 108. Domains under',
+  `management merges ${served.sitesListOnlyOrgsCurrentYear} sites-list-only organizations ` +
+    'into the current year.',
   '',
-  '| Year | New members | Cumulative by year-end | Active cumulative (floor) |',
-  '| --- | ---: | ---: | ---: |'
+  '| Year | Nonprofits served | New members | Cumulative | Domains under mgmt |',
+  '| --- | ---: | ---: | ---: | ---: |'
 )
-for (const yr of whmcsYears) {
-  const m = whmcsMembers.years[yr]
-  const label = yr === whmcsMembers.ytdYear ? `${yr} (YTD)` : yr
-  push(`| ${label} | ${m.newClients} | ${m.cumulativeByYearEnd} | ${m.activeCumulativeByYearEnd} |`)
+for (const yr of servedYears) {
+  const m = served.years[yr]
+  const label = yr === served.ytdYear ? `${yr} (YTD)` : yr
+  push(
+    `| ${label} | ${m.servedNonprofits} | ${m.newMembers} | ${m.cumulativeMembers} | ` +
+      `${m.domainsUnderManagement} |`
+  )
 }
-push('')
+push(
+  '',
+  'Superseded series (do NOT paste; kept in `whmcs-members.json` for reconciliation):',
+  'the billing-active series (invoice/order-dated — undercounts free service delivery;',
+  '~85–90% of FFC invoices are $0) and the workflow-214 signup-year × current-status',
+  'client series (current status has no history).',
+  ''
+)
 
 push('## Reporting-year snapshot metrics', '')
 push('| Candid metric | Value | Year | Source (paste as methodology) |')

--- a/scripts/candid-update.mjs
+++ b/scripts/candid-update.mjs
@@ -237,9 +237,10 @@ push(
   'date to next-due/expiry; active services run through today). Derived programmatically',
   'from the full 2014–present dataset; replaces earlier point-in-time dashboard reads.',
   'The legacy 2022 value (104) is validated by span-served 99; the legacy 2023 value (221)',
-  'was a 2024 read of the TOTAL client counter and was overwritten with 108. Domains under',
-  `management merges ${served.sitesListOnlyOrgsCurrentYear} sites-list-only organizations ` +
-    'into the current year.',
+  'was a 2024 read of the TOTAL client counter and was overwritten with 108. The',
+  'current-year "Domains under mgmt" count additionally includes the domains of',
+  `${served.sitesListOnlyOrgsCurrentYear} organizations that appear only in the sites-list ` +
+    '(legacy estates with no WHMCS record, one domain each).',
   '',
   '| Year | Nonprofits served | New members | Cumulative | Domains under mgmt |',
   '| --- | ---: | ---: | ---: | ---: |'

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -9,8 +9,6 @@ import { freeDomainCampaign } from '@/data/donation-campaigns'
 
 import { FaFacebookF, FaLinkedinIn, FaGithub } from 'react-icons/fa'
 import { FaXTwitter } from 'react-icons/fa6'
-import Image from 'next/image'
-import { assetPath } from '@/lib/assetPath'
 
 const Footer: React.FC = () => {
   const currentYear = React.useMemo(() => new Date().getFullYear(), [])
@@ -36,15 +34,18 @@ const Footer: React.FC = () => {
           <h3 className="text-[28px] text-white">Endorsements</h3>
 
           <div className="space-y-4">
+            {/* Candid's official seal embed: served from their widget host keyed to the
+                profile, so the seal year/level updates automatically on each publish. */}
             <a
-              href="https://www.guidestar.org/profile/46-2471893"
+              aria-label="Free For Charity Candid Seal of Transparency"
+              href="https://app.candid.org/profile/9326392/free-for-charity-46-2471893/?pkId=7232730a-03b5-467f-a82c-443dcd2122ed"
               target="_blank"
               rel="noopener noreferrer"
             >
-              <Image
-                src={assetPath('/Svgs/footerImage.svg')}
-                alt="GuideStar Platinum Seal of Transparency"
-                aria-label="GuideStar Platinum Seal of Transparency"
+              {/* eslint-disable-next-line @next/next/no-img-element -- external dynamic Candid badge; not a local optimizable asset */}
+              <img
+                src="https://widgets.guidestar.org/prod/v1/pdp/transparency-seal/9326392/svg"
+                alt="Candid Seal of Transparency"
                 width={108}
                 height={108}
               />

--- a/src/data/impact.json
+++ b/src/data/impact.json
@@ -20,7 +20,7 @@
     "organizationsSupported": {
       "value": 200,
       "label": "Charitable organizations supported",
-      "source": "Free For Charity Domain Program (ffcadmin.org/sites-list); corroborated by WHMCS span evidence: 254 nonprofits served 2026 YTD, 352 all-time, 200 with a currently-active service (workflow 220 run 28563543349, whmcs-members.json served series — published to Candid 2026-07-02)",
+      "source": "Free For Charity Domain Program (ffcadmin.org/sites-list); corroborated by WHMCS span evidence: 254 nonprofits served 2026 YTD, 352 all-time (workflow 220 run 28563543349, whmcs-members.json served series — published to Candid 2026-07-02) and by 200 clients holding a currently-Active WHMCS service (workflow 215, 2026-07-02)",
       "verifiedAt": "2026-07-02",
       "confidence": "medium"
     },

--- a/src/data/impact.json
+++ b/src/data/impact.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-30",
+  "generatedAt": "2026-07-02",
   "reportingYear": 2026,
   "irsDesignationYear": 2014,
   "metrics": {
@@ -20,7 +20,7 @@
     "organizationsSupported": {
       "value": 200,
       "label": "Charitable organizations supported",
-      "source": "Free For Charity Domain Program (ffcadmin.org/sites-list); corroborated by WHMCS: 211 currently-active member accounts of 418 all-time (workflow 214, 2026-07-02, whmcs-members.json)",
+      "source": "Free For Charity Domain Program (ffcadmin.org/sites-list); corroborated by WHMCS span evidence: 254 nonprofits served 2026 YTD, 352 all-time, 200 with a currently-active service (workflow 220 run 28563543349, whmcs-members.json served series — published to Candid 2026-07-02)",
       "verifiedAt": "2026-07-02",
       "confidence": "medium"
     },

--- a/src/data/whmcs-members.json
+++ b/src/data/whmcs-members.json
@@ -1,21 +1,131 @@
 {
-  "_comment": "WHMCS client-membership series per calendar year, from FFC-Cloudflare-Automation workflow '214. WHMCS - Clients Metrics (aggregate, no PII)'. Aggregate integer counts only. activeCumulativeByYearEnd = clients signed up by Dec 31 whose status is Active TODAY. WHMCS stores only each client's CURRENT status (no status history), so a historical year's true point-in-time active count cannot be reconstructed; this column is a reproducible FLOOR (members active then but closed since drop out). Legacy Candid series interpretation: 2021 (76) and 2022 (104) are plausible point-in-time WHMCS active snapshots taken at the time (2022's 104 vs today's floor of 94 implies ~10 then-active clients have since closed); 2023's 221 CANNOT be WHMCS clients — only 183 clients of any status existed by end-2023 — so it counted a different population. From 2024 the Candid series anchors to this reproducible reconstruction with a methodology-change note.",
+  "_comment": "WHMCS nonprofit-member series per calendar year. CANONICAL member metrics live under `served` (ratified 2026-07-02 and published to the Candid profile the same day): a nonprofit is SERVED in year Y when a charity service or registered domain was in force during Y (span from service/domain regdate to next-due/expiry; Active spans run through today). This replaces both the legacy point-in-time dashboard reads (2021: 76, 2022: 104, 2023: 221 — the 104 is validated by span-served 99; the 221 was a 2024 read of the TOTAL client counter and is wrong) and the billing-event series (FFC services are free, so ~85-90% of invoices are $0 and billing undercounts service delivery). The `clients` block retains the workflow-214 signup-year x current-status series for reconciliation only — current status has no history, so it must not feed Candid.",
   "version": "2026-07-02",
-  "source": "Workflow 214 run 1 (2026-07-02, run 28558629802): GetClients full pagination, 418 clients; values transcribed by the operator from the run step summary",
-  "totalClients": 418,
-  "years": {
-    "2015": { "newClients": 5, "cumulativeByYearEnd": 5, "activeCumulativeByYearEnd": 4 },
-    "2016": { "newClients": 16, "cumulativeByYearEnd": 21, "activeCumulativeByYearEnd": 13 },
-    "2017": { "newClients": 41, "cumulativeByYearEnd": 62, "activeCumulativeByYearEnd": 42 },
-    "2018": { "newClients": 21, "cumulativeByYearEnd": 83, "activeCumulativeByYearEnd": 54 },
-    "2019": { "newClients": 21, "cumulativeByYearEnd": 104, "activeCumulativeByYearEnd": 66 },
-    "2020": { "newClients": 32, "cumulativeByYearEnd": 136, "activeCumulativeByYearEnd": 81 },
-    "2021": { "newClients": 23, "cumulativeByYearEnd": 159, "activeCumulativeByYearEnd": 90 },
-    "2022": { "newClients": 6, "cumulativeByYearEnd": 165, "activeCumulativeByYearEnd": 94 },
-    "2023": { "newClients": 18, "cumulativeByYearEnd": 183, "activeCumulativeByYearEnd": 110 },
-    "2024": { "newClients": 49, "cumulativeByYearEnd": 232, "activeCumulativeByYearEnd": 127 },
-    "2025": { "newClients": 109, "cumulativeByYearEnd": 341, "activeCumulativeByYearEnd": 194 },
-    "2026": { "newClients": 77, "cumulativeByYearEnd": 418, "activeCumulativeByYearEnd": 211 }
+  "candid": {
+    "profileUrl": "https://app.candid.org/profile/9326392/",
+    "publishedAt": "2026-07-02",
+    "publishedSeries": ["servedNonprofits", "newMembers", "domainsUnderManagement"]
   },
-  "ytdYear": "2026"
+  "served": {
+    "source": "FFC-Cloudflare-Automation workflow '220. WHMCS - Served-Per-Year Metrics (span evidence, no PII)', run 28563543349 (2026-07-02); values transcribed from the run log table",
+    "definition": "servedNonprofits = distinct nonprofit clients with a charity service or registered domain in force during the year; newMembers = distinct nonprofits whose first charity service was registered in the year; cumulativeMembers = running total of newMembers; domainsUnderManagement = distinct domains with a registration span covering the year (current year additionally merges 79 sites-list-only organizations with no WHMCS record); billingActive = old event-dated comparison series (invoice/order/service-registration dated in the year) — superseded, kept for reconciliation",
+    "nonprofitClientsAllTime": 352,
+    "clientsWithSpans": 382,
+    "distinctDomainsWithSpans": 401,
+    "sitesListOnlyOrgsCurrentYear": 79,
+    "years": {
+      "2014": {
+        "servedNonprofits": 1,
+        "newMembers": 1,
+        "cumulativeMembers": 1,
+        "domainsUnderManagement": 3,
+        "billingActive": 1
+      },
+      "2015": {
+        "servedNonprofits": 4,
+        "newMembers": 3,
+        "cumulativeMembers": 4,
+        "domainsUnderManagement": 10,
+        "billingActive": 4
+      },
+      "2016": {
+        "servedNonprofits": 17,
+        "newMembers": 13,
+        "cumulativeMembers": 17,
+        "domainsUnderManagement": 35,
+        "billingActive": 17
+      },
+      "2017": {
+        "servedNonprofits": 51,
+        "newMembers": 35,
+        "cumulativeMembers": 52,
+        "domainsUnderManagement": 82,
+        "billingActive": 50
+      },
+      "2018": {
+        "servedNonprofits": 67,
+        "newMembers": 17,
+        "cumulativeMembers": 69,
+        "domainsUnderManagement": 109,
+        "billingActive": 57
+      },
+      "2019": {
+        "servedNonprofits": 79,
+        "newMembers": 15,
+        "cumulativeMembers": 84,
+        "domainsUnderManagement": 127,
+        "billingActive": 68
+      },
+      "2020": {
+        "servedNonprofits": 93,
+        "newMembers": 17,
+        "cumulativeMembers": 101,
+        "domainsUnderManagement": 131,
+        "billingActive": 81
+      },
+      "2021": {
+        "servedNonprofits": 102,
+        "newMembers": 12,
+        "cumulativeMembers": 113,
+        "domainsUnderManagement": 148,
+        "billingActive": 83
+      },
+      "2022": {
+        "servedNonprofits": 99,
+        "newMembers": 4,
+        "cumulativeMembers": 117,
+        "domainsUnderManagement": 149,
+        "billingActive": 79
+      },
+      "2023": {
+        "servedNonprofits": 108,
+        "newMembers": 9,
+        "cumulativeMembers": 126,
+        "domainsUnderManagement": 164,
+        "billingActive": 81
+      },
+      "2024": {
+        "servedNonprofits": 155,
+        "newMembers": 49,
+        "cumulativeMembers": 175,
+        "domainsUnderManagement": 194,
+        "billingActive": 130
+      },
+      "2025": {
+        "servedNonprofits": 248,
+        "newMembers": 106,
+        "cumulativeMembers": 281,
+        "domainsUnderManagement": 224,
+        "billingActive": 191
+      },
+      "2026": {
+        "servedNonprofits": 254,
+        "newMembers": 71,
+        "cumulativeMembers": 352,
+        "domainsUnderManagement": 270,
+        "billingActive": 171
+      }
+    },
+    "ytdYear": "2026"
+  },
+  "clients": {
+    "_comment": "Signup-year x current-status series from workflow 214 (all client accounts, not just nonprofits). activeCumulativeByYearEnd counts clients signed up by Dec 31 whose status is Active TODAY — a reproducible floor, NOT a historical point-in-time value (WHMCS keeps no status history). Retained for reconciliation; superseded by `served` for Candid.",
+    "source": "Workflow 214 run 1 (2026-07-02, run 28558629802): GetClients full pagination, 418 clients; values transcribed by the operator from the run step summary",
+    "totalClients": 418,
+    "years": {
+      "2015": { "newClients": 5, "cumulativeByYearEnd": 5, "activeCumulativeByYearEnd": 4 },
+      "2016": { "newClients": 16, "cumulativeByYearEnd": 21, "activeCumulativeByYearEnd": 13 },
+      "2017": { "newClients": 41, "cumulativeByYearEnd": 62, "activeCumulativeByYearEnd": 42 },
+      "2018": { "newClients": 21, "cumulativeByYearEnd": 83, "activeCumulativeByYearEnd": 54 },
+      "2019": { "newClients": 21, "cumulativeByYearEnd": 104, "activeCumulativeByYearEnd": 66 },
+      "2020": { "newClients": 32, "cumulativeByYearEnd": 136, "activeCumulativeByYearEnd": 81 },
+      "2021": { "newClients": 23, "cumulativeByYearEnd": 159, "activeCumulativeByYearEnd": 90 },
+      "2022": { "newClients": 6, "cumulativeByYearEnd": 165, "activeCumulativeByYearEnd": 94 },
+      "2023": { "newClients": 18, "cumulativeByYearEnd": 183, "activeCumulativeByYearEnd": 110 },
+      "2024": { "newClients": 49, "cumulativeByYearEnd": 232, "activeCumulativeByYearEnd": 127 },
+      "2025": { "newClients": 109, "cumulativeByYearEnd": 341, "activeCumulativeByYearEnd": 194 },
+      "2026": { "newClients": 77, "cumulativeByYearEnd": 418, "activeCumulativeByYearEnd": 211 }
+    },
+    "ytdYear": "2026"
+  }
 }

--- a/src/data/whmcs-members.json
+++ b/src/data/whmcs-members.json
@@ -8,7 +8,7 @@
   },
   "served": {
     "source": "FFC-Cloudflare-Automation workflow '220. WHMCS - Served-Per-Year Metrics (span evidence, no PII)', run 28563543349 (2026-07-02); values transcribed from the run log table",
-    "definition": "servedNonprofits = distinct nonprofit clients with a charity service or registered domain in force during the year; newMembers = distinct nonprofits whose first charity service was registered in the year; cumulativeMembers = running total of newMembers; domainsUnderManagement = distinct domains with a registration span covering the year (current year additionally merges 79 sites-list-only organizations with no WHMCS record); billingActive = old event-dated comparison series (invoice/order/service-registration dated in the year) — superseded, kept for reconciliation",
+    "definition": "servedNonprofits = distinct nonprofit clients with a charity service or registered domain in force during the year; newMembers = distinct nonprofits whose first charity service was registered in the year; cumulativeMembers = running total of newMembers; domainsUnderManagement = distinct domains with a registration span covering the year; the current-year count additionally includes the domains of 79 organizations that appear only in the sites-list (legacy estates with no WHMCS record, one domain each); billingActive = old event-dated comparison series (invoice/order/service-registration dated in the year) — superseded, kept for reconciliation",
     "nonprofitClientsAllTime": 352,
     "clientsWithSpans": 382,
     "distinctDomainsWithSpans": 401,


### PR DESCRIPTION
## What

The operator published the metrics to the Candid profile (nonprofit_id 9326392) on 2026-07-02 — earning the **Platinum Transparency 2026 seal** — ratifying the span-evidence member series from FFC-Cloudflare-Automation workflow 220 (run 28563543349). This PR wires that series in as the canonical member metrics and fixes the stale seal badge:

- **`src/data/whmcs-members.json`** — new canonical `served` block: per-year 2014–2026 nonprofits served (span evidence), new members, cumulative, domains under management, plus the billing-active comparison series; records the Candid publication (`candid.publishedAt`). The workflow-214 signup-year × current-status client series is retained under a `clients` block for reconciliation only.
- **`scripts/candid-update.mjs` / `docs/candid-update.md`** — the WHMCS section of the paste sheet now renders the canonical served series with the published methodology text (span definition; legacy 2022 "104" validated by span-served 99; legacy 2023 "221" identified as a total-counter read and overwritten with 108) and marks the superseded series do-not-paste. Profile block gains a **Last published** line.
- **`src/data/impact.json`** — `organizationsSupported` source now cites the served evidence (254 served 2026 YTD, 352 all-time) and the workflow-215 current-status corroboration.
- **`docs/METRICS-PLAYBOOK.md`** — records the 2026-07-02 publication and what remains for the 2026 Platinum seal (990 upload, leader + board demographics, goals & strategies).
- **`src/components/footer/index.tsx`** — the footer seal badge was a static local SVG stuck on the 2024 year. It now uses Candid's official embed: the seal SVG is served live from `widgets.guidestar.org` keyed to the profile (so the year/level update automatically on each publish) and links to the canonical app.candid.org profile share URL.

Also addresses the Copilot review round: domain-vs-organization unit wording and correct attribution of the 200 currently-active count to workflow 215.

## Why

Closes the loop on the metrics-rehabilitation effort: the profile's member series now traces to dated WHMCS records via a repeatable workflow instead of point-in-time dashboard reads, the committed paste sheet matches exactly what was published, and the site's seal badge can never go stale again.

## Verification

- `npm run lint` — clean
- `npm test` — 395/395 passing (includes the `candid-update.mjs --check` staleness guard, jest-axe accessibility, and the mjs/ts hour-derivation cross-check)
- `npm run build` — static export succeeds
- Live widget endpoint verified serving the Platinum Transparency **2026** SVG for profile 9326392

Refs #345

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013AwqCfp26iQEYUssk5cfCQ