### PR TITLE
feat: page-specific Open Graph and Twitter metadata sitewide (backlog wave 2)

### DIFF
--- a/__tests__/app/page-og-metadata.test.ts
+++ b/__tests__/app/page-og-metadata.test.ts
@@ -1,0 +1,46 @@
+import { readdirSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * OG metadata audit (issue #383): Next.js merges metadata shallowly, so a
+ * page that omits `openGraph` inherits the ROOT og:title/og:description —
+ * link previews would show the homepage text on every page. This suite
+ * requires every route's metadata to carry page-specific og/twitter fields
+ * (via the pageMetadata helper) so a new route can't regress link previews.
+ */
+
+const appDir = join(__dirname, '..', '..', 'src', 'app')
+
+// Pages intentionally relying on the root layout's own OG block:
+// - '' (homepage): the root layout defines its canonical OG metadata
+// - free-for-charity-donation-policy: uses a `title: { absolute }` override
+const EXEMPT = new Set(['', 'free-for-charity-donation-policy'])
+
+const routeDirs = [
+  '',
+  ...readdirSync(appDir, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name),
+].filter((dir) => existsSync(join(appDir, dir, 'page.tsx')))
+
+describe.each(routeDirs)('route /%s', (dir) => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const mod = require(join(appDir, dir, 'page.tsx'))
+  const metadata = mod.metadata
+
+  it('exports metadata with title and description', () => {
+    expect(metadata).toBeDefined()
+    expect(metadata.title ?? metadata.openGraph?.title).toBeTruthy()
+    expect(metadata.description).toBeTruthy()
+  })
+
+  if (!EXEMPT.has(dir)) {
+    it('has page-specific openGraph and twitter fields matching the page', () => {
+      expect(metadata.openGraph?.title).toBe(metadata.title)
+      expect(metadata.openGraph?.description).toBe(metadata.description)
+      expect(metadata.openGraph?.images?.length).toBeGreaterThan(0)
+      expect(metadata.openGraph?.url).toBe(metadata.alternates?.canonical)
+      expect(metadata.twitter?.title).toBe(metadata.title)
+    })
+  }
+})

--- a/src/app/501c3/page.tsx
+++ b/src/app/501c3/page.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from 'next'
+import { pageMetadata } from '@/lib/page-metadata'
 import HeroSection from '@/components/ui/HeroSection'
 import HelpForCharitiesandNonprofit from '@/components/501c3-components/Help-For-Charities-and-Nonprofit'
 import AdminGuideLink from '@/components/ui/AdminGuideLink'
@@ -6,12 +6,12 @@ import { adminLinks, ffcAdminUrl } from '@/data/admin-links'
 import ReadyToGetStartedAndFaq from '@/components/501c3-components/Ready-to-get-started-and-faqs'
 import CallSection from '@/components/help-for-charities-components/call-section'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: '501(c)(3) Onboarding Guide',
   description:
     'Apply to get a free website for your 501(c)(3)—a fast, secure GitHub Pages site built with AI—plus free domains, Microsoft 365 email, and technology tools from Free For Charity.',
-  alternates: { canonical: '/501c3/' },
-}
+  canonical: '/501c3/',
+})
 
 const index = () => {
   return (

--- a/src/app/about-us/page.tsx
+++ b/src/app/about-us/page.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from 'next'
+import { pageMetadata } from '@/lib/page-metadata'
 import React from 'react'
 import HeroSection from '@/components/ui/HeroSection'
 import Content from '@/components/about-us-components/content'
@@ -6,12 +6,12 @@ import CardSection from '@/components/about-us-components/Card-section'
 import ParaText from '@/components/about-us-components/ParaText'
 import CallToAction from '@/components/about-us-components/CallToAction'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'About Us',
   description:
     "Learn about Free For Charity's mission to reduce costs and increase revenues for nonprofits by connecting students, professionals, and businesses with charities in need.",
-  alternates: { canonical: '/about-us/' },
-}
+  canonical: '/about-us/',
+})
 
 const index = () => {
   return (

--- a/src/app/accessibility-statement/page.tsx
+++ b/src/app/accessibility-statement/page.tsx
@@ -1,12 +1,12 @@
-import type { Metadata } from 'next'
+import { pageMetadata } from '@/lib/page-metadata'
 import Link from 'next/link'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'Accessibility Statement',
   description:
     'Free For Charity is committed to WCAG 2.1 AA accessibility. How we test, what we enforce in CI, and how to report a barrier.',
-  alternates: { canonical: '/accessibility-statement/' },
-}
+  canonical: '/accessibility-statement/',
+})
 
 const heading2 = 'font-[var(--font-faustina)] text-[32px] leading-[40px] mt-8 mb-4'
 

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,16 +1,14 @@
+import { pageMetadata } from '@/lib/page-metadata'
 import React from 'react'
-import type { Metadata } from 'next'
 import HeroSection from '@/components/ui/HeroSection'
 import BlogCard from '@/components/ui/BlogCard'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'Blog',
   description:
     'News and updates from Free For Charity. Read about our GuideStar transparency seals, nonprofit tools, endorsements, and more.',
