### PR TITLE
feat: wire live Microsoft Forms URLs for hours + testimonial collection

### DIFF
--- a/src/data/testimonial-form.json
+++ b/src/data/testimonial-form.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Share-your-experience testimonial collection (issue #379). Provider decision 2026-07-04: Microsoft 365 Forms in the FFC tenant (same pattern as volunteer-hours-form.json). Once the Form exists, paste its share URL into formUrl and every callout switches from the email fallback to the form link automatically. Suggested Form fields: Name, Role/title, Organization, Your experience with FFC (long text), May we publish this with your name, role, and organization on freeforcharity.org? (yes/no consent checkbox - REQUIRED), Photo/logo permission (yes/no, optional). Review step before publishing: an FFC maintainer checks the consent answer, adds the entry as a JSON file in src/data/testimonials/ (newest first in src/data/testimonials.ts), and records the form response ID in the PR. See /publicity-consent-policy/.",
   "provider": "Microsoft 365 Forms",
-  "formUrl": "",
+  "formUrl": "https://forms.office.com/Pages/ResponsePage.aspx?id=8kvGgFv6XEKaWh_PKC0ydFO8HkC0Ry1PnJZ3Shf5W_RUOTlGN1A5MzRYWEZJQTVIWFpPQ1BVNlBYQS4u",
   "fallbackEmail": "clarkemoyer@freeforcharity.org",
   "fallbackSubject": "My Free For Charity experience (OK to publish)"
 }

--- a/src/data/volunteer-hours-form.json
+++ b/src/data/volunteer-hours-form.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Volunteer hours self-report (issue #394). Provider decision 2026-07-04: Microsoft 365 Forms in the FFC tenant. Once the Form exists, paste its share URL into formUrl and the report component switches from the email fallback to the form link automatically. Suggested Form fields: Name, Volunteer role, Month, Hours volunteered, Charity/charities helped (optional), Employer offers volunteer grants? (yes/no/unsure). Responses stay in the tenant; only aggregate hour totals ever feed the published metrics.",
   "provider": "Microsoft 365 Forms",
-  "formUrl": "",
+  "formUrl": "https://forms.office.com/Pages/ResponsePage.aspx?id=8kvGgFv6XEKaWh_PKC0ydFO8HkC0Ry1PnJZ3Shf5W_RURFdEVVpCVzM1RFhKN1hSRFJFVUY3NjAyOC4u",
   "fallbackEmail": "clarkemoyer@freeforcharity.org",
   "fallbackSubject": "Volunteer hours report"
 }


### PR DESCRIPTION
## What

Fills in the `formUrl` in both form config files with live Microsoft Forms created in the FFC tenant on 2026-07-04 (operator-authorized delegated device-code auth; forms are owned by the operator's account):

- **FFC Volunteer Hours Report** → `src/data/volunteer-hours-form.json`. Questions: name, volunteer role (the five standard roles + other), month, hours, charities helped (optional), employer volunteer-grant question. The hours callout on `/volunteer-roles/` and `/matching-gifts/` now links the form instead of the email fallback.
- **Share Your FFC Experience** → `src/data/testimonial-form.json`. Questions: name, role, organization, experience, **required publish-consent question** referencing `/publicity-consent-policy/`, optional logo/photo permission. The share callouts on the case-studies page and the Online Impacts onboarding guide now link the form.

Both forms accept anonymous responses (anyone with the link), verified returning HTTP 200 unauthenticated. Responses stay in the tenant; only aggregate hour totals feed published metrics, and testimonials are reviewed for the consent answer before anything is published.

## Verification
- `npm test` — 548/548 pass
- `npm run build` — static export succeeds; confirmed all four pages render the form links in `out/`

Fixes #394
Refs #379

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013AwqCfp26iQEYUssk5cfCQ

---
_Generated by [Claude Code](https://claude.ai/code/session_013AwqCfp26iQEYUssk5cfCQ)_