### PR TITLE
feat: data-driven blog with fresh posts and RSS feed (backlog wave 3)

### DIFF
--- a/__tests__/components/home/Ourblogs/index.test.tsx
+++ b/__tests__/components/home/Ourblogs/index.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import OutBlogs from '@/components/home/Ourblogs'
+import blogData from '@/data/blog-posts.json'
 
 // Mock the child component to isolate the test for OutBlogs
 jest.mock('@/components/ui/BlogCard', () => {
@@ -39,41 +40,23 @@ describe('OutBlogs Component', () => {
     expect(cards).toHaveLength(3)
   })
 
-  it('passes the correct props to the InfoCard components', () => {
+  it('renders the three newest posts from the blog registry', () => {
     render(<OutBlogs />)
 
-    // Check first blog
-    expect(
-      screen.getByText('We just updated for the 2022 GuideStar Platinum Seal')
-    ).toBeInTheDocument()
-    expect(screen.getByText('Jan 9, 2023')).toBeInTheDocument()
-    expect(
-      screen.getByText(/We're excited to share that our organization has earned/)
-    ).toBeInTheDocument()
-
-    // Check second blog
-    expect(
-      screen.getByText('Our organization earned a 2021 Platinum Seal of Transparency!')
-    ).toBeInTheDocument()
-    expect(screen.getByText('Jun 1, 2021')).toBeInTheDocument()
-
-    // Check third blog
-    expect(screen.getByText('What is the cost?')).toBeInTheDocument()
-    expect(screen.getByText('Aug 24, 2017')).toBeInTheDocument()
+    const headings = screen.getAllByRole('heading', { level: 3 }).map((h) => h.textContent)
+    expect(headings).toEqual(blogData.posts.slice(0, 3).map((p) => p.heading))
+    for (const post of blogData.posts.slice(0, 3)) {
+      expect(screen.getByText(post.date)).toBeInTheDocument()
+    }
   })
 
-  it('passes the href correctly', () => {
+  it('passes each post href through to the card', () => {
     render(<OutBlogs />)
     const links = screen.getAllByRole('link')
-    expect(links).toHaveLength(3)
-    expect(links[0]).toHaveAttribute(
-      'href',
-      '/we-just-updated-for-the-2022-guidestar-platinum-seal/'
-    )
-    expect(links[1]).toHaveAttribute(
-      'href',
-      '/our-organization-earned-a-2021-platinum-seal-of-transparency/'
-    )
-    expect(links[2]).toHaveAttribute('href', '/what-is-the-cost/')
+    const expected = blogData.posts
+      .slice(0, 3)
+      .map((p) => ('href' in p ? p.href : undefined))
+      .filter(Boolean)
+    expect(links.map((l) => l.getAttribute('href'))).toEqual(expected)
   })
 })

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -2,6 +2,7 @@ import { pageMetadata } from '@/lib/page-metadata'
 import React from 'react'
 import HeroSection from '@/components/ui/HeroSection'
 import BlogCard from '@/components/ui/BlogCard'
+import blogData from '@/data/blog-posts.json'
 
 export const metadata = pageMetadata({
   title: 'Blog',
@@ -10,50 +11,7 @@ export const metadata = pageMetadata({
   canonical: '/blog/',
 })
 
-const blogPosts = [
-  {
-    heading: 'We just updated for the 2022 GuideStar Platinum Seal',
-    date: '2022',
-    description:
-      "We're excited to share that our organization has earned a 2022 Platinum Seal of Transparency with Candid! Now, you can support our work with trust and confidence by viewing our nonprofit profile.",
-    imageUrl: '/Images/donation.webp',
-  },
-  {
-    heading: 'Our organization earned a 2021 Platinum Seal of Transparency!',
-    date: '2021',
-    description:
-      'Now, everyone can see our strategy, metrics, and achievements. Check out our updated nonprofit profile on Candid.',
-    imageUrl: '/Images/donation.webp',
-  },
-  {
-    heading: 'What is the cost?',
-    date: '',
-    description:
-      'You would be amazed at how frequently we get asked this question about our costs. For our consulting engagements we are actually 100% free. While there are many companies and other nonprofits that charge for these services, we provide them for free!',
-    imageUrl: '/Images/donation.webp',
-  },
-  {
-    heading: 'Free For Charity Just Earned the Platinum Seal of Transparency',
-    date: '',
-    description:
-      "Great news! Free For Charity just earned the Platinum Seal of Transparency from GuideStar, the world's largest source of nonprofit information. By sharing these metrics, we're helping the sector move beyond simplistic financial ratios to assess nonprofit progress.",
-    imageUrl: '/Images/donation.webp',
-  },
-  {
-    heading: 'Using a Registered Agent Service (Northwest Registered Agent)',
-    date: '',
-    description:
-      'Free For Charity uses a unique service for managing legal compliance for the non-profit. We use a registered agent service called Northwest Registered Agent.',
-    imageUrl: '/Images/donation.webp',
-  },
-  {
-    heading: 'Podio Sponsorship Program',
-    date: '',
-    description:
-      'With our brand new 501c3 status we are getting access to a lot of new and exciting tools. Free For Charity is now formally testing out Podio. Once tested we will add it to our technology directory.',
-    imageUrl: '/Images/donation.webp',
-  },
-]
+const blogPosts = blogData.posts
 
 const BlogPage = () => {
   return (
@@ -74,6 +32,7 @@ const BlogPage = () => {
                 date={post.date}
                 description={post.description}
                 imageUrl={post.imageUrl}
+                href={'href' in post ? post.href : undefined}
               />
             ))}
           </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -50,6 +50,7 @@ export const metadata: Metadata = {
   },
   alternates: {
     canonical: '/',
+    types: { 'application/rss+xml': `${basePath}/rss.xml` },
   },
   openGraph: {
     type: 'website',

--- a/src/app/rss.xml/route.ts
+++ b/src/app/rss.xml/route.ts
@@ -1,0 +1,47 @@
+import blogData from '@/data/blog-posts.json'
+
+// RSS feed generated at build time from the blog registry (issue #384).
+// Static export: this route handler runs during `next build` only.
+export const dynamic = 'force-static'
+
+const SITE = 'https://www.freeforcharity.org'
+
+function escapeXml(s: string) {
+  return s
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+}
+
+export async function GET() {
+  const items = blogData.posts
+    .map((post) => {
+      const link = post.href?.startsWith('/')
+        ? `${SITE}${post.href}`
+        : (post.href ?? `${SITE}/blog/`)
+      return `    <item>
+      <title>${escapeXml(post.heading)}</title>
+      <link>${escapeXml(link)}</link>
+      <guid isPermaLink="false">${escapeXml(post.isoDate + ':' + post.heading)}</guid>
+      <pubDate>${new Date(post.isoDate + 'T12:00:00Z').toUTCString()}</pubDate>
+      <description>${escapeXml(post.description)}</description>
+    </item>`
+    })
+    .join('\n')
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Free For Charity Blog</title>
+    <link>${SITE}/blog/</link>
+    <description>News and updates from Free For Charity — free websites, domains, and Microsoft 365 for nonprofits.</description>
+    <language>en-us</language>
+${items}
+  </channel>
+</rss>
+`
+  return new Response(xml, {
+    headers: { 'Content-Type': 'application/rss+xml; charset=utf-8' },
+  })
+}

--- a/src/components/home/Ourblogs/index.tsx
+++ b/src/components/home/Ourblogs/index.tsx
@@ -1,56 +1,35 @@
 import React from 'react'
 import InfoCard from '../../ui/BlogCard'
+import blogData from '@/data/blog-posts.json'
 
 interface Blog {
   heading: string
   date: string
+  isoDate: string
   description: string
   imageUrl?: string
-  href?: string // added href for dynamic link
+  href?: string
 }
 
-const OutBlogs: React.FC = () => {
-  const blogs: Blog[] = [
-    {
-      heading: 'We just updated for the 2022 GuideStar Platinum Seal',
-      date: 'Jan 9, 2023',
-      description:
-        "We're excited to share that our organization has earned a 2022 Platinum Seal of Transparency with Candid! Now, you can support our work with trust and confidence by viewing our nonprofit profile Free For Charity - GuideStar Profile",
-      imageUrl: '/Images/card-image.webp',
-      // .htaccess 301s the WP-era slug to /blog/ — using the relative
-      // path keeps the legacy URL alive for any external backlink.
-      href: '/we-just-updated-for-the-2022-guidestar-platinum-seal/',
-    },
-    {
-      heading: 'Our organization earned a 2021 Platinum Seal of Transparency!',
-      date: 'Jun 1, 2021',
-      description:
-        'Our organization earned a 2021 Platinum Seal of Transparency! Now, everyone can see our strategy, metrics, and achievements. Check out our updated #NonprofitProfile on Candid https://www.guidestar.org/profile/46-2471893',
-      href: '/our-organization-earned-a-2021-platinum-seal-of-transparency/',
-    },
-    {
-      heading: 'What is the cost?',
-      date: 'Aug 24, 2017',
-      description:
-        'You would be amazed at how frequently we get asked this question about our costs. For our consulting engagements we are actually 100% free. While there are many, many companies and some other nonprofits that charge for these services we provide them for free! Hence...',
-      href: '/what-is-the-cost/',
-    },
-  ]
+// Homepage section renders the three newest posts from the same registry the
+// /blog/ page and /rss.xml are generated from (src/data/blog-posts.json).
+const posts = (blogData.posts as Blog[]).slice(0, 3)
 
+const OutBlogs: React.FC = () => {
   return (
     <div className="py-10 pb-25 px-4 bg-white">
       <h2 className="text-center py-5 font-[700] text-[#b35000] text-[30px] md:text-[40px] leading-[44px] mb-7">
         Our Blogs
       </h2>
       <div className="w-full max-w-[1200px] mx-auto grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 sm:gap-8 lg:gap-12 items-start">
-        {blogs.map((blog, index) => (
+        {posts.map((blog) => (
           <InfoCard
-            key={index}
+            key={blog.heading}
             heading={blog.heading}
             date={blog.date}
             description={blog.description}
             imageUrl={blog.imageUrl}
-            href={blog.href} // pass href to InfoCard
+            href={blog.href}
           />
         ))}
       </div>

--- a/src/data/blog-posts.json
+++ b/src/data/blog-posts.json
@@ -1,0 +1,66 @@
+{
+  "_comment": "Single source of truth for blog posts (issue #384). Newest first. The /blog/ page renders all posts; the homepage Our Blogs section renders the first three; /rss.xml is generated from isoDate. href may point at an on-site page (deep dive) or a legacy WP slug kept alive by .htaccess redirects.",
+  "posts": [
+    {
+      "heading": "Free For Charity earns the 2026 Platinum Seal of Transparency",
+      "date": "Jul 2, 2026",
+      "isoDate": "2026-07-02",
+      "description": "We just renewed our Candid Platinum seal — and this time every published metric traces to dated records: 248 nonprofits served in 2025, 41 active volunteers, and a full census of 1,153 support conversations. See the numbers, the growth curve, and exactly how we count them on our new impact dashboard.",
+      "imageUrl": "/Images/donation.webp",
+      "href": "/impact/"
+    },
+    {
+      "heading": "New on freeforcharity.org: guides hub, eligibility check, and more",
+      "date": "Jul 3, 2026",
+      "isoDate": "2026-07-03",
+      "description": "One update, fifteen new resources for charities: a guides hub covering free email, domains, Google Ad Grants, fee-free donations, 990-N compliance, and security basics — plus a two-minute eligibility checker, a charity FAQ built from what you actually ask us, and a volunteer role quiz.",
+      "imageUrl": "/Images/donation.webp",
+      "href": "/guides/"
+    },
+    {
+      "heading": "We just updated for the 2022 GuideStar Platinum Seal",
+      "date": "Jan 9, 2023",
+      "isoDate": "2023-01-09",
+      "description": "We're excited to share that our organization has earned a 2022 Platinum Seal of Transparency with Candid! Now, you can support our work with trust and confidence by viewing our nonprofit profile.",
+      "imageUrl": "/Images/card-image.webp",
+      "href": "/we-just-updated-for-the-2022-guidestar-platinum-seal/"
+    },
+    {
+      "heading": "Our organization earned a 2021 Platinum Seal of Transparency!",
+      "date": "Jun 1, 2021",
+      "isoDate": "2021-06-01",
+      "description": "Our organization earned a 2021 Platinum Seal of Transparency! Now, everyone can see our strategy, metrics, and achievements. Check out our updated nonprofit profile on Candid.",
+      "imageUrl": "/Images/donation.webp",
+      "href": "/our-organization-earned-a-2021-platinum-seal-of-transparency/"
+    },
+    {
+      "heading": "What is the cost?",
+      "date": "Aug 24, 2017",
+      "isoDate": "2017-08-24",
+      "description": "You would be amazed at how frequently we get asked this question about our costs. For our consulting engagements we are actually 100% free. While there are many companies and other nonprofits that charge for these services, we provide them for free!",
+      "imageUrl": "/Images/donation.webp",
+      "href": "/what-is-the-cost/"
+    },
+    {
+      "heading": "Free For Charity Just Earned the Platinum Seal of Transparency",
+      "date": "2017",
+      "isoDate": "2017-06-01",
+      "description": "Great news! Free For Charity just earned the Platinum Seal of Transparency from GuideStar, the world's largest source of nonprofit information. By sharing these metrics, we're helping the sector move beyond simplistic financial ratios to assess nonprofit progress.",
+      "imageUrl": "/Images/donation.webp"
+    },
+    {
+      "heading": "Using a Registered Agent Service (Northwest Registered Agent)",
+      "date": "2016",
+      "isoDate": "2016-06-01",
+      "description": "Free For Charity uses a unique service for managing legal compliance for the non-profit. We use a registered agent service called Northwest Registered Agent.",
+      "imageUrl": "/Images/donation.webp"
+    },
+    {
+      "heading": "Podio Sponsorship Program",
+      "date": "2015",
+      "isoDate": "2015-06-01",
+      "description": "With our brand new 501c3 status we are getting access to a lot of new and exciting tools. Free For Charity is now formally testing out Podio. Once tested we will add it to our technology directory.",
+      "imageUrl": "/Images/donation.webp"
+    }
+  ]
+}


### PR DESCRIPTION
## What

The homepage "Our Blogs" section led with 2022 news while FFC just earned the **Platinum Transparency 2026** seal. This makes the blog data-driven and current:

- **`src/data/blog-posts.json`** — single source of truth (newest first, with `isoDate`) feeding three consumers:
  - `/blog/` page (all posts, now with links through to deep pages)
  - homepage Our Blogs section (three newest — tests now assert against the registry, not hardcoded copy)
  - **`/rss.xml`** — build-time route handler (`force-static`), advertised via `rel=alternate` in the head
- **Two new posts lead:** the 2026 Platinum seal with evidence-based metrics (→ `/impact/`) and the new charity self-service resources (→ `/guides/`). Legacy posts retained with their original dates.

## Verification
- `npm run lint` / Prettier — clean
- `npm test` — 519/519
- `npm run build` — static export succeeds; `out/rss.xml` verified well-formed with all 8 items

Fixes #384
Refs #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013AwqCfp26iQEYUssk5cfCQ

---
_Generated by [Claude Code](https://claude.ai/code/session_013AwqCfp26iQEYUssk5cfCQ)_