-  alternates: {
-    canonical: '/blog/',
-  },
-}
+  canonical: '/blog/',
+})
 
 const blogPosts = [
   {

--- a/src/app/charity-and-nonprofit-case-studies/page.tsx
+++ b/src/app/charity-and-nonprofit-case-studies/page.tsx
@@ -1,15 +1,13 @@
+import { pageMetadata } from '@/lib/page-metadata'
 import React from 'react'
-import type { Metadata } from 'next'
 import HeroSection from '@/components/ui/HeroSection'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'Charity and Nonprofit Case Studies',
   description:
     'Real-world nonprofit case studies to help your organization make informed decisions without wasting time and money on experimentation.',
-  alternates: {
-    canonical: '/charity-and-nonprofit-case-studies/',
-  },
-}
+  canonical: '/charity-and-nonprofit-case-studies/',
+})
 
 const orgTypes = [
   'Charities',

--- a/src/app/charity-and-nonprofit-service-and-consultant-directory/page.tsx
+++ b/src/app/charity-and-nonprofit-service-and-consultant-directory/page.tsx
@@ -1,15 +1,13 @@
+import { pageMetadata } from '@/lib/page-metadata'
 import React from 'react'
-import type { Metadata } from 'next'
 import HeroSection from '@/components/ui/HeroSection'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'Charity and Nonprofit Service and Consultant Directory',
   description:
     'Find nonprofit consultants and service providers for marketing, legal, IT, HR, fundraising, and more. A free resource from Free For Charity.',
-  alternates: {
-    canonical: '/charity-and-nonprofit-service-and-consultant-directory/',
-  },
-}
+  canonical: '/charity-and-nonprofit-service-and-consultant-directory/',
+})
 
 const topics = [
   'Marketing',

--- a/src/app/charity-and-nonprofit-technology-directory/page.tsx
+++ b/src/app/charity-and-nonprofit-technology-directory/page.tsx
@@ -1,17 +1,15 @@
+import { pageMetadata } from '@/lib/page-metadata'
 import React from 'react'
-import type { Metadata } from 'next'
 import HeroSection from '@/components/ui/HeroSection'
 import AdminGuideLink from '@/components/ui/AdminGuideLink'
 import { adminLinks, ffcAdminUrl } from '@/data/admin-links'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'Charity and Nonprofit Technology Directory',
   description:
     'Explore free and open source technology tools for nonprofit organizations. Find solutions for static-site web hosting, AI-assisted development, office automation, CRM, and more.',
-  alternates: {
-    canonical: '/charity-and-nonprofit-technology-directory/',
-  },
-}
+  canonical: '/charity-and-nonprofit-technology-directory/',
+})
 
 const categories = [
   {

--- a/src/app/charity-faq/page.tsx
+++ b/src/app/charity-faq/page.tsx
@@ -1,13 +1,13 @@
-import type { Metadata } from 'next'
+import { pageMetadata } from '@/lib/page-metadata'
 import Link from 'next/link'
 import AccordionItem from '@/components/ui/Accordian'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'Charity Support FAQ',
   description:
     'The questions charities actually ask Free For Charity — email at your domain, who owns the domain, onboarding timelines, site changes, migration, and costs.',
-  alternates: { canonical: '/charity-faq/' },
-}
+  canonical: '/charity-faq/',
+})
 
 // The ten most-repeated questions from the full census of FFC's support
 // conversations (2023–2025), each answered with a link to the guide that

--- a/src/app/charity-onboarding-journey/page.tsx
+++ b/src/app/charity-onboarding-journey/page.tsx
@@ -1,12 +1,12 @@
-import type { Metadata } from 'next'
+import { pageMetadata } from '@/lib/page-metadata'
 import Link from 'next/link'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'Your Onboarding Journey',
   description:
     'What happens after your charity applies to Free For Charity: the five stages, who does what, how long each takes, and what to prepare.',
-  alternates: { canonical: '/charity-onboarding-journey/' },
-}
+  canonical: '/charity-onboarding-journey/',
+})
 
 const h2 = 'font-[var(--font-faustina)] text-[32px] leading-[40px] mt-8 mb-4'
 

--- a/src/app/charity-security-guide/page.tsx
+++ b/src/app/charity-security-guide/page.tsx
@@ -1,12 +1,12 @@
-import type { Metadata } from 'next'
+import { pageMetadata } from '@/lib/page-metadata'
 import Link from 'next/link'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'Security Basics for Small Charities',
   description:
     'MFA, password managers, donation fraud, and domain safety — the security floor every small nonprofit should stand on, in plain language.',
-  alternates: { canonical: '/charity-security-guide/' },
-}
+  canonical: '/charity-security-guide/',
+})
 
 const h2 = 'font-[var(--font-faustina)] text-[32px] leading-[40px] mt-8 mb-4'
 

--- a/src/app/charity-validation-guide-ensuring-mutual-benefit-through-comprehensive-validation-processes/page.tsx
+++ b/src/app/charity-validation-guide-ensuring-mutual-benefit-through-comprehensive-validation-processes/page.tsx
@@ -1,16 +1,14 @@
-import type { Metadata } from 'next'
+import { pageMetadata } from '@/lib/page-metadata'
 import React from 'react'
 import Hero from '@/components/charity-validation-guide-ensuring-mutual-benefit-through-comprehensive-validation-processes-components/Hero'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'Charity Validation Guide',
   description:
     'Comprehensive guide for validating charitable entities, ensuring credibility and mutual benefit through GuideStar verification and due diligence processes.',
-  alternates: {
-    canonical:
-      '/charity-validation-guide-ensuring-mutual-benefit-through-comprehensive-validation-processes/',
-  },
-}
+  canonical:
+    '/charity-validation-guide-ensuring-mutual-benefit-through-comprehensive-validation-processes/',
+})
 
 const index = () => {
   return (

--- a/src/app/choosing-your-org-domain/page.tsx
+++ b/src/app/choosing-your-org-domain/page.tsx
@@ -1,12 +1,12 @@
-import type { Metadata } from 'next'
+import { pageMetadata } from '@/lib/page-metadata'
 import Link from 'next/link'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: "Choosing Your Charity's .org Domain",
   description:
     'How to pick a nonprofit domain name without fear: naming rules, availability, why .org, who owns it, and what Free For Charity pays for.',
-  alternates: { canonical: '/choosing-your-org-domain/' },
-}
+  canonical: '/choosing-your-org-domain/',
+})
 
 const h2 = 'font-[var(--font-faustina)] text-[32px] leading-[40px] mt-8 mb-4'
 

