### PR TITLE
feat: production outbound-link watchdog and public status page (backlog wave 7)

### DIFF
--- a/.github/workflows/outbound-links-prod.yml
+++ b/.github/workflows/outbound-links-prod.yml
@@ -1,0 +1,106 @@
+name: Production outbound links
+
+# Weekly watchdog for the LIVE site's outbound links (issue #410). The PR-time
+# Lychee workflow scans source files; production content can still rot between
+# deploys, and pages like /charities-we-support/ link to a hundred-plus charity
+# destinations whose health changes independently of this repo. This crawl
+# fetches every page in the production sitemap and checks the external links
+# found there, filing/refreshing a single production-health issue on failures.
+
+on:
+  schedule:
+    # Wednesdays 07:00 UTC — offset from the Monday source-link check so the
+    # two watchdogs don't report the same transient outage twice.
+    - cron: '0 7 * * 3'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check-production-outbound-links:
+    name: Crawl production outbound links
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository (for .lycheeignore)
+        uses: actions/checkout@v7
+
+      - name: Collect page URLs from the production sitemap
+        run: |
+          curl -sSf https://www.freeforcharity.org/sitemap.xml \
+            | grep -o '<loc>[^<]*</loc>' \
+            | sed -e 's/<loc>//' -e 's#</loc>##' > sitemap-urls.txt
+          wc -l sitemap-urls.txt
+          # Guard: an empty/unfetchable sitemap should fail loudly, not pass silently.
+          test -s sitemap-urls.txt
+
+      - name: Check outbound links on every production page
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          # --remap is not needed: lychee fetches each sitemap URL and checks
+          # the links found in the served HTML. Internal links are excluded —
+          # the post-deploy smoke suite owns those; this watchdog is only for
+          # external destinations (charity sites, Microsoft/Google/IRS docs).
+          args: >-
+            --verbose
+            --no-progress
+            --exclude-file .lycheeignore
+            --exclude 'freeforcharity.org'
+            --timeout 60
+            --max-retries 5
+            --retry-wait-time 5
+            --accept 200,201,202,203,204,206,301,302,303,307,308,429
+            -- $(cat sitemap-urls.txt | tr '\n' ' ')
+          fail: false
+
+      - name: Create or refresh the production-health issue
+        if: steps.lychee.outputs.exit_code != 0
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+            const marker = '<!-- outbound-links-prod-watchdog -->'
+            const body = [
+              marker,
+              '## Broken outbound links on the production site',
+              '',
+              'The weekly production crawl found external URLs that no longer resolve. These are',
+              'links our visitors (and the charities we host) actually click — review promptly.',
+              '',
+              `**Latest failing run:** ${runUrl}`,
+              '',
+              '## Next steps',
+              '1. Open the run output for the list of failing URLs and the pages that carry them',
+              '2. Charity destination down? Check whether the org moved or lapsed — update `src/data/supported-charities.json` (or contact the org) rather than silently dropping them',
+              '3. Third-party doc moved? Update the guide that links it',
+              '4. Persistent false positives (bot-blocking hosts) go in `.lycheeignore` with a comment',
+              '',
+              '_Filed automatically by the production outbound-links watchdog; it updates this issue on each failing run and stays quiet when the crawl is clean._',
+            ].join('\n')
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'production-health',
+              state: 'open',
+            })
+            const mine = existing.data.find((i) => i.body && i.body.includes(marker))
+            if (mine) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: mine.number,
+                body,
+              })
+              console.log(`Refreshed existing watchdog issue #${mine.number}`)
+              return
+            }
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: '🔗 Broken outbound links on production',
+              body,
+              labels: ['production-health', 'link-rot'],
+            })

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -110,6 +110,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { path: '/badge', priority: 0.5, changeFrequency: 'yearly' as const },
     { path: '/charities-we-support', priority: 0.8, changeFrequency: 'weekly' as const },
     { path: '/annual-report-2025', priority: 0.6, changeFrequency: 'yearly' as const },
