### PR TITLE
feat: honor the freeforcharity/ffcadmin split + Other Ways to Give (backlog wave 10)

### DIFF
--- a/src/app/charities-we-support/page.tsx
+++ b/src/app/charities-we-support/page.tsx
@@ -31,8 +31,17 @@ export default function CharitiesWeSupport() {
           . This directory lists only currently-live public sites.)
         </p>
         <p className="font-[var(--font-lato)] text-[14px] leading-[22px] text-[#767672] mb-8">
-          Snapshot from our operational sites inventory, {snapshotDate}. Listed organization?
-          We&rsquo;re glad to feature you — or remove you on request via the{' '}
+          Snapshot from our operational sites inventory ({snapshotDate}) — the full inventory with
+          health and migration detail is public on{' '}
+          <a
+            href="https://ffcadmin.org/sites-list/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline"
+          >
+            FFC Admin
+          </a>
+          . Listed organization? We&rsquo;re glad to feature you — or remove you on request via the{' '}
           <Link href="/contact-us/" className="underline">
             contact page
           </Link>

--- a/src/app/charity-onboarding-journey/page.tsx
+++ b/src/app/charity-onboarding-journey/page.tsx
@@ -111,6 +111,17 @@ export default function CharityOnboardingJourney() {
         </ol>
 
         <div className="prose max-w-none font-[var(--font-lato)] text-[18px] leading-[28px] mt-10">
+          <h2 className={h2}>Deep dives for every prerequisite</h2>
+          <p>
+            Stuck on a specific intake item — mission statement, board requirements, public contact
+            info, the 501c3 application itself, or fiscal sponsorship? Each has a dedicated
+            walkthrough in the{' '}
+            <a href="https://ffcadmin.org/intake-help/" target="_blank" rel="noopener noreferrer">
+              intake help section on FFC Admin
+            </a>
+            , our operational portal.
+          </p>
+
           <h2 className={h2}>How we communicate</h2>
           <p>
             Support happens over email and text with real volunteers. We aim to respond within a

--- a/src/app/charity-security-guide/page.tsx
+++ b/src/app/charity-security-guide/page.tsx
@@ -1,5 +1,7 @@
 import { pageMetadata } from '@/lib/page-metadata'
 import Link from 'next/link'
+import AdminGuideLink from '@/components/ui/AdminGuideLink'
+import { ffcAdminUrl } from '@/data/admin-links'
 
 export const metadata = pageMetadata({
   title: 'Security Basics for Small Charities',
@@ -60,6 +62,11 @@ export default function CharitySecurityGuide() {
               vault makes this a ten-minute chore instead of a forgotten risk.
             </li>
           </ul>
+
+          <AdminGuideLink
+            href={ffcAdminUrl('/guides/multi-factor-authentication/')}
+            description="Step-by-step MFA setup — plus companion FFC Admin guides for password managers and passkeys — live on the FFC Admin portal:"
+          />
 
           <h2 className={h2}>3. Recognize the two frauds aimed at charities</h2>
           <ul>

--- a/src/app/contribute/page.tsx
+++ b/src/app/contribute/page.tsx
@@ -95,6 +95,21 @@ export default function Contribute() {
 
           <h2 className={h2}>Why this matters</h2>
           <p>
+            Sustained contributors climb the{' '}
+            <a
+              href="https://ffcadmin.org/contributor-ladder/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              contributor ladder on FFC Admin
+            </a>{' '}
+            — the operational portal also covering{' '}
+            <a href="https://ffcadmin.org/get-involved/" target="_blank" rel="noopener noreferrer">
+              other ways to get involved
+            </a>
+            .
+          </p>
+          <p>
             A fix to a shared template ships to every charity built from it; a clearer guide page
             deflects dozens of support conversations. Small PRs here have unusually large blast
             radius — that&rsquo;s the fun of it. See the <Link href="/impact/">impact page</Link>{' '}

--- a/src/app/google-for-nonprofits-guide/page.tsx
+++ b/src/app/google-for-nonprofits-guide/page.tsx
@@ -1,5 +1,7 @@
 import { pageMetadata } from '@/lib/page-metadata'
 import Link from 'next/link'
+import AdminGuideLink from '@/components/ui/AdminGuideLink'
+import { ffcAdminUrl } from '@/data/admin-links'
 
 export const metadata = pageMetadata({
   title: 'Google for Nonprofits & Ad Grants',
@@ -72,6 +74,11 @@ export default function GoogleForNonprofitsGuide() {
               signup, donations, program enrollment.
             </li>
           </ol>
+
+          <AdminGuideLink
+            href={ffcAdminUrl('/guides/google-workspace/')}
+            description="Setting up Google Workspace itself (accounts, verification via Goodstack, admin console)? The detailed workflow is on FFC Admin:"
+          />
 
           <h2 className={h2}>The rules that keep the grant alive</h2>
           <p>Google cancels inactive or low-quality grant accounts. The essentials:</p>

--- a/src/app/guides/page.tsx
+++ b/src/app/guides/page.tsx
@@ -79,6 +79,19 @@ export default function GuidesHub() {
           )
         })}
 
+        <p className="font-[var(--font-lato)] text-[16px] leading-[26px] text-[#555] mb-4">
+          These guides are the charity-facing orientation set. Operational, click-by-click workflow
+          guides (30+ covering every tool we deploy) live on the{' '}
+          <a
+            href="https://ffcadmin.org/guides/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[#0567B1] underline"
+          >
+            FFC Admin guides hub
+          </a>{' '}
+          — the operational source of truth for accepted charities and active volunteers.
+        </p>
         <p className="font-[var(--font-lato)] text-[16px] leading-[26px] text-[#555]">
           Can&rsquo;t find what you need? Try{' '}
           <Link href="/search/" className="text-[#0567B1] underline">

--- a/src/app/m365-email-guide/page.tsx
+++ b/src/app/m365-email-guide/page.tsx
@@ -1,5 +1,7 @@
 import { pageMetadata } from '@/lib/page-metadata'
 import Link from 'next/link'
+import AdminGuideLink from '@/components/ui/AdminGuideLink'
+import { ffcAdminUrl } from '@/data/admin-links'
 
 export const metadata = pageMetadata({
   title: 'Free Microsoft 365 Email for Your Charity',
@@ -104,6 +106,11 @@ export default function M365EmailGuide() {
               minutes.
             </li>
           </ul>
+
+          <AdminGuideLink
+            href={ffcAdminUrl('/guides/microsoft-365-email/')}
+            description="This page is the orientation. The authoritative click-by-click workflow (kept current by the volunteers who do this weekly) lives on FFC Admin:"
+          />
 
           <h2 className={h2}>Common problems</h2>
           <ul>

--- a/src/app/matching-gifts/page.tsx
+++ b/src/app/matching-gifts/page.tsx
@@ -99,9 +99,10 @@ export default function MatchingGifts() {
           </p>
 
           <p className="mt-8">
-            Questions, or a form that needs something we didn&rsquo;t list?{' '}
-            <Link href="/contact-us/">Contact us</Link> and we&rsquo;ll turn it around quickly —
-            matched money is the best kind of money.
+            Looking for DAF grants, stock gifts, bequests, or IRA distributions? See{' '}
+            <Link href="/other-ways-to-give/">other ways to give</Link>. Questions, or a form that
+            needs something we didn&rsquo;t list? <Link href="/contact-us/">Contact us</Link> and
+            we&rsquo;ll turn it around quickly — matched money is the best kind of money.
           </p>
         </div>
       </div>

--- a/src/app/other-ways-to-give/page.tsx
+++ b/src/app/other-ways-to-give/page.tsx
@@ -1,0 +1,126 @@
+import { pageMetadata } from '@/lib/page-metadata'
+import Link from 'next/link'
+
+export const metadata = pageMetadata({
+  title: 'Other Ways to Give',
+  description:
+    'Donor-advised funds, appreciated stock, bequests, IRA qualified charitable distributions, and employer matching — every way to support Free For Charity beyond the donate button.',
+  canonical: '/other-ways-to-give/',
+})
+
+const h2 = 'font-[var(--font-faustina)] text-[32px] leading-[40px] mt-8 mb-4'
+
+// Larger gift vehicles carry legal/financial detail that must be confirmed
+// person-to-person before funds move — so every option below that involves a
+// transfer instruction routes through this confirm-first contact block
+// (published at the operator's direction).
+function ConfirmContact({ what }: { what: string }) {
+  return (
+    <p className="not-prose rounded border border-[#0567B1]/30 bg-[#f4f9fd] px-4 py-3 font-[var(--font-lato)] text-[15px] leading-[24px] text-[#333]">
+      <strong>Before initiating:</strong> confirm the exact {what} with Clarke Moyer —{' '}
+      <a href="mailto:clarkemoyer@freeforcharity.org" className="text-[#0567B1] underline">
+        clarkemoyer@freeforcharity.org
+      </a>{' '}
+      or{' '}
+      <a href="tel:+15202228104" className="text-[#0567B1] underline">
+        (520) 222-8104
+      </a>
+      . We reply quickly — large gifts get same-day attention.
+    </p>
+  )
+}
+
+export default function OtherWaysToGive() {
+  return (
+    <div className="ffc-container py-16">
+      <div className="max-w-4xl mx-auto">
+        <h1 className="font-[var(--font-faustina)] text-[48px] leading-[60px] mb-8">
+          Other Ways to Give
+        </h1>
+
+        <div className="prose max-w-none font-[var(--font-lato)] text-[18px] leading-[28px]">
+          <p>
+            The <Link href="/donate/">donate button</Link> is the fast path — but larger and
+            tax-smarter vehicles often do more for you <em>and</em> for the charities we keep
+            online. All of these are welcome. The identity details every form asks for:
+          </p>
+          <div className="border border-gray-200 rounded-lg p-6 not-prose font-[var(--font-lato)] text-[17px] leading-[28px]">
+            <dl>
+              <div>
+                <dt className="font-[700] inline">Legal name: </dt>
+                <dd className="inline">Free For Charity</dd>
+              </div>
+              <div>
+                <dt className="font-[700] inline">EIN (tax ID): </dt>
+                <dd className="inline">46-2471893 — 501(c)(3) public charity</dd>
+              </div>
+              <div>
+                <dt className="font-[700] inline">Mailing address: </dt>
+                <dd className="inline">4030 Wake Forrest Road, Suite 349, Raleigh, NC</dd>
+              </div>
+              <div>
+                <dt className="font-[700] inline">Verification: </dt>
+                <dd className="inline">
+                  <a
+                    href="https://www.guidestar.org/profile/46-2471893"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-[#0567B1] underline"
+                  >
+                    Candid profile — Platinum Seal of Transparency
+                  </a>
+                </dd>
+              </div>
+            </dl>
+          </div>
+
+          <h2 className={h2}>Donor-advised funds (DAF)</h2>
+          <p>
+            Recommend a grant to Free For Charity from Fidelity Charitable, Schwab Charitable,
+            Vanguard Charitable, or any DAF sponsor — search by our EIN above. DAF grants are among
+            the most efficient ways to fund the endowment.
+          </p>
+          <ConfirmContact what="grant designation and delivery details" />
+
+          <h2 className={h2}>Appreciated stock &amp; securities</h2>
+          <p>
+            Donating appreciated shares held over a year typically avoids capital-gains tax and
+            deducts the full market value — often 20%+ more impact than selling and giving cash. We
+            accept securities gifts; transfers are arranged individually.
+          </p>
+          <ConfirmContact what="brokerage transfer instructions (account and DTC details)" />
+
+          <h2 className={h2}>Bequests &amp; planned gifts</h2>
+          <p>
+            A sentence in your will can fund charities&rsquo; digital presence permanently through
+            the <Link href="/free-for-charity-endowment-fund/">endowment</Link>. Your attorney will
+            want our exact legal name and EIN (above). We&rsquo;re glad to discuss designation
+            language and how your gift will be recognized.
+          </p>
+          <ConfirmContact what="designation language for your estate documents" />
+
+          <h2 className={h2}>IRA qualified charitable distributions (QCD)</h2>
+          <p>
+            If you&rsquo;re 70½ or older, a QCD from your IRA counts toward required minimum
+            distributions without increasing taxable income. Your IRA custodian sends the check
+            directly to the charity.
+          </p>
+          <ConfirmContact what="payee and mailing details for your custodian" />
+
+          <h2 className={h2}>Employer matching &amp; volunteer grants</h2>
+          <p>
+            Free money you may already have: most large employers match donations and many pay
+            grants for volunteer hours. Everything you need is on the{' '}
+            <Link href="/matching-gifts/">matching gifts page</Link>.
+          </p>
+
+          <p className="mt-8">
+            Not tax advice — consult your advisor for your situation. For what your gift
+            accomplishes per dollar, see <Link href="/cost-transparency/">the unit economics</Link>:
+            $16.50 keeps one charity&rsquo;s entire digital presence alive for a year.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -112,6 +112,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { path: '/annual-report-2025', priority: 0.6, changeFrequency: 'yearly' as const },
     { path: '/status', priority: 0.5, changeFrequency: 'weekly' as const },
     { path: '/search', priority: 0.5, changeFrequency: 'monthly' as const },
+    { path: '/other-ways-to-give', priority: 0.7, changeFrequency: 'monthly' as const },
   ]
 
   return routes.map((route) => ({

--- a/src/app/status/page.tsx
+++ b/src/app/status/page.tsx
@@ -50,7 +50,17 @@ export default function StatusPage() {
           carries an honest last-checked date.
         </p>
         <p className="font-[var(--font-lato)] text-[14px] text-[#767672] mb-8">
-          Page last updated {updatedAt}. Something looks down and isn&rsquo;t noted here?{' '}
+          Page last updated {updatedAt}. Deeper operational dashboards (per-site health, automation
+          runs) are public on{' '}
+          <a
+            href="https://ffcadmin.org/sites-list/summary/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline"
+          >
+            FFC Admin
+          </a>
+          . Something looks down and isn&rsquo;t noted here?{' '}
           <Link href="/contact-us/" className="underline">
             Tell us
           </Link>{' '}

--- a/src/app/volunteer-onboarding-guide/page.tsx
+++ b/src/app/volunteer-onboarding-guide/page.tsx
@@ -1,5 +1,7 @@
 import { pageMetadata } from '@/lib/page-metadata'
 import Link from 'next/link'
+import AdminGuideLink from '@/components/ui/AdminGuideLink'
+import { ffcAdminUrl } from '@/data/admin-links'
 
 export const metadata = pageMetadata({
   title: 'Volunteer Onboarding: Your First Two Weeks',
@@ -47,6 +49,11 @@ export default function VolunteerOnboardingGuide() {
               folder names, accessibility checks passing, and CI green before merge.
             </li>
           </ul>
+
+          <AdminGuideLink
+            href={ffcAdminUrl('/developer-environment-setup/')}
+            description="Tooling setup (VS Code, Claude Desktop, Codex, Antigravity), the training tracks, and the contributor ladder are maintained on FFC Admin — the operational source of truth:"
+          />
 
           <h2 className={h2}>How a charity site actually goes live</h2>
           <ol>

--- a/src/app/volunteer-roles/page.tsx
+++ b/src/app/volunteer-roles/page.tsx
@@ -131,6 +131,64 @@ export default function VolunteerRoles() {
         </div>
 
         <p className="font-[var(--font-lato)] text-[16px] leading-[26px] text-[#555] mt-8">
+          Each technical role has a detailed working page on the FFC Admin portal —{' '}
+          <a
+            href="https://ffcadmin.org/volunteer/web-developer/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[#0567B1] underline"
+          >
+            web developer
+          </a>
+          ,{' '}
+          <a
+            href="https://ffcadmin.org/volunteer/microsoft-365-admin/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[#0567B1] underline"
+          >
+            Microsoft 365 admin
+          </a>
+          ,{' '}
+          <a
+            href="https://ffcadmin.org/volunteer/canva-designer/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[#0567B1] underline"
+          >
+            Canva designer
+          </a>{' '}
+          — plus roles not listed here:{' '}
+          <a
+            href="https://ffcadmin.org/volunteer/google-workspace-admin/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[#0567B1] underline"
+          >
+            Google Workspace admin
+          </a>
+          ,{' '}
+          <a
+            href="https://ffcadmin.org/volunteer/data-analytics/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[#0567B1] underline"
+          >
+            data analytics
+          </a>
+          , and a{' '}
+          <a
+            href="https://ffcadmin.org/volunteer/military-volunteers/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[#0567B1] underline"
+          >
+            military volunteers
+          </a>{' '}
+          program (MOVSM-eligible). FFC Admin is the authoritative role catalog; this page is the
+          overview.
+        </p>
+        <p className="font-[var(--font-lato)] text-[16px] leading-[26px] text-[#555] mt-4">
           Technical volunteer? Read the{' '}
           <Link href="/volunteer-onboarding-guide/" className="text-[#0567B1] underline">
             first-two-weeks onboarding guide

--- a/src/app/zeffy-donations-guide/page.tsx
+++ b/src/app/zeffy-donations-guide/page.tsx
@@ -83,6 +83,17 @@ export default function ZeffyDonationsGuide() {
 
           <h2 className={h2}>Beyond the basic form</h2>
           <p>
+            Moving existing member or donor data into Zeffy? Our volunteers follow the{' '}
+            <a
+              href="https://ffcadmin.org/guides/zeffy-member-data-migration/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Zeffy member-data migration guide on FFC Admin
+            </a>
+            .
+          </p>
+          <p>
             Zeffy also does event tickets, raffles (where legal), memberships, peer-to-peer
             campaigns, and e-commerce — all at 0% fees. Start with one donation form; add the rest
             when a real need appears.

--- a/src/data/search-index.json
+++ b/src/data/search-index.json
@@ -254,6 +254,12 @@
       "type": "page"
     },
     {
+      "title": "Other Ways to Give",
+      "description": "Donor-advised funds, appreciated stock, bequests, IRA qualified charitable distributions, and employer matching — every way to support Free For Charity beyond the donate button.",
+      "href": "/other-ways-to-give/",
+      "type": "page"
+    },
+    {
       "title": "Our organization earned a 2021 Platinum Seal of Transparency!",
       "description": "Our organization earned a 2021 Platinum Seal of Transparency! Now, everyone can see our strategy, metrics, and achievements. Check out our updated nonprofit profile on Candid.",
       "href": "/our-organization-earned-a-2021-platinum-seal-of-transparency/",

--- a/tests/routes.ts
+++ b/tests/routes.ts
@@ -91,4 +91,5 @@ export const siteRoutes = [
   { route: '/annual-report-2025', name: 'Annual Report 2025' },
   { route: '/status', name: 'Service Status' },
   { route: '/search', name: 'Site Search' },
+  { route: '/other-ways-to-give', name: 'Other Ways to Give' },
 ]


### PR DESCRIPTION
## What

**Part 1 — site-split reconciliation.** Per the architecture already encoded in `src/data/admin-links.ts` (freeforcharity.org = public funnel; ffcadmin.org = authoritative step-by-step workflows), every overlap the duplication audit found now hands off explicitly, using the existing `AdminGuideLink` pattern:

- **Guides:** M365 email → `/guides/microsoft-365-email/`; security → `/guides/multi-factor-authentication/` (+ password-manager/passkeys); Google for Nonprofits → `/guides/google-workspace/` (+ Goodstack); Zeffy → member-data-migration guide.
- **Volunteers:** `/volunteer-roles/` now names FFC Admin as the authoritative role catalog and links its per-role pages — including the roles this site's overview doesn't list (Google Workspace admin, data analytics, military volunteers/MOVSM); onboarding guide → developer-environment-setup/training/contributor-ladder; contribute → contributor ladder + get-involved.
- **Onboarding:** journey page → the 11 `/intake-help/` prerequisite deep dives.
- **Hubs & ops:** the guides hub states its scope and links the FFC Admin guides hub; `/charities-we-support/` → full sites-list; `/status/` → operational dashboards.

**Part 2 — `/other-ways-to-give/`** (unblocks #401 with the operator-approved confirm-first pattern): DAF, appreciated stock, bequests, IRA QCDs, and matching gifts are all presented as welcome options with the verified identity block (legal name, EIN, mailing address, Candid verification) inline — and **every transfer-level instruction routes through a "confirm exact details first" contact block (clarkemoyer@freeforcharity.org / (520) 222-8104)** rather than publishing unverified brokerage/designation details. Linked from the matching-gifts page; registered in sitemap, route list, and the search index.

## Verification
- `npm run lint` / Prettier — clean
- `npm test` — 542/542 (search index regenerated and staleness guard green)
- `npm run build` — static export succeeds
- All ffcadmin.org target URLs verified against its live sitemap

Fixes #401
Refs #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013AwqCfp26iQEYUssk5cfCQ

---
_Generated by [Claude Code](https://claude.ai/code/session_013AwqCfp26iQEYUssk5cfCQ)_