--- a/src/app/consulting/page.tsx
+++ b/src/app/consulting/page.tsx
@@ -1,17 +1,15 @@
+import { pageMetadata } from '@/lib/page-metadata'
 import React from 'react'
-import type { Metadata } from 'next'
 import HeroSection from '@/components/ui/HeroSection'
 import AdminGuideLink from '@/components/ui/AdminGuideLink'
 import { adminLinks, ffcAdminUrl } from '@/data/admin-links'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'Consulting',
   description:
     'Free nonprofit consulting services from Free For Charity. Get expert help with charity operations, technology, and strategy at no cost.',
-  alternates: {
-    canonical: '/consulting/',
-  },
-}
+  canonical: '/consulting/',
+})
 
 const ConsultingPage = () => {
   return (

--- a/src/app/contact-us/page.tsx
+++ b/src/app/contact-us/page.tsx
@@ -1,15 +1,15 @@
-import type { Metadata } from 'next'
+import { pageMetadata } from '@/lib/page-metadata'
 import React from 'react'
 import HeroSection from '@/components/ui/HeroSection'
 import IntentRouting from '@/components/contact-us-components/Intent-Routing'
 import ContactSection from '@/components/contact-us-components/Contact-Us'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'Contact Us',
   description:
     'Get in touch with Free For Charity. We connect students, professionals, and businesses with charities in need of support.',
-  alternates: { canonical: '/contact-us/' },
-}
+  canonical: '/contact-us/',
+})
 
 const index = () => {
   return (

--- a/src/app/contribute/page.tsx
+++ b/src/app/contribute/page.tsx
@@ -1,12 +1,12 @@
-import type { Metadata } from 'next'
+import { pageMetadata } from '@/lib/page-metadata'
 import Link from 'next/link'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'Contribute on GitHub',
   description:
     'Free For Charity is built in the open. Pick up a good-first-issue in our repositories and help charities with a pull request — no formal signup required.',
-  alternates: { canonical: '/contribute/' },
-}
+  canonical: '/contribute/',
+})
 
 const h2 = 'font-[var(--font-faustina)] text-[32px] leading-[40px] mt-8 mb-4'
 

--- a/src/app/cookie-policy/page.tsx
+++ b/src/app/cookie-policy/page.tsx
@@ -1,11 +1,11 @@
-import type { Metadata } from 'next'
+import { pageMetadata } from '@/lib/page-metadata'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'Cookie Policy',
   description:
     'Free For Charity cookie policy explaining how we use cookies and similar tracking technologies on our website.',
-  alternates: { canonical: '/cookie-policy/' },
-}
+  canonical: '/cookie-policy/',
+})
 
 // Update this date when the policy changes
 const LAST_UPDATED = 'November 26, 2025'

--- a/src/app/cost-transparency/page.tsx
+++ b/src/app/cost-transparency/page.tsx
@@ -1,13 +1,13 @@
-import type { Metadata } from 'next'
+import { pageMetadata } from '@/lib/page-metadata'
 import Link from 'next/link'
 import { metric } from '@/data/impact'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'What $16.50 Per Charity Per Year Buys',
   description:
     "Free For Charity's unit economics: what one charity's full digital presence costs us, what it would cost commercially, and how far a donation multiplies.",
-  alternates: { canonical: '/cost-transparency/' },
-}
+  canonical: '/cost-transparency/',
+})
 
 const h2 = 'font-[var(--font-faustina)] text-[32px] leading-[40px] mt-8 mb-4'
 

--- a/src/app/domains/page.tsx
+++ b/src/app/domains/page.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from 'next'
+import { pageMetadata } from '@/lib/page-metadata'
 import React from 'react'
 import Hero from '@/components/domains/Hero'
 import DearProspective from '@/components/domains/Dear-Prospective'
@@ -11,12 +11,12 @@ import CurvedBlueSection from '@/components/domains/Curved-Blue-Section'
 import CurvedBlackSection from '@/components/domains/Curved-Black-Section'
 import GetNewWebsite from '@/components/domains/Get-New-Website'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'Free Domains for Nonprofits',
   description:
     'Free For Charity provides free domain registration, DNS management, and email setup for verified 501(c)(3) nonprofit organizations.',
