### PR TITLE
feat: matching-gifts page and Powered-by-FFC badge (backlog wave 4)

### DIFF
--- a/public/badges/powered-by-ffc-dark.svg
+++ b/public/badges/powered-by-ffc-dark.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="220" height="44" viewBox="0 0 220 44" role="img" aria-label="Powered by Free For Charity">
+  <title>Powered by Free For Charity</title>
+  <rect x="0.5" y="0.5" width="219" height="43" rx="8" fill="#1a1a1a" stroke="#5BA3D9"/>
+  <path d="M22 30.5c-.4 0-.8-.15-1.1-.44l-6.2-5.9A5.4 5.4 0 0 1 13 20.2c0-3 2.3-5.4 5.2-5.4 1.4 0 2.8.6 3.8 1.7a5.14 5.14 0 0 1 3.8-1.7c2.9 0 5.2 2.4 5.2 5.4 0 1.5-.6 2.9-1.7 3.96l-6.2 5.9c-.3.29-.7.44-1.1.44z" fill="#F26721"/>
+  <text x="40" y="19" font-family="Segoe UI, Arial, Helvetica, sans-serif" font-size="11" fill="#cccccc">Powered by</text>
+  <text x="40" y="34" font-family="Segoe UI, Arial, Helvetica, sans-serif" font-size="14" font-weight="700" fill="#5BA3D9">Free For Charity</text>
+</svg>

--- a/public/badges/powered-by-ffc.svg
+++ b/public/badges/powered-by-ffc.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="220" height="44" viewBox="0 0 220 44" role="img" aria-label="Powered by Free For Charity">
+  <title>Powered by Free For Charity</title>
+  <rect x="0.5" y="0.5" width="219" height="43" rx="8" fill="#ffffff" stroke="#0567B1"/>
+  <path d="M22 30.5c-.4 0-.8-.15-1.1-.44l-6.2-5.9A5.4 5.4 0 0 1 13 20.2c0-3 2.3-5.4 5.2-5.4 1.4 0 2.8.6 3.8 1.7a5.14 5.14 0 0 1 3.8-1.7c2.9 0 5.2 2.4 5.2 5.4 0 1.5-.6 2.9-1.7 3.96l-6.2 5.9c-.3.29-.7.44-1.1.44z" fill="#F26721"/>
+  <text x="40" y="19" font-family="Segoe UI, Arial, Helvetica, sans-serif" font-size="11" fill="#555555">Powered by</text>
+  <text x="40" y="34" font-family="Segoe UI, Arial, Helvetica, sans-serif" font-size="14" font-weight="700" fill="#0567B1">Free For Charity</text>
+</svg>

