### PR TITLE
feat: Terms of Service incorporates the FFC policy set by reference

### DIFF
--- a/src/app/terms-of-service/page.tsx
+++ b/src/app/terms-of-service/page.tsx
@@ -207,6 +207,52 @@ export default function TermsOfService() {
             principles.
           </p>
 
+          {/* Incorporated Policies */}
+          <h1 className="text-[30px] text-[#333] pb-[10px] leading-[1em] font-[500]">
+            Incorporated Policies
+          </h1>
+          <p className="text-[14px] text-[#666] pb-[10px] leading-[24px] font-[500]">
+            The following Free For Charity policies are incorporated into these Terms by reference.
+            By accepting these Terms — including when ordering services through our management
+            system — you also accept each of them:
+          </p>
+          <ul className="text-[14px] text-[#666] pb-[10px] leading-[24px] font-[500] list-disc list-inside">
+            <li>
+              <a href="/privacy-policy/" className="text-[#0567B1] underline">
+                Privacy Policy
+              </a>
+            </li>
+            <li>
+              <a href="/cookie-policy/" className="text-[#0567B1] underline">
+                Cookie Policy
+              </a>
+            </li>
+            <li>
+              <a href="/donation-policy/" className="text-[#0567B1] underline">
+                Donation Policy
+              </a>
+            </li>
+            <li>
+              <a href="/publicity-consent-policy/" className="text-[#0567B1] underline">
+                Publicity &amp; Story Consent Policy
+              </a>{' '}
+              — permits FFC to feature your organization (name, logo, site link, mission blurb, and
+              a factual account of the free services provided) in case studies, testimonials, the
+              charity spotlight, and directory listings. You can withdraw this consent at any time
+              with no effect on your services.
+            </li>
+            <li>
+              <a href="/vulnerability-disclosure-policy/" className="text-[#0567B1] underline">
+                Vulnerability Disclosure Policy
+              </a>
+            </li>
+            <li>
+              <a href="/accessibility-statement/" className="text-[#0567B1] underline">
+                Accessibility Statement
+              </a>
+            </li>
+          </ul>
+
           {/* Changes to Terms */}
           <h1 className="text-[30px] text-[#333] pb-[10px] leading-[1em] font-[500]">
             Changes to Terms


### PR DESCRIPTION
## What

Adds an **Incorporated Policies** section to `/terms-of-service/` listing the privacy, cookie, donation, **publicity & story consent**, vulnerability-disclosure, and accessibility policies as accepted-by-reference — with the publicity-consent line spelling out exactly what it permits and that it's revocable anytime without affecting services.

## Why

WHMCS checkout already requires ToS acceptance (verified live via the new `whmcs-config-ops` workflow: `EnableTOSAccept = on`, `TermsOfService = https://freeforcharity.org/free-for-charity-terms-of-service/`, which 301s to this page). With this section, the existing checkout checkbox becomes the consent mechanism for the whole policy set — completing the operator's decision that publicity consent is granted "when they accept all the other policies" at signup (#378/#379/#380).

After merge, the WHMCS `TermsOfService` setting gets updated to the canonical `https://freeforcharity.org/terms-of-service/` via the workflow (removing the dependency on the legacy-slug redirect).

## Verification
- `npm run lint` — 0 errors; `npm test` — 549/549; `npm run build` — succeeds; incorporation section confirmed in the built page.
- WHMCS current state read live through the APIM route (runs 28745142376, 28745205737).

Refs #378, #379, #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013AwqCfp26iQEYUssk5cfCQ

---
_Generated by [Claude Code](https://claude.ai/code/session_013AwqCfp26iQEYUssk5cfCQ)_