-  alternates: { canonical: '/domains/' },
-}
+  canonical: '/domains/',
+})
 
 const index = () => {
   return (

--- a/src/app/donate/page.tsx
+++ b/src/app/donate/page.tsx
@@ -1,16 +1,16 @@
-import type { Metadata } from 'next'
+import { pageMetadata } from '@/lib/page-metadata'
 import React from 'react'
 import HeroSection from '@/components/ui/HeroSection'
 import Measurableimpact from '@/components/donate-components/measurable-impact'
 import FreeForCharityDonationOptions from '@/components/donate-components/Free-for-Charity-Donation-Options'
 import DonationCampaigns from '@/components/donate-components/Donation-Campaigns'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'Donate',
   description:
     'Support Free For Charity through Zeffy—100% of your gift reaches the mission (Zeffy charges 0% platform fees). Fund free, AI-built GitHub Pages websites, domains, and Microsoft 365 for nonprofits.',
-  alternates: { canonical: '/donate/' },
-}
+  canonical: '/donate/',
+})
 
 const index = () => {
   return (

--- a/src/app/donation-policy/page.tsx
+++ b/src/app/donation-policy/page.tsx
@@ -1,11 +1,11 @@
-import type { Metadata } from 'next'
+import { pageMetadata } from '@/lib/page-metadata'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'Donation Policy',
   description:
     'Free For Charity donation policy outlining guidelines for acceptance, management, and acknowledgment of tax-deductible donations.',
-  alternates: { canonical: '/donation-policy/' },
-}
+  canonical: '/donation-policy/',
+})
 
 export default function DonationPolicy() {
   return (

--- a/src/app/eligibility-check/page.tsx
+++ b/src/app/eligibility-check/page.tsx
@@ -1,12 +1,12 @@
-import type { Metadata } from 'next'
+import { pageMetadata } from '@/lib/page-metadata'
 import DecisionWizard, { type WizardConfig } from '@/components/wizards/DecisionWizard'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'Charity Eligibility Check',
   description:
     'Answer five quick questions and find out which free Free For Charity programs your nonprofit qualifies for — domain, email, website, or migration.',
-  alternates: { canonical: '/eligibility-check/' },
-}
+  canonical: '/eligibility-check/',
+})
 
 const config: WizardConfig = {
   firstQuestion: 'org-status',

--- a/src/app/ffc-volunteer-proving-ground-core-competencies/page.tsx
+++ b/src/app/ffc-volunteer-proving-ground-core-competencies/page.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from 'next'
+import { pageMetadata } from '@/lib/page-metadata'
 import React from 'react'
 import Header from '@/components/ffc-volunteer-proving-ground-core-competencies/Header'
 import AdminGuideLink from '@/components/ui/AdminGuideLink'
@@ -7,12 +7,12 @@ import ContentSection from '@/components/ffc-volunteer-proving-ground-core-compe
 import Modulessection from '@/components/ffc-volunteer-proving-ground-core-competencies/Modules-section'
 import Footer from '@/components/ffc-volunteer-proving-ground-core-competencies/Footer'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'Volunteer Proving Ground: Core Competencies',
   description:
     'Mandatory first step for FFC volunteers. Learn foundational tools for security and effective collaboration in nonprofit technology services—and the path into our AI-driven static-site development workflow.',
-  alternates: { canonical: '/ffc-volunteer-proving-ground-core-competencies/' },
-}
+  canonical: '/ffc-volunteer-proving-ground-core-competencies/',
+})
 
 const index = () => {
   return (

--- a/src/app/ffcadmin-free-for-charity-cpanel-backup-sop/page.tsx
+++ b/src/app/ffcadmin-free-for-charity-cpanel-backup-sop/page.tsx
@@ -1,14 +1,14 @@
-import type { Metadata } from 'next'
+import { pageMetadata } from '@/lib/page-metadata'
 import Link from 'next/link'
 import AdminGuideLink from '@/components/ui/AdminGuideLink'
 import { adminLinks, ffcAdminUrl } from '@/data/admin-links'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'cPanel Backup SOP',
   description: 'Internal Free For Charity admin runbook for cPanel backups.',
-  alternates: { canonical: '/ffcadmin-free-for-charity-cpanel-backup-sop/' },
-  robots: { index: false, follow: false },
-}
+  canonical: '/ffcadmin-free-for-charity-cpanel-backup-sop/',
+  noindex: true,
+})
 
 export default function CpanelBackupSop() {
   return (

--- a/src/app/ffcadmin/page.tsx
+++ b/src/app/ffcadmin/page.tsx
@@ -1,14 +1,14 @@
-import type { Metadata } from 'next'
+import { pageMetadata } from '@/lib/page-metadata'
 import React from 'react'
 import AdminGuideLink from '@/components/ui/AdminGuideLink'
 import { adminLinks, ffcAdminUrl } from '@/data/admin-links'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'FFC Admin',
   description: 'Free For Charity internal administration portal.',
-  alternates: { canonical: '/ffcadmin/' },
-  robots: { index: false, follow: false },
-}
+  canonical: '/ffcadmin/',
+  noindex: true,
+})
 
 const index = () => {
   return (

--- a/src/app/free-charity-web-hosting/page.tsx
+++ b/src/app/free-charity-web-hosting/page.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from 'next'
+import { pageMetadata } from '@/lib/page-metadata'
 import React from 'react'
 import Hero from '@/components/free-charity-web-hosting/Hero'
 import Hosting from '@/components/free-charity-web-hosting/hosting'
@@ -9,12 +9,12 @@ import ReadyToGetStarted from '@/components/free-charity-web-hosting/ReadyToGetS
 import ClientTestimonials from '@/components/free-charity-web-hosting/ClientTestimonials'
 import FAQs from '@/components/free-charity-web-hosting/FAQs'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'Free Nonprofit Web Hosting',
   description:
     'Free website hosting for nonprofits—fast, secure GitHub Pages static sites built with AI development agents—plus free domain registration and Microsoft 365 email, with legacy WordPress hosting still available. Powered by Free For Charity volunteers.',
-  alternates: { canonical: '/free-charity-web-hosting/' },
-}
+  canonical: '/free-charity-web-hosting/',
+})
 
 const index = () => {
   return (

--- a/src/app/free-for-charity-endowment-fund/page.tsx
+++ b/src/app/free-for-charity-endowment-fund/page.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from 'next'
+import { pageMetadata } from '@/lib/page-metadata'
 import React from 'react'
 import Hero from '@/components/free-for-charity-endowment-fund-components/Hero'
 import TextSection from '@/components/free-for-charity-endowment-fund-components/Text-Section'
@@ -9,12 +9,12 @@ import SupportOurMission from '@/components/free-for-charity-endowment-fund-comp
 import VoicesofGratitude from '@/components/free-for-charity-endowment-fund-components/Voices-of-Gratitude'
 import EmpowerCharities from '@/components/free-for-charity-endowment-fund-components/Empower-Charities'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'Endowment Fund',
   description:
     'Support the Free For Charity Endowment Fund to sustain free domain and hosting services for nonprofits long-term.',
-  alternates: { canonical: '/free-for-charity-endowment-fund/' },
-}
+  canonical: '/free-for-charity-endowment-fund/',
+})
 
 const index = () => {
   return (

--- a/src/app/free-for-charity-ffc-service-delivery-stages/page.tsx
+++ b/src/app/free-for-charity-ffc-service-delivery-stages/page.tsx
@@ -1,13 +1,13 @@
-import type { Metadata } from 'next'
+import { pageMetadata } from '@/lib/page-metadata'
 import React from 'react'
 import Hero from '@/components/free-for-charity-ffc-service-delivery-stages-components/Hero'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'Service Delivery Stages',
   description:
     'How Free For Charity delivers a free nonprofit website—a fast, secure GitHub Pages static site built with AI—through our charity validation, onboarding, and launch stages, with the legacy WordPress build retained as an option.',
-  alternates: { canonical: '/free-for-charity-ffc-service-delivery-stages/' },
-}
+  canonical: '/free-for-charity-ffc-service-delivery-stages/',
+})
 
 const index = () => {
   return (

--- a/src/app/free-for-charity-ffc-web-developer-training-guide/page.tsx
+++ b/src/app/free-for-charity-ffc-web-developer-training-guide/page.tsx
@@ -1,15 +1,15 @@
-import type { Metadata } from 'next'
+import { pageMetadata } from '@/lib/page-metadata'
 import React from 'react'
 import Hero from '@/components/free-for-charity-ffc-web-developer-training-guide-components/Hero'
 import AdminGuideLink from '@/components/ui/AdminGuideLink'
 import { adminLinks, ffcAdminUrl } from '@/data/admin-links'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'Web Developer Training Guide',
   description:
     'FFC web developer training for the modern stack—building GitHub Pages static sites with AI development agents (Claude and GitHub Copilot), Next.js, Cloudflare, and Microsoft 365—with the legacy WordPress workflow retained for existing sites.',
-  alternates: { canonical: '/free-for-charity-ffc-web-developer-training-guide/' },
-}
+  canonical: '/free-for-charity-ffc-web-developer-training-guide/',
+})
 
 const index = () => {
   return (

--- a/src/app/free-for-charitys-tools-for-success/page.tsx
+++ b/src/app/free-for-charitys-tools-for-success/page.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from 'next'
+import { pageMetadata } from '@/lib/page-metadata'
 import React from 'react'
 import HeroSection from '@/components/ui/HeroSection'
 import CardSection from '@/components/free-for-charitys-tools-for-success-components/Card-section'
@@ -13,12 +13,12 @@ import SixGridCards from '@/components/free-for-charitys-tools-for-success-compo
 import ToolsForBusinesses from '@/components/free-for-charitys-tools-for-success-components/Tools-For-Businesses'
 import FiveCardsGridSection from '@/components/free-for-charitys-tools-for-success-components/Five-Cards-Grid-Section'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'Tools for Success',
   description:
     'Free productivity, educational, and business tools curated by Free For Charity to help nonprofits and volunteers succeed.',
-  alternates: { canonical: '/free-for-charitys-tools-for-success/' },
-}
+  canonical: '/free-for-charitys-tools-for-success/',
+})
 
 const index = () => {
   return (

--- a/src/app/free-training-programs/page.tsx
+++ b/src/app/free-training-programs/page.tsx
@@ -1,18 +1,16 @@
+import { pageMetadata } from '@/lib/page-metadata'
 import React from 'react'
-import type { Metadata } from 'next'
 import HeroSection from '@/components/ui/HeroSection'
 import FaqSection from '@/components/free-training-programs-components/faq-section'
 import AdminGuideLink from '@/components/ui/AdminGuideLink'
 import { adminLinks, ffcAdminUrl } from '@/data/admin-links'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'Free Training Programs',
   description:
     'Build real-world skills in business and technology through hands-on projects that help nonprofit organizations. Free For Charity offers training in research, business analysis, and web development.',
-  alternates: {
-    canonical: '/free-training-programs/',
-  },
-}
+  canonical: '/free-training-programs/',
+})
 
 const programs = [
   {

--- a/src/app/getting-started-checklist/page.tsx
+++ b/src/app/getting-started-checklist/page.tsx
@@ -1,12 +1,12 @@
-import type { Metadata } from 'next'
+import { pageMetadata } from '@/lib/page-metadata'
 import Link from 'next/link'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'Getting Started Checklist',
   description:
     'The printable one-page checklist for charities joining Free For Charity: what to gather before applying, during onboarding, and after launch.',
-  alternates: { canonical: '/getting-started-checklist/' },
-}
+  canonical: '/getting-started-checklist/',
+})
 
 const h2 =
   'font-[var(--font-faustina)] text-[32px] leading-[40px] mt-8 mb-4 print:text-[22px] print:leading-[28px] print:mt-4 print:mb-2'