--- a/src/app/badge/page.tsx
+++ b/src/app/badge/page.tsx
@@ -1,0 +1,94 @@
+import { pageMetadata } from '@/lib/page-metadata'
+import Link from 'next/link'
+import { assetPath } from '@/lib/assetPath'
+
+export const metadata = pageMetadata({
+  title: 'Powered by Free For Charity Badge',
+  description:
+    'Show your supporters your site runs on donated infrastructure — copy the Powered by Free For Charity badge embed for your nonprofit website.',
+  canonical: '/badge/',
+})
+
+const h2 = 'font-[var(--font-faustina)] text-[32px] leading-[40px] mt-8 mb-4'
+
+// Served from the production host (not assetPath) so the snippet works on any
+// charity site and design refreshes propagate to every embedder — the same
+// live-embed principle as the Candid seal.
+const LIGHT = 'https://www.freeforcharity.org/badges/powered-by-ffc.svg'
+const DARK = 'https://www.freeforcharity.org/badges/powered-by-ffc-dark.svg'
+
+const snippet = `<a href="https://www.freeforcharity.org/" title="Free websites, domains, and email for nonprofits">
+  <img src="${LIGHT}" alt="Powered by Free For Charity" width="220" height="44" />
+</a>`
+
+export default function BadgePage() {
+  return (
+    <div className="ffc-container py-16">
+      <div className="max-w-4xl mx-auto">
+        <h1 className="font-[var(--font-faustina)] text-[48px] leading-[60px] mb-8">
+          The &ldquo;Powered by Free For Charity&rdquo; Badge
+        </h1>
+
+        <div className="prose max-w-none font-[var(--font-lato)] text-[18px] leading-[28px]">
+          <p>
+            If FFC hosts your charity&rsquo;s site, this badge tells your supporters their donations
+            aren&rsquo;t paying hosting bills — and it points the next charity that needs help
+            toward us. Every badge link also strengthens the search authority of the whole network
+            of supported charities, including yours.
+          </p>
+
+          <h2 className={h2}>The badge</h2>
+          <p className="flex flex-wrap items-center gap-6">
+            {/* eslint-disable-next-line @next/next/no-img-element -- displaying the literal badge asset */}
+            <img
+              src={assetPath('/badges/powered-by-ffc.svg')}
+              alt="Powered by Free For Charity (light variant)"
+              width={220}
+              height={44}
+            />
+            <span className="inline-block rounded bg-[#1a1a1a] p-2">
+              {/* eslint-disable-next-line @next/next/no-img-element -- displaying the literal badge asset */}
+              <img
+                src={assetPath('/badges/powered-by-ffc-dark.svg')}
+                alt="Powered by Free For Charity (dark variant)"
+                width={220}
+                height={44}
+              />
+            </span>
+          </p>
+
+          <h2 className={h2}>Copy the embed</h2>
+          <p>
+            Paste this anywhere in your site&rsquo;s footer. The image is served from
+            freeforcharity.org, so if the design is refreshed your badge updates automatically — no
+            maintenance on your side. (If FFC built your site, just ask and we&rsquo;ll add it for
+            you.)
+          </p>
+          <pre className="whitespace-pre-wrap break-all bg-[#f5f5f5] text-left text-[13px] leading-[20px] p-4 rounded border border-gray-200">
+            {snippet}
+          </pre>
+          <p>
+            Dark background? Swap the image URL for <code>{DARK}</code>.
+          </p>
+
+          <h2 className={h2}>Usage terms (short version)</h2>
+          <ul>
+            <li>
+              Use it if Free For Charity provides your organization&rsquo;s hosting, domain, email,
+              or site support.
+            </li>
+            <li>
+              Don&rsquo;t alter the artwork or imply endorsement of products/services we don&rsquo;t
+              provide.
+            </li>
+            <li>
+              Not supported by us yet?{' '}
+              <Link href="/eligibility-check/">Check your eligibility</Link> — the badge comes with
+              the program.
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/matching-gifts/page.tsx
+++ b/src/app/matching-gifts/page.tsx
@@ -1,0 +1,110 @@
+import { pageMetadata } from '@/lib/page-metadata'
+import Link from 'next/link'
+
+export const metadata = pageMetadata({
+  title: 'Matching Gifts & Volunteer Grants',
+  description:
+    "Double your donation for free: check your employer's matching-gift program, and turn volunteer hours into employer grants. FFC's details for the forms are here.",
+  canonical: '/matching-gifts/',
+})
+
+const h2 = 'font-[var(--font-faustina)] text-[32px] leading-[40px] mt-8 mb-4'
+
+export default function MatchingGifts() {
+  return (
+    <div className="ffc-container py-16">
+      <div className="max-w-4xl mx-auto">
+        <h1 className="font-[var(--font-faustina)] text-[48px] leading-[60px] mb-8">
+          Double Your Gift — Without Spending Another Dollar
+        </h1>
+
+        <div className="prose max-w-none font-[var(--font-lato)] text-[18px] leading-[28px]">
+          <p>
+            Most large employers (and many mid-size ones) will{' '}
+            <strong>match charitable donations</strong> their employees make — often
+            dollar-for-dollar — and many also pay <strong>volunteer grants</strong>: a donation to
+            the nonprofit for every hour you volunteer. Billions of matching dollars go unclaimed
+            every year simply because nobody submits the form. Two minutes of paperwork can double
+            what your gift does for the charities we serve.
+          </p>
+
+          <h2 className={h2}>Step 1 — Check whether your employer matches</h2>
+          <ul>
+            <li>
+              Search your company intranet or benefits portal for &ldquo;matching gifts.&rdquo;
+            </li>
+            <li>
+              Ask HR — the programs are usually run through platforms like Benevity, YourCause, or
+              Bright Funds.
+            </li>
+            <li>Retirees and employees&rsquo; spouses are often eligible too — worth asking.</li>
+          </ul>
+
+          <h2 className={h2}>Step 2 — Submit FFC&rsquo;s details</h2>
+          <p>Everything a matching-gift or volunteer-grant form asks for:</p>
+          <div className="border border-gray-200 rounded-lg p-6 not-prose font-[var(--font-lato)] text-[17px] leading-[28px]">
+            <dl>
+              <div>
+                <dt className="font-[700] inline">Legal name: </dt>
+                <dd className="inline">Free For Charity</dd>
+              </div>
+              <div>
+                <dt className="font-[700] inline">EIN (tax ID): </dt>
+                <dd className="inline">46-2471893</dd>
+              </div>
+              <div>
+                <dt className="font-[700] inline">Status: </dt>
+                <dd className="inline">501(c)(3) public charity (IRS designation since 2014)</dd>
+              </div>
+              <div>
+                <dt className="font-[700] inline">Mailing address: </dt>
+                <dd className="inline">4030 Wake Forrest Road, Suite 349, Raleigh, NC</dd>
+              </div>
+              <div>
+                <dt className="font-[700] inline">Website: </dt>
+                <dd className="inline">https://www.freeforcharity.org</dd>
+              </div>
+              <div>
+                <dt className="font-[700] inline">Verification: </dt>
+                <dd className="inline">
+                  Candid (GuideStar) profile —{' '}
+                  <a
+                    href="https://www.guidestar.org/profile/46-2471893"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-[#0567B1] underline"
+                  >
+                    Platinum Seal of Transparency
+                  </a>
+                </dd>
+              </div>
+            </dl>
+          </div>
+
+          <h2 className={h2}>Volunteer grants: your hours are worth money</h2>
+          <p>
+            If you volunteer with FFC — as a webmaster, project manager, designer, or M365 admin —
+            your employer may donate for every hour you log (commonly $10–25/hour). A volunteer
+            giving 4 hours a week can generate <em>thousands</em> of dollars a year for the program
+            without donating a cent. Check the same benefits portal for &ldquo;volunteer
+            grants&rdquo; or &ldquo;dollars for doers,&rdquo; and we&rsquo;ll gladly verify your
+            hours. Not volunteering yet? <Link href="/volunteer-quiz/">Find your role</Link>.
+          </p>
+
+          <h2 className={h2}>What your matched dollars do</h2>
+          <p>
+            Every ${String(16.5)} keeps one charity&rsquo;s domain, email, and website alive for a
+            year — see the full <Link href="/cost-transparency/">unit economics</Link>. A $100 gift
+            matched to $200 covers <strong>twelve charities</strong>.
+          </p>
+
+          <p className="mt-8">
+            Questions, or a form that needs something we didn&rsquo;t list?{' '}
+            <Link href="/contact-us/">Contact us</Link> and we&rsquo;ll turn it around quickly —
+            matched money is the best kind of money.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -106,6 +106,8 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { path: '/contribute', priority: 0.7, changeFrequency: 'monthly' as const },
     { path: '/eligibility-check', priority: 0.8, changeFrequency: 'monthly' as const },
     { path: '/volunteer-quiz', priority: 0.7, changeFrequency: 'monthly' as const },
+    { path: '/matching-gifts', priority: 0.7, changeFrequency: 'monthly' as const },
+    { path: '/badge', priority: 0.5, changeFrequency: 'yearly' as const },
   ]
 
   return routes.map((route) => ({

--- a/tests/routes.ts
+++ b/tests/routes.ts
@@ -85,4 +85,6 @@ export const siteRoutes = [
   { route: '/contribute', name: 'Contribute on GitHub' },
   { route: '/eligibility-check', name: 'Eligibility Check' },
   { route: '/volunteer-quiz', name: 'Volunteer Quiz' },
+  { route: '/matching-gifts', name: 'Matching Gifts' },
+  { route: '/badge', name: 'Powered-by Badge' },
 ]


### PR DESCRIPTION
## What

Two more backlog items, both purely additive:

- **`/matching-gifts/`** — employer matching-gift + volunteer-grant ("dollars for doers") guidance, with the exact details donor forms require in one copyable block: legal name, EIN 46-2471893, 501(c)(3) status, mailing address (from the footer's published Main Address), website, and the Candid verification link. Ties gift units to the cost-transparency math. Fixes #400
- **`/badge/`** — the embeddable "Powered by Free For Charity" badge: light + dark SVGs under `public/badges/`, a copyable snippet that hotlinks the production asset (so design refreshes propagate to every charity site, same live-embed principle as the Candid seal), and short usage terms. Fixes #381

Both routes registered in `sitemap.ts` and the shared E2E route list (they're covered by the accessibility + trailing-slash suites automatically).

## Verification
- `npm run lint` / Prettier — clean
- `npm test` — 523/523
- `npm run build` — static export succeeds; both badge SVGs ship in the export

Refs #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013AwqCfp26iQEYUssk5cfCQ

---
_Generated by [Claude Code](https://claude.ai/code/session_013AwqCfp26iQEYUssk5cfCQ)_