+    { path: '/status', priority: 0.5, changeFrequency: 'weekly' as const },
   ]
 
   return routes.map((route) => ({

--- a/src/app/status/page.tsx
+++ b/src/app/status/page.tsx
@@ -1,0 +1,119 @@
+import { pageMetadata } from '@/lib/page-metadata'
+import Link from 'next/link'
+import statusData from '@/data/service-status.json'
+
+export const metadata = pageMetadata({
+  title: 'Service Status',
+  description:
+    'Is it just my site? Current health of FFC-managed services — charity hosting, DNS, the member portal — with honest last-checked timestamps and incident notes.',
+  canonical: '/status/',
+})
+
+interface Service {
+  name: string
+  status: 'operational' | 'degraded' | 'outage' | 'unknown'
+  detail: string
+  checkedBy: string
+  lastChecked: string
+}
+
+interface Incident {
+  date: string
+  title: string
+  note: string
+  resolved: boolean
+}
+
+const { services, incidents, updatedAt } = statusData as unknown as {
+  services: Service[]
+  incidents: Incident[]
+  updatedAt: string
+}
+
+const STATUS_STYLE: Record<Service['status'], { label: string; classes: string }> = {
+  operational: { label: 'Operational', classes: 'bg-[#e6f4ea] text-[#1e7d32] border-[#1e7d32]' },
+  degraded: { label: 'Degraded', classes: 'bg-[#fef7e0] text-[#8a6d00] border-[#8a6d00]' },
+  outage: { label: 'Outage', classes: 'bg-[#fdecea] text-[#b3261e] border-[#b3261e]' },
+  unknown: { label: 'Not monitored', classes: 'bg-[#f1f3f4] text-[#555] border-[#999]' },
+}
+
+export default function StatusPage() {
+  return (
+    <div className="ffc-container py-16">
+      <div className="max-w-4xl mx-auto">
+        <h1 className="font-[var(--font-faustina)] text-[48px] leading-[60px] mb-4">
+          Service Status
+        </h1>
+        <p className="font-[var(--font-lato)] text-[18px] leading-[28px] text-[#555] mb-2">
+          &ldquo;Is it just my site?&rdquo; — check here first. This page is updated from our
+          automated checks and by hand during incidents (not a real-time monitor), so every entry
+          carries an honest last-checked date.
+        </p>
+        <p className="font-[var(--font-lato)] text-[14px] text-[#767672] mb-8">
+          Page last updated {updatedAt}. Something looks down and isn&rsquo;t noted here?{' '}
+          <Link href="/contact-us/" className="underline">
+            Tell us
+          </Link>{' '}
+          — include your domain and what you saw.
+        </p>
+
+        <ul className="space-y-4">
+          {services.map((service) => {
+            const style = STATUS_STYLE[service.status]
+            return (
+              <li key={service.name} className="border border-gray-200 rounded-lg p-5">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <h2
+                    className="font-[var(--font-lato)] text-[19px] font-[600] text-[#333]"
+                    data-font="lato-font"
+                  >
+                    {service.name}
+                  </h2>
+                  <span
+                    className={`inline-block rounded-full border px-3 py-0.5 font-[var(--font-lato)] text-[13px] font-[600] ${style.classes}`}
+                  >
+                    {style.label}
+                  </span>
+                </div>
+                <p className="font-[var(--font-lato)] text-[15px] leading-[24px] text-[#555] mt-2">
+                  {service.detail}
+                </p>
+                <p className="font-[var(--font-lato)] text-[13px] text-[#767672] mt-1">
+                  {service.checkedBy}
+                  {service.lastChecked ? ` · last checked ${service.lastChecked}` : ''}
+                </p>
+              </li>
+            )
+          })}
+        </ul>
+
+        <h2 className="font-[var(--font-faustina)] text-[32px] leading-[40px] mt-10 mb-4">
+          Incident notes
+        </h2>
+        {incidents.length === 0 ? (
+          <p className="font-[var(--font-lato)] text-[17px] leading-[27px] text-[#555]">
+            No current or recent incidents. When one occurs, a dated note appears here (and the
+            change history of this page serves as the public incident log).
+          </p>
+        ) : (
+          <ul className="space-y-3">
+            {incidents.map((incident) => (
+              <li
+                key={incident.date + incident.title}
+                className="border border-gray-200 rounded-lg p-4"
+              >
+                <p className="font-[var(--font-lato)] text-[16px] font-[600] text-[#333]">
+                  {incident.date} — {incident.title}{' '}
+                  {incident.resolved ? '(resolved)' : '(ongoing)'}
+                </p>
+                <p className="font-[var(--font-lato)] text-[15px] leading-[24px] text-[#555] mt-1">
+                  {incident.note}
+                </p>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/contact-us-components/Intent-Routing/index.tsx
+++ b/src/components/contact-us-components/Intent-Routing/index.tsx
@@ -20,7 +20,8 @@ const paths: IntentPath[] = [
     heading: "I'm a supported charity and need help",
     body: 'Site changes, email problems, domain questions, or anything broken. Include your organization name, the page or address affected, and what you expected to happen.',
     cta: { label: 'Open the support portal', href: hubUrl(), external: true },
-    expectation: 'Typical response: 1–2 business days. Something urgent? Say “urgent” up front.',
+    expectation:
+      'Check /status/ first for known issues. Typical response: 1–2 business days; say “urgent” up front when it is.',
   },
   {
     heading: 'I want FFC to help my charity',

--- a/src/data/service-status.json
+++ b/src/data/service-status.json
@@ -1,0 +1,42 @@
+{
+  "_comment": "Data behind /status/ (issue #416). Not real-time monitoring: statuses reflect the named automated checks with honest lastChecked stamps, and incident notes are posted by PR — this file's git history doubles as the incident log. status is one of: operational | degraded | outage | unknown.",
+  "updatedAt": "2026-07-03",
+  "services": [
+    {
+      "name": "Charity websites (static hosting)",
+      "status": "operational",
+      "detail": "Charity sites are served from static hosting behind Cloudflare. Health is probed weekly by the sites-list pipeline; 129 public charity sites are currently live.",
+      "checkedBy": "Weekly sites-list health probe",
+      "lastChecked": "2026-06-08"
+    },
+    {
+      "name": "freeforcharity.org (this site)",
+      "status": "operational",
+      "detail": "The main site is smoke-tested on a schedule (homepage, donate flow, key routes) and on every production deploy.",
+      "checkedBy": "Scheduled production smoke suite",
+      "lastChecked": "2026-07-01"
+    },
+    {
+      "name": "DNS & domains (Cloudflare)",
+      "status": "operational",
+      "detail": "All managed charity domains resolve through Cloudflare DNS with registrations kept current by FFC.",
+      "checkedBy": "Weekly sites-list pipeline (Cloudflare inventory)",
+      "lastChecked": "2026-06-08"
+    },
+    {
+      "name": "Supported-charity portal (/hub/)",
+      "status": "operational",
+      "detail": "The WHMCS member portal for supported charities (logins, service records, tickets).",
+      "checkedBy": "Scheduled production smoke suite",
+      "lastChecked": "2026-07-01"
+    },
+    {
+      "name": "Email guidance (Microsoft 365 tenants)",
+      "status": "unknown",
+      "detail": "Charity mailboxes live in each organization's own Microsoft 365 tenant — Microsoft operates the service; FFC assists with configuration. Check Microsoft's service health for platform issues.",
+      "checkedBy": "Not centrally monitored (tenant-owned)",
+      "lastChecked": ""
+    }
+  ],
+  "incidents": []
+}

--- a/tests/routes.ts
+++ b/tests/routes.ts
@@ -89,4 +89,5 @@ export const siteRoutes = [
   { route: '/badge', name: 'Powered-by Badge' },
   { route: '/charities-we-support', name: 'Charities We Support' },
   { route: '/annual-report-2025', name: 'Annual Report 2025' },
+  { route: '/status', name: 'Service Status' },
 ]


### PR DESCRIPTION
## What

- **`.github/workflows/outbound-links-prod.yml`** — weekly (Wed 07:00 UTC, offset from the Monday source-link check) Lychee crawl of every page in the **production sitemap**, checking **external links only** (`--exclude freeforcharity.org`; internal routes are the smoke suite's job). On failure it files — or refreshes, via an HTML-comment marker, never duplicates — a single `production-health`/`link-rot` issue with triage guidance (charity destination down vs third-party doc moved vs `.lycheeignore` candidate). Quiet when clean. Fixes #410
- **`/status/`** — public "is it just my site?" page driven by `src/data/service-status.json`: five services (charity hosting, this site, DNS/domains, the /hub/ portal, M365 guidance) each with status, what checks it, and an **honest last-checked date** — explicitly not presented as real-time monitoring. Incident notes post via PR so the file's git history doubles as the incident log. Linked from the contact-routing expectations. Fixes #416

## Verification
- `npm run lint` / Prettier — clean
- `npm test` — 531/531
- `npm run build` — static export succeeds
- Workflow YAML follows the existing lychee.yml patterns (same action version, retry posture, ignore file)

Refs #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013AwqCfp26iQEYUssk5cfCQ

---
_Generated by [Claude Code](https://claude.ai/code/session_013AwqCfp26iQEYUssk5cfCQ)_