--- a/src/app/google-for-nonprofits-guide/page.tsx
+++ b/src/app/google-for-nonprofits-guide/page.tsx
@@ -1,12 +1,12 @@
-import type { Metadata } from 'next'
+import { pageMetadata } from '@/lib/page-metadata'
 import Link from 'next/link'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'Google for Nonprofits & Ad Grants',
   description:
     'Claim Google for Nonprofits with your FFC-hosted site: eligibility, verification, the $10,000/month Ad Grant, and the rules that keep it active.',
-  alternates: { canonical: '/google-for-nonprofits-guide/' },
-}
+  canonical: '/google-for-nonprofits-guide/',
+})
 
 const h2 = 'font-[var(--font-faustina)] text-[32px] leading-[40px] mt-8 mb-4'
 

--- a/src/app/guides/page.tsx
+++ b/src/app/guides/page.tsx
@@ -1,13 +1,13 @@
-import type { Metadata } from 'next'
+import { pageMetadata } from '@/lib/page-metadata'
 import Link from 'next/link'
 import guidesData from '@/data/guides.json'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'Guides for Charities & Volunteers',
   description:
     'Every Free For Charity guide in one place: getting started, email and domains, fundraising visibility, compliance, security, and volunteer training.',
-  alternates: { canonical: '/guides/' },
-}
+  canonical: '/guides/',
+})
 
 interface Guide {
   href: string

--- a/src/app/guidestar-guide/page.tsx
+++ b/src/app/guidestar-guide/page.tsx
@@ -1,16 +1,16 @@
-import type { Metadata } from 'next'
+import { pageMetadata } from '@/lib/page-metadata'
 import React from 'react'
 import HeroSection from '@/components/ui/HeroSection'
 import FreeForCharity from '@/components/guidestar-guide/Free-for-charity'
 import Faqs from '@/components/guidestar-guide/Faqs'
 import CallSection from '@/components/help-for-charities-components/call-section'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'GuideStar Guide',
   description:
     "Guide for achieving GuideStar/Candid Platinum Seal of Transparency. Enhance your charity's credibility and visibility for donors.",
-  alternates: { canonical: '/guidestar-guide/' },
-}
+  canonical: '/guidestar-guide/',
+})
 
 const index = () => {
   return (

--- a/src/app/help-for-charities/page.tsx
+++ b/src/app/help-for-charities/page.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from 'next'
+import { pageMetadata } from '@/lib/page-metadata'
 import React from 'react'
 import HeroSection from '@/components/ui/HeroSection'
 import HelpForCharities from '@/components/ui/help-for-charity'
@@ -9,12 +9,12 @@ import CallSection from '@/components/help-for-charities-components/call-section
 import AdminGuideLink from '@/components/ui/AdminGuideLink'
 import { adminLinks, ffcAdminUrl } from '@/data/admin-links'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'Help for Charities',
   description:
     'Resources and support for charity and nonprofit directors. Get instant access to free tools, domains, hosting, and technology services from Free For Charity.',
-  alternates: { canonical: '/help-for-charities/' },
-}
+  canonical: '/help-for-charities/',
+})
 
 const index = () => {
   return (

--- a/src/app/how-we-count/page.tsx
+++ b/src/app/how-we-count/page.tsx
@@ -1,12 +1,12 @@
-import type { Metadata } from 'next'
+import { pageMetadata } from '@/lib/page-metadata'
 import Link from 'next/link'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'How We Count What We Report',
   description:
     'The methodology behind every Free For Charity metric: span evidence from dated records, a full census of support conversations, and the corrections we made to our own history.',
-  alternates: { canonical: '/how-we-count/' },
-}
+  canonical: '/how-we-count/',
+})
 
 const h2 = 'font-[var(--font-faustina)] text-[32px] leading-[40px] mt-8 mb-4'
 

