### PR TITLE
refactor: WHMCS config-ops reads credentials from Azure Key Vault

### DIFF
--- a/.github/workflows/whmcs-config-ops.yml
+++ b/.github/workflows/whmcs-config-ops.yml
@@ -1,27 +1,24 @@
 # WHMCS configuration ops via the WHMCS Admin API (manual dispatch only).
 #
-# Purpose: read/update WHMCS General Settings values from CI without anyone
-# handling credentials interactively — first use case is wiring the checkout
-# Terms-of-Service acceptance to the site's policy set (publicity consent,
-# issues #378/#379/#380).
+# Purpose: read/update WHMCS General Settings values from CI — first use case
+# is wiring the checkout Terms-of-Service acceptance to the site's policy set
+# (publicity consent, issues #378/#379/#380).
+#
+# Credentials come from Azure Key Vault kv-ffc-admin-prod-cbm via the same
+# OIDC login the cpanel-* workflows use — no GitHub secrets beyond the two
+# OIDC client identifiers that already exist. Vault secrets read (masked,
+# never printed):
+#   read-all-ffc-whmcs-api-identifier      WHMCS API credential identifier
+#   read-all-ffc-whmcs-api-secret          paired secret
+#   read-all-ffc-whmcs-api-url             API endpoint to call (direct
+#                                          includes/api.php or the APIM proxy)
+#   read-all-ffc-apim-whmcs-subscription-key  sent as Ocp-Apim-Subscription-Key
+#                                          when non-empty (static-egress APIM
+#                                          route beats the WHMCS IP allowlist)
 #
 # Scope is deliberately narrow: only GetConfigurationValue and
 # SetConfigurationValue are allowed, so this workflow can never create
 # clients, orders, invoices, or touch member data.
-#
-# Required repository secrets (Settings -> Secrets -> Actions):
-#   WHMCS_API_IDENTIFIER  API credential identifier (WHMCS Admin ->
-#                         Configuration -> System Settings -> API Credentials)
-#   WHMCS_API_SECRET      the paired secret
-#   WHMCS_API_ACCESS_KEY  the $api_access_key value from WHMCS
-#                         configuration.php. GitHub runners have dynamic IPs,
-#                         so the WHMCS IP allowlist cannot cover them; WHMCS's
-#                         documented bypass is an access key passed alongside
-#                         normal credentials. Add one line to
-#                         ~/public_html/hub/configuration.php:
-#                           $api_access_key = '<long random string>';
-#
-# WHMCS endpoint: https://freeforcharity.org/hub/includes/api.php
 
 name: WHMCS Config Ops
 
@@ -46,53 +43,58 @@ on:
         type: string
 
 permissions:
-  contents: read
+  id-token: write # OIDC to Azure; no checkout needed
 
 jobs:
   whmcs-config:
     runs-on: ubuntu-latest
+    environment: cpanel-staging
     steps:
-      - name: Validate secrets
-        run: |
-          if [ -z "${{ secrets.WHMCS_API_IDENTIFIER }}" ]; then
-            echo "::error::WHMCS_API_IDENTIFIER secret not set"
-            exit 1
-          fi
-          if [ -z "${{ secrets.WHMCS_API_SECRET }}" ]; then
-            echo "::error::WHMCS_API_SECRET secret not set"
-            exit 1
-          fi
-          if [ -z "${{ secrets.WHMCS_API_ACCESS_KEY }}" ]; then
-            echo "::error::WHMCS_API_ACCESS_KEY secret not set (required: runner IPs are dynamic)"
-            exit 1
-          fi
+      - name: Azure login (OIDC)
+        uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.WR_ALL_FFC_AZURE_KV_CLIENT_ID }}
+          tenant-id: ${{ secrets.WR_ALL_FFC_AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
 
-      - name: Call WHMCS API
+      - name: Call WHMCS API (credentials from Key Vault, masked)
         env:
-          WHMCS_API_IDENTIFIER: ${{ secrets.WHMCS_API_IDENTIFIER }}
-          WHMCS_API_SECRET: ${{ secrets.WHMCS_API_SECRET }}
-          WHMCS_API_ACCESS_KEY: ${{ secrets.WHMCS_API_ACCESS_KEY }}
           API_ACTION: ${{ inputs.api_action }}
           SETTING: ${{ inputs.setting }}
           NEW_VALUE: ${{ inputs.value }}
         run: |
           set -euo pipefail
+          v=kv-ffc-admin-prod-cbm
+          ident=$(az keyvault secret show --vault-name "$v" --name read-all-ffc-whmcs-api-identifier --query value -o tsv --only-show-errors)
+          secret=$(az keyvault secret show --vault-name "$v" --name read-all-ffc-whmcs-api-secret --query value -o tsv --only-show-errors)
+          url=$(az keyvault secret show --vault-name "$v" --name read-all-ffc-whmcs-api-url --query value -o tsv --only-show-errors)
+          apimkey=$(az keyvault secret show --vault-name "$v" --name read-all-ffc-apim-whmcs-subscription-key --query value -o tsv --only-show-errors || true)
+          echo "::add-mask::$ident"; echo "::add-mask::$secret"; echo "::add-mask::$apimkey"
+          if [ -z "$ident" ] || [ -z "$secret" ] || [ -z "$url" ]; then
+            echo "::error::WHMCS API secrets missing or empty in $v"
+            exit 1
+          fi
+
           args=(
             --data-urlencode "action=${API_ACTION}"
-            --data-urlencode "identifier=${WHMCS_API_IDENTIFIER}"
-            --data-urlencode "secret=${WHMCS_API_SECRET}"
-            --data-urlencode "accesskey=${WHMCS_API_ACCESS_KEY}"
+            --data-urlencode "identifier=${ident}"
+            --data-urlencode "secret=${secret}"
             --data-urlencode "setting=${SETTING}"
             --data-urlencode "responsetype=json"
           )
           if [ "${API_ACTION}" = "SetConfigurationValue" ]; then
             args+=(--data-urlencode "value=${NEW_VALUE}")
           fi
+          hdr=()
+          if [ -n "$apimkey" ]; then
+            hdr=(-H "Ocp-Apim-Subscription-Key: ${apimkey}")
+          fi
+
           http_code=$(curl -sS -o response.json -w "%{http_code}" \
-            -X POST "https://freeforcharity.org/hub/includes/api.php" "${args[@]}")
+            -X POST "$url" "${hdr[@]}" "${args[@]}")
           echo "HTTP ${http_code}"
-          # Response contains no credentials; settings values are not secret.
-          cat response.json | head -c 2000
+          # Response carries no credentials; settings values are not secret.
+          head -c 2000 response.json
           echo
           result=$(python3 -c "import json;print(json.load(open('response.json')).get('result',''))" || echo parse-error)
           {
@@ -100,5 +102,9 @@ jobs:
             echo ""
             echo "- Setting: \`${SETTING}\`"
             echo "- Result: \`${result}\` (HTTP ${http_code})"
+            if [ "${API_ACTION}" = "GetConfigurationValue" ] && [ "${result}" = "success" ]; then
+              val=$(python3 -c "import json;print(json.load(open('response.json')).get('value',''))" || true)
+              echo "- Value: \`${val}\`"
+            fi
           } >> "$GITHUB_STEP_SUMMARY"
           [ "${result}" = "success" ] || exit 1


### PR DESCRIPTION
## What

Reworks the just-merged `whmcs-config-ops.yml` (#432) to use the repo's **existing Key Vault method** instead of asking the operator to create new GitHub secrets. A `list-kv-secret-names` run of the existing diagnostics workflow showed `kv-ffc-admin-prod-cbm` already holds everything needed:

- `read-all-ffc-whmcs-api-identifier` / `-secret` / `-url`
- `read-all-ffc-apim-whmcs-subscription-key` (static-egress APIM route — clears the WHMCS IP allowlist that rejects dynamic runner IPs)

Changes:
- OIDC `azure/login` in the `cpanel-staging` environment (same as every cpanel-* workflow), then `az keyvault secret show` with `::add-mask::` on all values — identical pattern to `cpanel-kv-diagnostics.yml`.
- Calls the endpoint stored in `read-all-ffc-whmcs-api-url`, attaching `Ocp-Apim-Subscription-Key` when the APIM key is present.
- Drops the `WHMCS_API_IDENTIFIER`/`WHMCS_API_SECRET`/`WHMCS_API_ACCESS_KEY` GitHub-secret requirements entirely — **no operator setup needed**.
- Action scope unchanged: only `GetConfigurationValue` / `SetConfigurationValue`; reads report the value in the step summary (settings values are not secrets), credentials never printed.

First runs after merge: read `EnableTOSAccept` + `TermsOfServiceURL`, then point checkout ToS acceptance at the policy set including `/publicity-consent-policy/`.

## Verification
- YAML formatted; no site/build changes.
- Vault secret names confirmed present via diagnostics run 28744905052 (names only, no values read).

Refs #378, #379, #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013AwqCfp26iQEYUssk5cfCQ

---
_Generated by [Claude Code](https://claude.ai/code/session_013AwqCfp26iQEYUssk5cfCQ)_