### PR TITLE
feat: volunteer hours self-report wiring + campaign designation note (backlog wave 11)

### DIFF
--- a/src/app/matching-gifts/page.tsx
+++ b/src/app/matching-gifts/page.tsx
@@ -1,5 +1,6 @@
 import { pageMetadata } from '@/lib/page-metadata'
 import Link from 'next/link'
+import HoursReportCallout from '@/components/volunteer/HoursReportCallout'
 
 export const metadata = pageMetadata({
   title: 'Matching Gifts & Volunteer Grants',
@@ -90,6 +91,8 @@ export default function MatchingGifts() {
             grants&rdquo; or &ldquo;dollars for doers,&rdquo; and we&rsquo;ll gladly verify your
             hours. Not volunteering yet? <Link href="/volunteer-quiz/">Find your role</Link>.
           </p>
+
+          <HoursReportCallout />
 
           <h2 className={h2}>What your matched dollars do</h2>
           <p>

--- a/src/app/volunteer-roles/page.tsx
+++ b/src/app/volunteer-roles/page.tsx
@@ -1,5 +1,6 @@
 import { pageMetadata } from '@/lib/page-metadata'
 import Link from 'next/link'
+import HoursReportCallout from '@/components/volunteer/HoursReportCallout'
 
 export const metadata = pageMetadata({
   title: 'Volunteer Roles',
@@ -129,6 +130,8 @@ export default function VolunteerRoles() {
             </section>
           ))}
         </div>
+
+        <HoursReportCallout />
 
         <p className="font-[var(--font-lato)] text-[16px] leading-[26px] text-[#555] mt-8">
           Each technical role has a detailed working page on the FFC Admin portal —{' '}

--- a/src/components/donate-components/Donation-Campaigns/index.tsx
+++ b/src/components/donate-components/Donation-Campaigns/index.tsx
@@ -62,6 +62,14 @@ const DonationCampaigns = () => {
             domains, and Microsoft 365 for nonprofits. Give to the general fund, or choose a
             specific campaign.
           </p>
+          <p
+            className="text-[16px] font-[500] leading-[25px] text-[#555] max-w-[760px] mx-auto mt-[12px]"
+            data-font="lato-font"
+          >
+            Giving in honor of a particular nonprofit? Every campaign&apos;s checkout includes an
+            optional field to name the specific charity you want your gift to support — for example,
+            fund the domain or the website build of an organization you care about.
+          </p>
         </div>
 
         {general ? (

--- a/src/components/volunteer/HoursReportCallout.tsx
+++ b/src/components/volunteer/HoursReportCallout.tsx
@@ -1,0 +1,54 @@
+import React from 'react'
+import hoursForm from '@/data/volunteer-hours-form.json'
+
+/**
+ * Volunteer hours self-report callout (issue #394). Renders the Microsoft 365
+ * Forms link once `formUrl` is set in src/data/volunteer-hours-form.json; until
+ * then it degrades to the operator email so hour reports are never blocked on
+ * the form's creation. Hours feed the published volunteer-hours metric (as an
+ * additional evidence line on top of the census floor) and unlock employer
+ * volunteer grants.
+ */
+
+const { formUrl, fallbackEmail, fallbackSubject } = hoursForm as {
+  formUrl: string
+  fallbackEmail: string
+  fallbackSubject: string
+}
+
+export default function HoursReportCallout() {
+  const mailto = `mailto:${fallbackEmail}?subject=${encodeURIComponent(fallbackSubject)}`
+  return (
+    <div className="rounded-[10px] border border-[#0567B1]/30 bg-[#f4f9fd] px-5 py-4 my-6">
+      <p
+        className="font-[var(--font-lato)] text-[17px] font-[600] text-[#333]"
+        data-font="lato-font"
+      >
+        Log your volunteer hours — they count twice
+      </p>
+      <p className="font-[var(--font-lato)] text-[15px] leading-[24px] text-[#555] mt-1">
+        A monthly minute of reporting makes your hours part of FFC&rsquo;s published impact{' '}
+        <em>and</em> unlocks employer volunteer-grant programs that pay the nonprofit for every hour
+        you serve.{' '}
+        {formUrl ? (
+          <a
+            href={formUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[#0567B1] underline font-[600]"
+          >
+            Report your hours (Microsoft Forms) →
+          </a>
+        ) : (
+          <>
+            Send your month, role, hours, and the charities you helped to{' '}
+            <a href={mailto} className="text-[#0567B1] underline font-[600]">
+              {fallbackEmail}
+            </a>{' '}
+            (a one-click Microsoft Form is coming).
+          </>
+        )}
+      </p>
+    </div>
+  )
+}

--- a/src/data/volunteer-hours-form.json
+++ b/src/data/volunteer-hours-form.json
@@ -1,0 +1,7 @@
+{
+  "_comment": "Volunteer hours self-report (issue #394). Provider decision 2026-07-04: Microsoft 365 Forms in the FFC tenant. Once the Form exists, paste its share URL into formUrl and the report component switches from the email fallback to the form link automatically. Suggested Form fields: Name, Volunteer role, Month, Hours volunteered, Charity/charities helped (optional), Employer offers volunteer grants? (yes/no/unsure). Responses stay in the tenant; only aggregate hour totals ever feed the published metrics.",
+  "provider": "Microsoft 365 Forms",
+  "formUrl": "",
+  "fallbackEmail": "clarkemoyer@freeforcharity.org",
+  "fallbackSubject": "Volunteer hours report"
+}


### PR DESCRIPTION
## What

Implements two operator decisions (2026-07-04):

**#394 — hours self-report via Microsoft 365 Forms.** New `src/data/volunteer-hours-form.json` + `HoursReportCallout` component, placed on `/volunteer-roles/` and `/matching-gifts/` (where it pairs with the volunteer-grants pitch — reported hours both feed the published metric and unlock employer grants). Until the Form exists, the callout degrades to the operator email fallback, so hour reporting is live today; **the one remaining step is creating the Form in the FFC tenant (suggested fields documented in the data file) and pasting its share URL into `formUrl`** — the component switches over automatically.

**#399 — sponsor-a-charity via existing campaigns.** No new Zeffy campaign needed: every campaign's checkout already includes an optional field to designate a specific charity (e.g., fund one org's domain or website build). The donate hub now says so, right under the campaign-chooser intro. Fixes #399

## Verification
- `npm run lint` / Prettier — clean
- `npm test` — 543/543
- `npm run build` — static export succeeds

Fixes #399
Refs #394, #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013AwqCfp26iQEYUssk5cfCQ

---
_Generated by [Claude Code](https://claude.ai/code/session_013AwqCfp26iQEYUssk5cfCQ)_