--- a/src/app/impact/page.tsx
+++ b/src/app/impact/page.tsx
@@ -1,15 +1,15 @@
-import type { Metadata } from 'next'
+import { pageMetadata } from '@/lib/page-metadata'
 import Link from 'next/link'
 import BarChart from '@/components/impact/BarChart'
 import whmcsMembers from '@/data/whmcs-members.json'
 import { textMetrics, metric, reportingYear } from '@/data/impact'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'Our Impact — Evidence-Based Metrics',
   description:
     'Free For Charity impact, from dated records: nonprofits served per year, domains under management, support interactions, and volunteers — the same numbers published on our Candid profile.',
-  alternates: { canonical: '/impact/' },
-}
+  canonical: '/impact/',
+})
 
 interface ServedYear {
   servedNonprofits: number

--- a/src/app/irs-990n-filing-guide/page.tsx
+++ b/src/app/irs-990n-filing-guide/page.tsx
@@ -1,12 +1,12 @@
-import type { Metadata } from 'next'
+import { pageMetadata } from '@/lib/page-metadata'
 import Link from 'next/link'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'IRS Form 990-N Filing Guide',
   description:
     'Keep your 501(c)(3) alive: who files the 990-N e-Postcard, the deadline, the 8-minute filing walkthrough, and what happens if you miss three years.',
-  alternates: { canonical: '/irs-990n-filing-guide/' },
-}
+  canonical: '/irs-990n-filing-guide/',
+})
 
 const h2 = 'font-[var(--font-faustina)] text-[32px] leading-[40px] mt-8 mb-4'
 

--- a/src/app/m365-email-guide/page.tsx
+++ b/src/app/m365-email-guide/page.tsx
@@ -1,12 +1,12 @@
-import type { Metadata } from 'next'
+import { pageMetadata } from '@/lib/page-metadata'
 import Link from 'next/link'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'Free Microsoft 365 Email for Your Charity',
   description:
     'Step-by-step: get free Microsoft 365 nonprofit email at your charity domain — eligibility, tenant signup, DNS verification, mailboxes, and MFA.',
-  alternates: { canonical: '/m365-email-guide/' },
-}
+  canonical: '/m365-email-guide/',
+})
 
 const h2 = 'font-[var(--font-faustina)] text-[32px] leading-[40px] mt-8 mb-4'
 

--- a/src/app/online-impacts-onboarding-guide/page.tsx
+++ b/src/app/online-impacts-onboarding-guide/page.tsx
@@ -1,16 +1,16 @@
-import type { Metadata } from 'next'
+import { pageMetadata } from '@/lib/page-metadata'
 import React from 'react'
 import HeroSection from '@/components/ui/HeroSection'
 import CharityText from '@/components/online-impacts-onboarding-guide-components/charity-text'
 import ReadyToGetStartedNow from '@/components/online-impacts-onboarding-guide-components/Ready-To-Get-Started-Now'
 import CallSection from '@/components/help-for-charities-components/call-section'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'Online Impacts Onboarding Guide',
   description:
     'Onboarding guide for charities hosted and designed by Online Impacts, providing instant access to free tools and services.',
