### PR TITLE
feat: charities-we-support directory from the sites-list snapshot (backlog wave 5)

### DIFF
--- a/src/app/charities-we-support/page.tsx
+++ b/src/app/charities-we-support/page.tsx
@@ -1,0 +1,68 @@
+import { pageMetadata } from '@/lib/page-metadata'
+import Link from 'next/link'
+import directory from '@/data/supported-charities.json'
+
+export const metadata = pageMetadata({
+  title: 'Charities We Support',
+  description:
+    'The nonprofits whose domains, email, and websites run on Free For Charity — a live directory of the organizations our volunteers and donors keep online.',
+  canonical: '/charities-we-support/',
+})
+
+const { charities, snapshotDate } = directory as unknown as {
+  charities: { domain: string }[]
+  snapshotDate: string
+}
+
+export default function CharitiesWeSupport() {
+  return (
+    <div className="ffc-container py-16">
+      <div className="max-w-4xl mx-auto">
+        <h1 className="font-[var(--font-faustina)] text-[48px] leading-[60px] mb-4">
+          Charities We Support
+        </h1>
+        <p className="font-[var(--font-lato)] text-[18px] leading-[28px] text-[#555] mb-2">
+          These are {charities.length} organizations with live websites running on Free For
+          Charity&rsquo;s donated infrastructure — domains we keep registered, DNS we keep secure,
+          and sites our volunteers build and maintain. (Our full estate is larger:{' '}
+          <Link href="/impact/" className="text-[#0567B1] underline">
+            see the impact numbers
+          </Link>
+          . This directory lists only currently-live public sites.)
+        </p>
+        <p className="font-[var(--font-lato)] text-[14px] leading-[22px] text-[#767672] mb-8">
+          Snapshot from our operational sites inventory, {snapshotDate}. Listed organization?
+          We&rsquo;re glad to feature you — or remove you on request via the{' '}
+          <Link href="/contact-us/" className="underline">
+            contact page
+          </Link>
+          .
+        </p>
+
+        <ul className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-x-6 gap-y-2">
+          {charities.map((c) => (
+            <li key={c.domain}>
+              <a
+                href={`https://${c.domain}/`}
+                target="_blank"
+                rel="noopener"
+                className="font-[var(--font-lato)] text-[16px] leading-[26px] text-[#0567B1] hover:underline break-all"
+              >
+                {c.domain}
+              </a>
+            </li>
+          ))}
+        </ul>
+
+        <div className="prose max-w-none font-[var(--font-lato)] text-[18px] leading-[28px] mt-10">
+          <p>
+            Want your nonprofit on this list — with the free domain, email, and website that come
+            with it? Take the <Link href="/eligibility-check/">two-minute eligibility check</Link>.
+            Want to keep these organizations online? Each one costs about $16.50/year —{' '}
+            <Link href="/donate/">fund a few</Link>.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -108,6 +108,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { path: '/volunteer-quiz', priority: 0.7, changeFrequency: 'monthly' as const },
     { path: '/matching-gifts', priority: 0.7, changeFrequency: 'monthly' as const },
     { path: '/badge', priority: 0.5, changeFrequency: 'yearly' as const },
+    { path: '/charities-we-support', priority: 0.8, changeFrequency: 'weekly' as const },
   ]
 
   return routes.map((route) => ({

--- a/src/data/supported-charities.json
+++ b/src/data/supported-charities.json
@@ -1,0 +1,394 @@
+{
+  "_comment": "Public directory snapshot for /charities-we-support/ (issue #377). Derived from the FFC sites-list (FFC-Cloudflare-Automation sites-list/sites_list.json, commit c18c5c5, 2026-06-08): domains with a working site (Live/Redirect health), excluding organizations that left FFC, staging domains, and FFC's own infrastructure domains. Org domains are public project data (sites-list precedent); no contact or personal data. OPT-OUT: any organization can be removed on request via the contact page - delete its row here and note the request in the PR.",
+  "sourceCommit": "c18c5c5",
+  "snapshotDate": "2026-06-08",
+  "charities": [
+    {
+      "domain": "3dmc2.com"
+    },
+    {
+      "domain": "aariasblueelephant.org"
+    },
+    {
+      "domain": "abundances.org"
+    },
+    {
+      "domain": "acharyaapp.org"
+    },
+    {
+      "domain": "alltypetowing.com"
+    },
+    {
+      "domain": "amargraves.org"
+    },
+    {
+      "domain": "ambofoundation.org"
+    },
+    {
+      "domain": "americanlegionpost64.com"
+    },
+    {
+      "domain": "americanlegionpost64.org"
+    },
+    {
+      "domain": "amplifiedaid.org"
+    },
+    {
+      "domain": "aprilhansen.com"
+    },
+    {
+      "domain": "aprilunlimited.com"
+    },
+    {
+      "domain": "avengedfastpitch.org"
+    },
+    {
+      "domain": "bearupinternationalministries.org"
+    },
+    {
+      "domain": "bhakthinivedana.com/sandbox"
+    },
+    {
+      "domain": "bintobetter.org"
+    },
+    {
+      "domain": "bowiesblessings.org"
+    },
+    {
+      "domain": "bringingpeople2people.org"
+    },
+    {
+      "domain": "browncanyonranch.org"
+    },
+    {
+      "domain": "bucktownbullsbaseball.org"
+    },
+    {
+      "domain": "bulldogztowing.com"
+    },
+    {
+      "domain": "canadatokeywestcoastalrun.org"
+    },
+    {
+      "domain": "clarasbridge.org"
+    },
+    {
+      "domain": "clarkemoyer.com"
+    },
+    {
+      "domain": "clarkmoyer.com"
+    },
+    {
+      "domain": "coronadonationalforestheritagesociety.org"
+    },
+    {
+      "domain": "cortesdesignworks.com"
+    },
+    {
+      "domain": "ctvip.org"
+    },
+    {
+      "domain": "cucu-il.org"
+    },
+    {
+      "domain": "cvrs-us.org"
+    },
+    {
+      "domain": "database.onlineimpacts.org"
+    },
+    {
+      "domain": "e2inc.org"
+    },
+    {
+      "domain": "educationandempowerment.org"
+    },
+    {
+      "domain": "emc-professional.com"
+    },
+    {
+      "domain": "emc-professional.org"
+    },
+    {
+      "domain": "exceptionalridersprogram.org"
+    },
+    {
+      "domain": "facinggiantsnc.org"
+    },
+    {
+      "domain": "falloutshelterecovillage.org"
+    },
+    {
+      "domain": "fencingtogether.org"
+    },
+    {
+      "domain": "focus-on-free.com"
+    },
+    {
+      "domain": "foxtrotenterprises.com"
+    },
+    {
+      "domain": "freedomrisingusa.org"
+    },
+    {
+      "domain": "ftnfcog.org"
+    },
+    {
+      "domain": "ghcd.onlineimpacts.org"
+    },
+    {
+      "domain": "graftonareahistory.org"
+    },
+    {
+      "domain": "greenrecon.org"
+    },
+    {
+      "domain": "hardpointconsulting.com"
+    },
+    {
+      "domain": "harmonycenterfoundation.org"
+    },
+    {
+      "domain": "heroes2others.org"
+    },
+    {
+      "domain": "homesforchange.org"
+    },
+    {
+      "domain": "hunnewellscottages.com"
+    },
+    {
+      "domain": "iawea.net"
+    },
+    {
+      "domain": "innovatesphere.org"
+    },
+    {
+      "domain": "instituteofforgiveness.org"
+    },
+    {
+      "domain": "jwvpost619.org"
+    },
+    {
+      "domain": "kainkaryasri.org"
+    },
+    {
+      "domain": "kieranrunnelsdev.org"
+    },
+    {
+      "domain": "kierstensride.org"
+    },
+    {
+      "domain": "ksgf.org"
+    },
+    {
+      "domain": "legion-in-the-woods.org"
+    },
+    {
+      "domain": "legioninthewoods.org"
+    },
+    {
+      "domain": "letsdanceactivities.com"
+    },
+    {
+      "domain": "letsdanceactivities.org"
+    },
+    {
+      "domain": "letsleadwise.org"
+    },
+    {
+      "domain": "letspiritlead.org"
+    },
+    {
+      "domain": "lifelessonslearned.us.org"
+    },
+    {
+      "domain": "mattressfiberglass.org"
+    },
+    {
+      "domain": "mitchellnchistory.org"
+    },
+    {
+      "domain": "movewithcompassion.org"
+    },
+    {
+      "domain": "moyermanagement.com"
+    },
+    {
+      "domain": "muckfichigan.com"
+    },
+    {
+      "domain": "my-missions.org"
+    },
+    {
+      "domain": "myservicehours.org"
+    },
+    {
+      "domain": "nj4israel.org"
+    },
+    {
+      "domain": "nochaos.org"
+    },
+    {
+      "domain": "nolef.onlineimpacts.org"
+    },
+    {
+      "domain": "npbandparents.org"
+    },
+    {
+      "domain": "nu4children.org"
+    },
+    {
+      "domain": "ohiomtawest.org"
+    },
+    {
+      "domain": "onlineimpacts.org"
+    },
+    {
+      "domain": "pagbooster.org"
+    },
+    {
+      "domain": "postpartumcarefoundation.com"
+    },
+    {
+      "domain": "postpartumcarefoundation.org"
+    },
+    {
+      "domain": "ptuganda.org"
+    },
+    {
+      "domain": "rebirthsdc.org"
+    },
+    {
+      "domain": "savewatersaveplanet.org"
+    },
+    {
+      "domain": "scwcinc.org"
+    },
+    {
+      "domain": "sfcityarts.org"
+    },
+    {
+      "domain": "slopestohope.org"
+    },
+    {
+      "domain": "southamptonfriends.org"
+    },
+    {
+      "domain": "srrn.net"
+    },
+    {
+      "domain": "srs806.org"
+    },
+    {
+      "domain": "stylesbysheba.com"
+    },
+    {
+      "domain": "tamkeensports.org"
+    },
+    {
+      "domain": "tasteandseelocal.org"
+    },
+    {
+      "domain": "tech4security.com"
+    },
+    {
+      "domain": "techforsecurity.com"
+    },
+    {
+      "domain": "technologyadoptionbarriers.org"
+    },
+    {
+      "domain": "technologymonastery.org"
+    },
+    {
+      "domain": "technologymonastery.us"
+    },
+    {
+      "domain": "technomonasteries.org"
+    },
+    {
+      "domain": "thebirf.org"
+    },
+    {
+      "domain": "thecrookedhouse.net"
+    },
+    {
+      "domain": "thecrookedhouse.org"
+    },
+    {
+      "domain": "thedeviators.org"
+    },
+    {
+      "domain": "theeverythingproject.org"
+    },
+    {
+      "domain": "thegracehouseinc.org"
+    },
+    {
+      "domain": "thestudiovisit.org"
+    },
+    {
+      "domain": "thetrendylittlegeek.com"
+    },
+    {
+      "domain": "thewayofyeshuaministries.org"
+    },
+    {
+      "domain": "transferca.org"
+    },
+    {
+      "domain": "trendylittlegeek.com"
+    },
+    {
+      "domain": "trinitylutheranconcord.org"
+    },
+    {
+      "domain": "trinityucclewistown.org"
+    },
+    {
+      "domain": "turksotx.org"
+    },
+    {
+      "domain": "veterans.onlineimpacts.org"
+    },
+    {
+      "domain": "wamhelp.org"
+    },
+    {
+      "domain": "wh1374403.ispot.cc/wp"
+    },
+    {
+      "domain": "wisdomfinancialministries.org"
+    },
+    {
+      "domain": "wonderseed.org"
+    },
+    {
+      "domain": "wonderseedstudio.com"
+    },
+    {
+      "domain": "wonderseedstudios.org"
+    },
+    {
+      "domain": "workreadyrva.com"
+    },
+    {
+      "domain": "www.americanlegionpost64.org"
+    },
+    {
+      "domain": "www.henricovareentrycouncil.com"
+    },
+    {
+      "domain": "www.nolefturns.org"
+    },
+    {
+      "domain": "www.shebawilliams.com"
+    },
+    {
+      "domain": "www.virginiajusticeconference.com"
+    },
+    {
+      "domain": "youngfatherscare.org"
+    }
+  ]
+}

--- a/tests/routes.ts
+++ b/tests/routes.ts
@@ -87,4 +87,5 @@ export const siteRoutes = [
   { route: '/volunteer-quiz', name: 'Volunteer Quiz' },
   { route: '/matching-gifts', name: 'Matching Gifts' },
   { route: '/badge', name: 'Powered-by Badge' },
+  { route: '/charities-we-support', name: 'Charities We Support' },
 ]


### PR DESCRIPTION
## What

**`/charities-we-support/`** — a public directory of the **129 organizations with live websites on FFC infrastructure**, built from a committed snapshot of the operational sites-list (`src/data/supported-charities.json`, source commit `c18c5c5`, 2026-06-08).

- **Filters (per the issue's acceptance criteria):** working sites only (Live/Redirect health), excludes the 11 orgs marked Left FFC, staging domains, and FFC's own infrastructure domains.
- **Privacy:** org domains only (public project data, sites-list precedent) — no contact or personal data. Opt-out documented on the page and in the data file's header comment.
- Each entry links to the charity's site (a quality backlink for every org we host); the page cross-sells the eligibility check and the $16.50 sponsorship framing, and links to /impact/ for the full-estate numbers.
- Route registered in sitemap + the shared E2E route list (accessibility/trailing-slash suites pick it up automatically).

When the canonical metrics pipeline (#387 / FFC-Cloudflare-Automation#552) lands, this snapshot can refresh via the same automated-PR pattern.

## Verification
- `npm run lint` / Prettier — clean
- `npm test` — 526/526
- `npm run build` — static export succeeds

Fixes #377
Refs #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013AwqCfp26iQEYUssk5cfCQ

---
_Generated by [Claude Code](https://claude.ai/code/session_013AwqCfp26iQEYUssk5cfCQ)_