### PR TITLE
fix: harden WHMCS workflow + close safety-review findings

### DIFF
--- a/.github/workflows/whmcs-config-ops.yml
+++ b/.github/workflows/whmcs-config-ops.yml
@@ -16,9 +16,19 @@
 # 20.231.116.111 — the only IP on WHMCS's API allowlist), not the direct
 # origin URL: see FFC-Cloudflare-Automation docs/whmcs-apim-routing.md.
 #
-# Scope is deliberately narrow: only GetConfigurationValue and
-# SetConfigurationValue are allowed, so this workflow can never create
-# clients, orders, invoices, or touch member data.
+# Scope is deliberately narrow, enforced two ways:
+#   1. Only GetConfigurationValue and SetConfigurationValue actions.
+#   2. A hard allowlist of setting names (SETTING_ALLOWLIST below).
+#      tblconfiguration also stores sensitive rows (SMTP credentials,
+#      CronKey, API access keys, captcha secrets); without the allowlist
+#      this workflow would be an arbitrary config read/write primitive
+#      and reads would leak secret values into run logs and step
+#      summaries. Extend the allowlist only via reviewed PR, and only
+#      with settings whose values are safe to print.
+#
+# Operator action: ensure the cpanel-staging environment has required
+# reviewers — this workflow reads production credentials, so dispatch
+# should need a human approval, not just repo write access.
 
 name: WHMCS Config Ops
 
@@ -64,6 +74,17 @@ jobs:
           NEW_VALUE: ${{ inputs.value }}
         run: |
           set -euo pipefail
+          # Only non-sensitive checkout/policy settings. Values of anything
+          # on this list are safe to appear in logs and step summaries.
+          SETTING_ALLOWLIST="EnableTOSAccept TermsOfService"
+          allowed=false
+          for s in $SETTING_ALLOWLIST; do
+            if [ "$s" = "${SETTING}" ]; then allowed=true; break; fi
+          done
+          if [ "$allowed" != "true" ]; then
+            echo "::error::Setting '${SETTING}' is not on the allowlist (${SETTING_ALLOWLIST}). tblconfiguration holds sensitive rows; extend the allowlist via reviewed PR only."
+            exit 1
+          fi
           v=kv-ffc-admin-prod-cbm
           ident=$(az keyvault secret show --vault-name "$v" --name read-all-ffc-whmcs-api-identifier --query value -o tsv --only-show-errors)
           secret=$(az keyvault secret show --vault-name "$v" --name read-all-ffc-whmcs-api-secret --query value -o tsv --only-show-errors)
@@ -96,10 +117,12 @@ jobs:
           http_code=$(curl -sS -o response.json -w "%{http_code}" \
             -X POST "$url" "${hdr[@]}" "${args[@]}")
           echo "HTTP ${http_code}"
-          # Response carries no credentials; settings values are not secret.
-          head -c 2000 response.json
-          echo
+          # Never dump the raw response: print only the OData result/message
+          # fields. Values are printed solely for allowlisted settings, which
+          # are non-sensitive by construction.
           result=$(python3 -c "import json;print(json.load(open('response.json')).get('result',''))" || echo parse-error)