-  alternates: { canonical: '/online-impacts-onboarding-guide/' },
-}
+  canonical: '/online-impacts-onboarding-guide/',
+})
 
 const index = () => {
   return (

--- a/src/app/pre501c3/page.tsx
+++ b/src/app/pre501c3/page.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from 'next'
+import { pageMetadata } from '@/lib/page-metadata'
 import React from 'react'
 import HeroSection from '@/components/ui/HeroSection'
 import ReadyToGetStarted from '@/components/help-for-charities-components/Ready-to-Get-Started-Now'
@@ -9,12 +9,12 @@ import { adminLinks, ffcAdminUrl } from '@/data/admin-links'
 import Faqs from '@/components/pre501c3-components/Faqs'
 import Charity from '@/components/pre501c3-components/charity'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'Pre-501(c)(3) Onboarding Guide',
   description:
     'For charities pending 501(c)(3) status: apply to get a free website—a fast, secure GitHub Pages site built with AI—plus free tools and services from Free For Charity while your application is in progress.',
-  alternates: { canonical: '/pre501c3/' },
-}
+  canonical: '/pre501c3/',
+})
 
 const index = () => {
   return (

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -1,11 +1,11 @@
-import type { Metadata } from 'next'
+import { pageMetadata } from '@/lib/page-metadata'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'Privacy Policy',
   description:
     'Free For Charity privacy policy describing how we collect, use, and protect your personal information.',
-  alternates: { canonical: '/privacy-policy/' },
-}
+  canonical: '/privacy-policy/',
+})
 
 export default function PrivacyPolicy() {
   return (

--- a/src/app/security-acknowledgements/page.tsx
+++ b/src/app/security-acknowledgements/page.tsx
@@ -1,13 +1,13 @@
-import type { Metadata } from 'next'
+import { pageMetadata } from '@/lib/page-metadata'
 import React from 'react'
 import Link from 'next/link'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'Security Acknowledgements',
   description:
     'Acknowledging security researchers who have responsibly disclosed vulnerabilities to Free For Charity.',
-  alternates: { canonical: '/security-acknowledgements/' },
-}
+  canonical: '/security-acknowledgements/',
+})
 
 const index = () => {
   return (

--- a/src/app/techstack/page.tsx
+++ b/src/app/techstack/page.tsx
@@ -1,13 +1,13 @@
-import type { Metadata } from 'next'
+import { pageMetadata } from '@/lib/page-metadata'
 import React from 'react'
 import Hero from '@/components/techstack-components/Hero'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'Tech Stack',
   description:
     'The Free For Charity tech stack: free GitHub Pages static-site hosting, Next.js, AI-built sites (Claude and GitHub Copilot), GitHub Actions CI/CD, Cloudflare, and Microsoft 365—with the legacy WordPress architecture retained for existing sites.',
-  alternates: { canonical: '/techstack/' },
-}
+  canonical: '/techstack/',
+})
 
 const index = () => {
   return <Hero />

--- a/src/app/terms-of-service/page.tsx
+++ b/src/app/terms-of-service/page.tsx
@@ -1,11 +1,11 @@
-import type { Metadata } from 'next'
+import { pageMetadata } from '@/lib/page-metadata'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'Terms of Service',
   description:
     'Free For Charity terms of service governing access to our website and nonprofit technology services.',
-  alternates: { canonical: '/terms-of-service/' },
-}
+  canonical: '/terms-of-service/',
+})
 
 export default function TermsOfService() {
   return (

--- a/src/app/volunteer-onboarding-guide/page.tsx
+++ b/src/app/volunteer-onboarding-guide/page.tsx
@@ -1,12 +1,12 @@
-import type { Metadata } from 'next'
+import { pageMetadata } from '@/lib/page-metadata'
 import Link from 'next/link'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'Volunteer Onboarding: Your First Two Weeks',
   description:
     'The technical volunteer ramp-up at Free For Charity: accounts, the repo landscape, how a charity site goes live, communication norms, and your guaranteed first task.',
-  alternates: { canonical: '/volunteer-onboarding-guide/' },
-}
+  canonical: '/volunteer-onboarding-guide/',
+})
 
 const h2 = 'font-[var(--font-faustina)] text-[32px] leading-[40px] mt-8 mb-4'
 

--- a/src/app/volunteer-quiz/page.tsx
+++ b/src/app/volunteer-quiz/page.tsx
@@ -1,13 +1,13 @@
-import type { Metadata } from 'next'
+import { pageMetadata } from '@/lib/page-metadata'
 import Link from 'next/link'
 import DecisionWizard, { type WizardConfig } from '@/components/wizards/DecisionWizard'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'Which Volunteer Role Fits You?',
   description:
     'A one-minute quiz matching your skills and available time to a Free For Charity volunteer role — webmaster, project manager, designer, M365 admin, or coordinator.',
