### PR TITLE
test: match footer E2E to the Candid live seal embed (unblocks production deploy)

### DIFF
--- a/tests/footer-complete.spec.ts
+++ b/tests/footer-complete.spec.ts
@@ -4,7 +4,7 @@ import { test, expect } from '@playwright/test'
  * Complete Footer Verification E2E Tests
  *
  * Verifies all three columns of the footer:
- * - Column 1: Endorsements (GuideStar seal, EIN)
+ * - Column 1: Endorsements (Candid/GuideStar seal, EIN)
  * - Column 2: Quick Links (8 nav links + 7 policy links)
  * - Column 3: Contact Us (email, phone, addresses, social icons)
  * - Bottom bar: Copyright with current year
@@ -20,9 +20,13 @@ test.describe('Footer - Column 1: Endorsements', () => {
     await expect(footer.getByText('Endorsements')).toBeVisible()
   })
 
-  test('should display GuideStar Platinum seal image', async ({ page }) => {
+  test('should display Candid Seal of Transparency image', async ({ page }) => {
     const footer = page.locator('footer')
-    const sealImg = footer.locator('img[alt*="GuideStar"]')
+    // Served live from Candid's widget host (official embed), so the seal
+    // year/level update automatically on each profile publish.
+    const sealImg = footer.locator(
+      'img[src*="widgets.guidestar.org"][alt*="Candid Seal of Transparency"]'
+    )
     await expect(sealImg).toBeVisible()
   })
 


### PR DESCRIPTION
## What

After #363 merged, `CI - Build and Test` failed on main at the **Run E2E tests** step (run 28568851483), which made the production deploy step **skip** — so the live site is still serving the old footer with the stale 2024 seal.

Root cause: `tests/footer-complete.spec.ts` located the seal via `img[alt*="GuideStar"]`, but the footer now uses Candid's official live embed whose alt text is "Candid Seal of Transparency". This PR updates the spec to locate the seal by its widget host (`widgets.guidestar.org`) + the new alt text, and renames the test accordingly.

## Verification

Run locally against the affected suites:

- `tests/footer-complete.spec.ts` + `tests/external-links.spec.ts` — 20/20 passed
- `tests/accessibility.spec.ts` — 33/33 passed
- Pre-commit format + lint clean

Merging this re-runs main CI and, on success, triggers the InterServer production deploy that puts the auto-updating **Platinum Transparency 2026** seal live.

Refs #345

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013AwqCfp26iQEYUssk5cfCQ

---
_Generated by [Claude Code](https://claude.ai/code/session_013AwqCfp26iQEYUssk5cfCQ)_