+          message=$(python3 -c "import json;print(json.load(open('response.json')).get('message',''))" || true)
+          echo "result=${result} ${message:+message=${message}}"
           {
             echo "## WHMCS ${API_ACTION}"
             echo ""

--- a/src/app/publicity-consent-policy/page.tsx
+++ b/src/app/publicity-consent-policy/page.tsx
@@ -64,14 +64,22 @@ export default function PublicityConsentPolicy() {
               permission to feature the organization as described above.
             </li>
             <li>
-              <strong>For organizations onboarded before this policy existed:</strong> FFC confirms
-              consent individually before publishing a new feature about them. Testimonials an
-              organization has already given publicly remain published unless they ask otherwise.
+              <strong>For organizations onboarded before this policy existed:</strong> features
+              built strictly from material the organization already provided for publication (such
+              as its testimonials) and from its own public website may be published on FFC
+              leadership&rsquo;s designation; anything beyond that is confirmed with the
+              organization individually first. Testimonials an organization has already given
+              publicly remain published unless they ask otherwise.
             </li>
             <li>
-              <strong>For quotes and photos of individuals:</strong> we attribute quotes only to
-              people who provided them for publication (for example through our testimonial form),
-              and we identify them only by name, role, and organization.
+              <strong>For quotes of individuals:</strong> we attribute quotes only to people who
+              provided them for publication (for example through our testimonial form), and we
+              identify them only by name, role, and organization.
+            </li>
+            <li>
+              <strong>For photos and logos:</strong> published only with explicit permission — the
+              testimonial form asks about photo/logo use as a separate question, and it is never
+              implied by any other consent.
             </li>
           </ul>
 
@@ -79,17 +87,17 @@ export default function PublicityConsentPolicy() {
           <p>
             Any organization can withdraw publicity consent at any time, even after accepting it at
             signup. <Link href="/contact-us/">Contact us</Link> and we will remove the requested
-            content from the next site deployment — typically within a few business days. Opting out
-            never affects the free services an organization receives from FFC.
+            content in the next site update, normally within a few business days. Opting out never
+            affects the free services an organization receives from FFC.
           </p>
 
           <h2 className={h2}>Review before publication</h2>
           <p>
             Every case study and spotlight entry is reviewed by FFC leadership before it goes live,
-            and the organization&rsquo;s approval is recorded in the public change history of this
-            website&rsquo;s repository. If we drafted a story from your organization&rsquo;s public
-            information and you&rsquo;d like it corrected, tell us and we&rsquo;ll fix it in the
-            next deployment.
+            and each entry&rsquo;s documented consent basis is recorded in the public change history
+            of this website&rsquo;s repository. If we drafted a story from your organization&rsquo;s
+            public information and you&rsquo;d like it corrected, tell us and we&rsquo;ll fix it in
+            the next update.
           </p>
 
           <p className="mt-8">

--- a/src/app/terms-of-service/page.tsx
+++ b/src/app/terms-of-service/page.tsx
@@ -14,7 +14,10 @@ export default function TermsOfService() {
         <div data-font="aria-font">
           {/* Effective Date */}
           <p className="text-[14px] text-[#666] pb-[10px] leading-[24px] font-[500]">
-            <em>Effective Date: 11-20-2024</em>
+            <em>
+              Effective Date: 07-05-2026 (Incorporated Policies section added; original terms
+              effective 11-20-2024)
+            </em>
           </p>
 
           {/* Main Title */}
@@ -230,6 +233,10 @@ export default function TermsOfService() {
             <li>
               <a href="/donation-policy/" className="text-[#0567B1] underline">
                 Donation Policy
+              </a>{' '}
+              and the{' '}
+              <a href="/free-for-charity-donation-policy/" className="text-[#0567B1] underline">
+                Free For Charity Donation Policy
               </a>
             </li>
             <li>

--- a/src/components/home-page/CharitySpotlight/index.tsx
+++ b/src/components/home-page/CharitySpotlight/index.tsx
@@ -14,12 +14,15 @@ interface Spotlight {
   month: string
   organization: string
   website: string
+  status: string
   blurb: string
 }
 
 function pickSpotlight(): Spotlight | null {
+  // Same publish gate as case studies: queued-but-unreviewed months never
+  // auto-publish just because their date arrived.
   const entries = (spotlightsData.spotlights as Spotlight[])
-    .slice()
+    .filter((e) => e.status === 'published')
     .sort((a, b) => a.month.localeCompare(b.month))
   if (entries.length === 0) return null
   const buildMonth = new Date().toISOString().slice(0, 7)

--- a/src/data/spotlights.json
+++ b/src/data/spotlights.json
@@ -1,19 +1,21 @@
 {
-  "_comment": "Monthly charity spotlight queue (issue #380). The homepage picks the entry whose month (YYYY-MM) matches the build month; if none matches, the most recent past entry shows, so the section never goes empty. The rotation advances with the first deployment of each month. Nomination/consent process: any FFC volunteer or the charity itself can nominate via the contact page; publicity consent per /publicity-consent-policy/ (granted at WHMCS signup for new charities, confirmed individually for earlier ones); the operator approves the entry and its consent basis is noted in consentNote. Only public facts: org name, its own site, mission blurb.",
+  "_comment": "Monthly charity spotlight queue (issue #380). Only entries with status 'published' render — mirroring case-studies.json, so a queued month cannot auto-publish before its review is done. The homepage picks the published entry whose month (YYYY-MM) matches the build month; if none matches, the most recent past published entry shows, so the section never goes empty. The rotation advances with the first deployment of each month. Nomination/consent process: any FFC volunteer or the charity itself can nominate via the contact page; publicity consent per /publicity-consent-policy/ (granted at WHMCS signup for new charities; for earlier orgs, features built strictly from material they already provided for publication plus their own public site may be operator-designated, anything beyond is confirmed individually); the operator approves the entry and its consent basis is noted in consentNote. Only public facts: org name, its own site, mission blurb.",
   "spotlights": [
     {
       "month": "2026-07",
       "organization": "American Legion Ahwatukee Post 64",
       "website": "https://americanlegionpost64.org/",
+      "status": "published",
       "blurb": "A veteran-led American Legion post in Ahwatukee, Arizona serving local veterans and their families. FFC provides their domain, website, and Microsoft 365 email free of charge — so every dollar raised goes to veteran programs, not technology bills.",
-      "consentNote": "Operator-designated first wave (2026-07-04); org already featured in published testimonials."
+      "consentNote": "Operator-designated first wave (2026-07-04); built strictly from the org's published testimonial and its own public site."
     },
     {
       "month": "2026-08",
       "organization": "Melanin Magic Foundation",
       "website": "",
+      "status": "published",
       "blurb": "A small foundation whose team puts every dollar into its mission. FFC handles their online presence — domain, website, and email — completely free, the same services we provide to every 501(c)(3) that asks.",
-      "consentNote": "Operator-designated first wave (2026-07-04); org already featured in published testimonials."
+      "consentNote": "Operator-designated first wave (2026-07-04); built strictly from the org's published testimonial."
     }
   ]
 }


### PR DESCRIPTION
## What

Fixes from a full safety & quality review (two independent adversarial passes — security and privacy/content — over everything merged this session, plus Lighthouse spot-checks on the routes CI doesn't cover).

### Security — `whmcs-config-ops.yml` (2 HIGH findings, both fixed)
- **Arbitrary config read → secret leak**: the free-text `setting` input let `GetConfigurationValue` read any `tblconfiguration` row (SMTP password, CronKey, API keys…) and print it into run logs and the permanent step summary. Now a **hard allowlist** (`EnableTOSAccept`, `TermsOfService`) rejects everything else before the API call, and raw response bodies are never printed — only `result`/`message`.
- **Arbitrary config write**: same allowlist bounds `SetConfigurationValue`, so the workflow can no longer redirect system mail or flip security settings.
- Header now instructs the operator to add **required reviewers** on the `cpanel-staging` environment (it gates production credentials).

### Privacy/consistency (policy & data)
- `/publicity-consent-policy/` no longer claims "the organization's approval is recorded" for operator-designated entries — it accurately states the documented consent basis, and scopes operator designation to features built strictly from material the org already provided for publication plus its own public site.
- Photos/logos get an explicit-permission bullet (the policy previously said "and photos" without stating a rule).
- Opt-out timing softened to "next site update, normally within a few business days."
- ToS effective date updated per its own change-notice clause; incorporated-policies list now names **both** donation policy pages, removing ambiguity about which governs.
- `spotlights.json` entries gain the same `status: "published"` gate as case studies (component filters on it), so a queued month can't auto-publish unreviewed when its date arrives.

### Verified clean by the review
Injection surfaces in the workflow (env-var + `--data-urlencode` pattern), credential masking, `.lycheeignore` anchoring, the `.at()` polyfill, all new `target="_blank"` links, Forms URLs (public response links, not secrets), PII discipline in all data files, sitemap/route registration, and consent-basis cross-references. Lighthouse on the five session-touched routes outside the CI list: **accessibility 100 / SEO 100** on all.

## Verification
- `npm run lint` — 0 errors; `npm test` — 549/549; `npm run build` — succeeds; homepage spotlight still renders with the new gate.

Refs #378, #379, #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013AwqCfp26iQEYUssk5cfCQ

---
_Generated by [Claude Code](https://claude.ai/code/session_013AwqCfp26iQEYUssk5cfCQ)_