-  alternates: { canonical: '/volunteer-quiz/' },
-}
+  canonical: '/volunteer-quiz/',
+})
 
 const config: WizardConfig = {
   firstQuestion: 'energy',

--- a/src/app/volunteer-roles/page.tsx
+++ b/src/app/volunteer-roles/page.tsx
@@ -1,12 +1,12 @@
-import type { Metadata } from 'next'
+import { pageMetadata } from '@/lib/page-metadata'
 import Link from 'next/link'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'Volunteer Roles',
   description:
     'The five Free For Charity volunteer roles — webmaster, IT project manager, graphic designer, Microsoft 365 admin, onboarding coordinator — with skills, hours, and growth paths.',
-  alternates: { canonical: '/volunteer-roles/' },
-}
+  canonical: '/volunteer-roles/',
+})
 
 interface Role {
   title: string

--- a/src/app/volunteer/page.tsx
+++ b/src/app/volunteer/page.tsx
@@ -1,14 +1,14 @@
-import type { Metadata } from 'next'
+import { pageMetadata } from '@/lib/page-metadata'
 import React from 'react'
 import HeroSection from '@/components/ui/HeroSection'
 import FreeForCharity from '@/components/volunteer/Free-For-Charity'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'Volunteer',
   description:
     'Become a Free For Charity volunteer. Gain marketable skills in technology while helping nonprofits with domains, websites, and IT services.',
-  alternates: { canonical: '/volunteer/' },
-}
+  canonical: '/volunteer/',
+})
 
 const index = () => {
   return (

--- a/src/app/vulnerability-disclosure-policy/page.tsx
+++ b/src/app/vulnerability-disclosure-policy/page.tsx
@@ -1,13 +1,13 @@
-import type { Metadata } from 'next'
+import { pageMetadata } from '@/lib/page-metadata'
 import Link from 'next/link'
 import { hubUrl, SITE_ORIGIN } from '@/lib/config'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'Vulnerability Disclosure Policy',
   description:
     "Free For Charity's responsible vulnerability disclosure policy for security researchers, including safe harbor provisions.",
-  alternates: { canonical: '/vulnerability-disclosure-policy/' },
-}
+  canonical: '/vulnerability-disclosure-policy/',
+})
 
 export default function VulnerabilityDisclosurePolicy() {
   return (

--- a/src/app/workforce-development/page.tsx
+++ b/src/app/workforce-development/page.tsx
@@ -1,17 +1,15 @@
+import { pageMetadata } from '@/lib/page-metadata'
 import React from 'react'
-import type { Metadata } from 'next'
 import HeroSection from '@/components/ui/HeroSection'
 import AdminGuideLink from '@/components/ui/AdminGuideLink'
 import { adminLinks, ffcAdminUrl } from '@/data/admin-links'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'Workforce Development',
   description:
     'Free workforce development and training in modern web development—building GitHub Pages static sites with AI development agents (Claude and GitHub Copilot)—and programming. Build your skills while helping charities.',
-  alternates: {
-    canonical: '/workforce-development/',
-  },
-}
+  canonical: '/workforce-development/',
+})
 
 const webDevSkills = [
   'Building GitHub Pages static sites (Next.js, React, Tailwind CSS)',

--- a/src/app/zeffy-donations-guide/page.tsx
+++ b/src/app/zeffy-donations-guide/page.tsx
@@ -1,12 +1,12 @@
-import type { Metadata } from 'next'
+import { pageMetadata } from '@/lib/page-metadata'
 import Link from 'next/link'
 
-export const metadata: Metadata = {
+export const metadata = pageMetadata({
   title: 'Fee-Free Donations with Zeffy',
   description:
     'Stop losing 3-5% of every gift: how FFC charities accept online donations with Zeffy — signup, embedding on your site, receipts, and payouts.',
-  alternates: { canonical: '/zeffy-donations-guide/' },
-}
+  canonical: '/zeffy-donations-guide/',
+})
 
 const h2 = 'font-[var(--font-faustina)] text-[32px] leading-[40px] mt-8 mb-4'
 

--- a/src/lib/page-metadata.ts
+++ b/src/lib/page-metadata.ts
@@ -1,0 +1,45 @@
+import type { Metadata } from 'next'
+
+// Page-level metadata builder (issue #383). Next.js merges metadata shallowly
+// per top-level key, so a page that sets only `title`/`description` inherits
+// the ROOT openGraph/twitter objects — link previews then show the homepage
+// title on every page. This helper emits matching og/twitter fields per page
+// so shared links preview correctly. Root layout keeps the site-wide defaults.
+
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH || ''
+const OG_IMAGE = {
+  url: `${basePath}/web-app-manifest-512x512.png`,
+  width: 512,
+  height: 512,
+  alt: 'Free For Charity',
+}
+
+export function pageMetadata(input: {
+  title: string
+  description: string
+  canonical: string
+  noindex?: boolean
+}): Metadata {
+  const { title, description, canonical, noindex } = input
+  return {
+    title,
+    description,
+    alternates: { canonical },
+    ...(noindex ? { robots: { index: false, follow: false } } : {}),
+    openGraph: {
+      type: 'website',
+      siteName: 'Free For Charity',
+      url: canonical,
+      title,
+      description,
+      images: [OG_IMAGE],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      site: '@freeforcharity',
+      title,
+      description,
+      images: [OG_IMAGE.url],
+    },
+  }
+}


### PR DESCRIPTION
## What

Next.js merges route metadata shallowly, so any page that set only `title`/`description` inherited the **root** `og:title`/`og:description`/`og:url` — every guide, impact page, and policy page previewed as the homepage when shared (verified in the static export before this change).

- New `src/lib/page-metadata.ts` — `pageMetadata({title, description, canonical, noindex?})` builder that emits matching `openGraph` + `twitter` blocks (incl. the branded og:image) per page.
- Applied via codemod across **51 routes**; unused `Metadata` type imports cleaned up.
- New regression suite `__tests__/app/page-og-metadata.test.ts` (106 assertions): every route must export metadata whose og/twitter title, description, url, and image are page-specific — a new route can't silently regress link previews.
- Intentional exemptions (documented in the test): the homepage (root layout owns its OG block) and `free-for-charity-donation-policy` (absolute-title override).

## Verification
- `npm run lint` / Prettier — clean
- `npm test` — **511/511** (was 405; +106 new assertions)
- `npm run build` — static export succeeds; spot-checked `out/guides/index.html` now carries `og:title "Guides for Charities & Volunteers"` instead of the homepage title

Fixes #383
Refs #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013AwqCfp26iQEYUssk5cfCQ

---
_Generated by [Claude Code](https://claude.ai/code/session_013AwqCfp26iQEYUssk5cfCQ)_