### PR TITLE
perf: scroll-primed Zeffy iframes — 8MB embed loads only when approached

### DIFF
--- a/docs/STAGING-CHECKLIST.md
+++ b/docs/STAGING-CHECKLIST.md
@@ -67,8 +67,9 @@ Section 2c "Navigation and Footer" and the `/hub/` check below MUST be done on t
 
 ### 2a. Critical Pages
 
-- [ ] **Homepage** `/` — hero loads, Zeffy endowment-fund iframe renders in
-      the `#donate` section, team section visible
+- [ ] **Homepage** `/` — hero loads, team section visible; scroll down to
+      the `#donate` section and confirm the Zeffy endowment-fund iframe
+      mounts (scroll-primed — not present until you approach it)
 - [ ] **About Us** `/about-us` — team member cards and photos appear
 - [ ] **Donate** `/donate` — PayPal "Donate Today" button (hosted button
       `9ZKQ23YC3G2J2`) appears in the Measurable Impact section
@@ -210,7 +211,7 @@ After the document-root swap, monitor:
 - [ ] `https://freeforcharity.org/hub/` renders the WHMCS storefront — **critical billing check**
 - [ ] `https://freeforcharity.org/hub/globaladmin` reaches WHMCS admin
 - [ ] Homepage loads without any `404` or `5xx` errors
-- [ ] Donation buttons on `/donate` and the Zeffy iframe on `/free-for-charity-endowment-fund` still work
+- [ ] Donation buttons on `/donate` still work; on `/free-for-charity-endowment-fund`, scroll to the donation section and confirm the Zeffy iframes mount (scroll-primed)
 - [ ] Sample WP→Next redirects fire (see `docs/CUTOVER-REDIRECTS.md`)
 - [ ] WHMCS PHP error logs in cPanel show no new errors related to path changes
 - [ ] If problems are detected, on-call manually creates an `incident` issue and begins rollback as needed

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -519,10 +519,15 @@ async function main() {
     'zeffy-form-link',
     'zeffy.com/embed/',
   ])
+  // The Zeffy iframes are scroll-primed (LazyZeffyIframe), so the raw HTML
+  // contains no <iframe> tag; the embed src survives as a serialized client
+  // prop plus a <noscript> fallback link. Assert that marker — it proves
+  // the lazy-iframe wiring shipped, not that the form visually mounted
+  // (only a scrolling browser can prove that; donation-flows.spec.ts does).
   await checkBodyContains(
-    `/free-for-charity-endowment-fund mounts the Zeffy form`,
+    `/free-for-charity-endowment-fund ships the Zeffy embed wiring`,
     '/free-for-charity-endowment-fund/',
-    ['zeffy']
+    ['zeffy.com/embed/']
   )
   // PayPal return flow: the donation-confirmation callback must 302 to
   // /donate AND preserve the transaction query (tx=...), or the post-donation

--- a/src/components/free-for-charity-endowment-fund-components/Empower-Charities/index.tsx
+++ b/src/components/free-for-charity-endowment-fund-components/Empower-Charities/index.tsx
@@ -1,9 +1,5 @@
-import React, { CSSProperties, FC, IframeHTMLAttributes } from 'react'
-
-interface ExtendedIframeProps extends IframeHTMLAttributes<HTMLIFrameElement> {
-  allowpaymentrequest?: string
-  allowtransparency?: string // lowercase version for DOM compatibility
-}
+import React, { CSSProperties, FC } from 'react'
+import LazyZeffyIframe, { ZeffyIframeProps } from '@/components/ui/LazyZeffyIframe'
 
 const DonationSection: FC = () => {
   const commonStyle: CSSProperties = {
@@ -26,7 +22,7 @@ const DonationSection: FC = () => {
     height: '120px',
   }
 
-  const donationFormProps: ExtendedIframeProps = {
+  const donationFormProps: ZeffyIframeProps = {
     title: 'Donation form powered by Zeffy',
     style: donationFormStyle,
     src: 'https://www.zeffy.com/embed/donation-form/free-for-charity-endowment-fund',
@@ -34,7 +30,7 @@ const DonationSection: FC = () => {
     allowtransparency: 'true', // ✅ fixed here
   }
 
-  const thermometerProps: ExtendedIframeProps = {
+  const thermometerProps: ZeffyIframeProps = {
     title: 'Donation thermometer powered by Zeffy',
     style: thermometerStyle,
     src: 'https://www.zeffy.com/embed/thermometer/free-for-charity-endowment-fund',
@@ -56,14 +52,14 @@ const DonationSection: FC = () => {
         <div className="h-full min-h-[1374px] pt-[120px]">
           {/* Thermometer Embed */}
           <div className="relative w-full h-[120px]">
-            <iframe {...thermometerProps}></iframe>
+            <LazyZeffyIframe {...thermometerProps} />
           </div>
         </div>
 
         <div className="h-full min-h-[1200px] bg-white space-y-10">
           {/* Donation Form */}
           <div className="relative w-full h-[1200px]">
-            <iframe {...donationFormProps}></iframe>
+            <LazyZeffyIframe {...donationFormProps} />
           </div>
         </div>
       </div>

--- a/src/components/free-for-charity-endowment-fund-components/Empower-Charities/index.tsx
+++ b/src/components/free-for-charity-endowment-fund-components/Empower-Charities/index.tsx
@@ -1,5 +1,6 @@
 import React, { CSSProperties, FC } from 'react'
 import LazyZeffyIframe, { ZeffyIframeProps } from '@/components/ui/LazyZeffyIframe'
+import { ZEFFY_BASE } from '@/data/donation-campaigns'
 
 const DonationSection: FC = () => {
   const commonStyle: CSSProperties = {
@@ -25,7 +26,7 @@ const DonationSection: FC = () => {
   const donationFormProps: ZeffyIframeProps = {
     title: 'Donation form powered by Zeffy',
     style: donationFormStyle,
-    src: 'https://www.zeffy.com/embed/donation-form/free-for-charity-endowment-fund',
+    src: `${ZEFFY_BASE}/embed/donation-form/free-for-charity-endowment-fund`,
     allowpaymentrequest: '',
     allowtransparency: 'true', // ✅ fixed here
   }
@@ -33,7 +34,7 @@ const DonationSection: FC = () => {
   const thermometerProps: ZeffyIframeProps = {
     title: 'Donation thermometer powered by Zeffy',
     style: thermometerStyle,
-    src: 'https://www.zeffy.com/embed/thermometer/free-for-charity-endowment-fund',
+    src: `${ZEFFY_BASE}/embed/thermometer/free-for-charity-endowment-fund`,
     allowtransparency: 'true', // ✅ fixed here
   }
 

--- a/src/components/home-page/SupportFreeForCharity/index.tsx
+++ b/src/components/home-page/SupportFreeForCharity/index.tsx
@@ -1,12 +1,8 @@
-import React, { CSSProperties, IframeHTMLAttributes } from 'react'
+import React, { CSSProperties } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
 import { assetPath } from '@/lib/assetPath'
-
-interface ExtendedIframeProps extends IframeHTMLAttributes<HTMLIFrameElement> {
-  allowpaymentrequest?: string
-  allowtransparency?: string
-}
+import LazyZeffyIframe, { ZeffyIframeProps } from '@/components/ui/LazyZeffyIframe'
 
 const Index = () => {
   const donationFormStyle: CSSProperties = {
@@ -20,7 +16,7 @@ const Index = () => {
     height: '100%',
   }
 
-  const donationFormProps: ExtendedIframeProps = {
+  const donationFormProps: ZeffyIframeProps = {
     title: 'Donation form powered by Zeffy',
     style: donationFormStyle,
     src: 'https://www.zeffy.com/embed/donation-form/free-for-charity-endowment-fund',
@@ -76,7 +72,7 @@ const Index = () => {
               role="region"
               aria-label="Donation form"
             >
-              <iframe {...donationFormProps}></iframe>
+              <LazyZeffyIframe {...donationFormProps} />
             </div>
           </div>
         </div>

--- a/src/components/home-page/SupportFreeForCharity/index.tsx
+++ b/src/components/home-page/SupportFreeForCharity/index.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { assetPath } from '@/lib/assetPath'
 import LazyZeffyIframe, { ZeffyIframeProps } from '@/components/ui/LazyZeffyIframe'
+import { ZEFFY_BASE } from '@/data/donation-campaigns'
 
 const Index = () => {
   const donationFormStyle: CSSProperties = {
@@ -19,7 +20,7 @@ const Index = () => {
   const donationFormProps: ZeffyIframeProps = {
     title: 'Donation form powered by Zeffy',
     style: donationFormStyle,
-    src: 'https://www.zeffy.com/embed/donation-form/free-for-charity-endowment-fund',
+    src: `${ZEFFY_BASE}/embed/donation-form/free-for-charity-endowment-fund`,
     allowpaymentrequest: '',
     allowtransparency: 'true',
   }

--- a/src/components/ui/LazyZeffyIframe.tsx
+++ b/src/components/ui/LazyZeffyIframe.tsx
@@ -39,6 +39,10 @@ const LazyZeffyIframe = (props: ZeffyIframeProps) => {
       const t = setTimeout(() => setMounted(true), 0)
       return () => clearTimeout(t)
     }
+    // Margin on top AND bottom so the preload lead also applies when
+    // approaching from below (e.g. after following an anchor further down
+    // the page). The top margin extends the window upward off-screen at
+    // load time, so it cannot re-trigger eager loading.
     const observer = new IntersectionObserver(
       (entries) => {
         if (entries.some((entry) => entry.isIntersecting)) {
@@ -46,7 +50,7 @@ const LazyZeffyIframe = (props: ZeffyIframeProps) => {
           observer.disconnect()
         }
       },
-      { rootMargin: `0px 0px ${PRELOAD_MARGIN_PX}px 0px` }
+      { rootMargin: `${PRELOAD_MARGIN_PX}px 0px` }
     )
     observer.observe(el)
     return () => observer.disconnect()

--- a/src/components/ui/LazyZeffyIframe.tsx
+++ b/src/components/ui/LazyZeffyIframe.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React, { useEffect, useRef, useState, IframeHTMLAttributes } from 'react'
+import { zeffyHostedUrl } from '@/data/donation-campaigns'
 
 export interface ZeffyIframeProps extends IframeHTMLAttributes<HTMLIFrameElement> {
   allowpaymentrequest?: string
@@ -32,7 +33,7 @@ const LazyZeffyIframe = (props: ZeffyIframeProps) => {
 
   useEffect(() => {
     const el = hostRef.current
-    if (!el || mounted) return
+    if (!el) return
     // No IntersectionObserver (very old browsers): load immediately rather
     // than never. (Async so the effect doesn't set state synchronously.)
     if (typeof IntersectionObserver === 'undefined') {
@@ -54,13 +55,31 @@ const LazyZeffyIframe = (props: ZeffyIframeProps) => {
     )
     observer.observe(el)
     return () => observer.disconnect()
-  }, [mounted])
+  }, [])
 
   // Before mount the reserved box simply stays empty — the same thing
   // visitors saw while the Zeffy app booted when the iframe was eager.
+  // Without JavaScript the observer never fires, so <noscript> keeps a
+  // donation path alive: a link to the Zeffy-hosted page (same form,
+  // full page), matching ZeffyPopupButton's no-JS fallback pattern.
   return (
     <div ref={hostRef} className="absolute inset-0">
       {mounted && <iframe {...props}></iframe>}
+      {props.src && (
+        <noscript>
+          <a
+            href={zeffyHostedUrl(props.src)}
+            className="absolute inset-0 flex items-center justify-center"
+          >
+            <span
+              className="bg-white text-[#0567B1] underline px-4 py-2 rounded shadow"
+              data-font="lato-font"
+            >
+              {props.title ?? 'Open the donation form'}
+            </span>
+          </a>
+        </noscript>
+      )}
     </div>
   )
 }

--- a/src/components/ui/LazyZeffyIframe.tsx
+++ b/src/components/ui/LazyZeffyIframe.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import React, { useEffect, useRef, useState, IframeHTMLAttributes } from 'react'
+
+export interface ZeffyIframeProps extends IframeHTMLAttributes<HTMLIFrameElement> {
+  allowpaymentrequest?: string
+  allowtransparency?: string
+}
+
+/**
+ * Scroll-primed Zeffy iframe. Zeffy's embed app pulls ~8MB of script, which
+ * used to download eagerly on every page view. The iframe now mounts when
+ * the visitor scrolls within PRELOAD_MARGIN_PX of the section — far enough
+ * ahead that the form is typically loaded before it enters the viewport,
+ * while visitors who never scroll this far download nothing.
+ *
+ * The parent must be the same `relative`, fixed-size box that previously
+ * held the iframe directly; the reserved box means mounting causes no
+ * layout shift.
+ *
+ * Margin sizing: the homepage #donate section sits ~1100px below the fold
+ * on desktop (~1400px on mobile), so the margin must stay under that or
+ * the observer fires at load and eager loading is effectively back
+ * (donation-flows.spec.ts locks this in). 800px still gives a full
+ * viewport-plus of scroll lead for the form to load before arrival.
+ */
+const PRELOAD_MARGIN_PX = 800
+
+const LazyZeffyIframe = (props: ZeffyIframeProps) => {
+  const hostRef = useRef<HTMLDivElement>(null)
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    const el = hostRef.current
+    if (!el || mounted) return
+    // No IntersectionObserver (very old browsers): load immediately rather
+    // than never. (Async so the effect doesn't set state synchronously.)
+    if (typeof IntersectionObserver === 'undefined') {
+      const t = setTimeout(() => setMounted(true), 0)
+      return () => clearTimeout(t)
+    }
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          setMounted(true)
+          observer.disconnect()
+        }
+      },
+      { rootMargin: `0px 0px ${PRELOAD_MARGIN_PX}px 0px` }
+    )
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [mounted])
+
+  // Before mount the reserved box simply stays empty — the same thing
+  // visitors saw while the Zeffy app booted when the iframe was eager.
+  return (
+    <div ref={hostRef} className="absolute inset-0">
+      {mounted && <iframe {...props}></iframe>}
+    </div>
+  )
+}
+
+export default LazyZeffyIframe

--- a/tests/donation-flows.spec.ts
+++ b/tests/donation-flows.spec.ts
@@ -81,14 +81,20 @@ test.describe('Donation flows', () => {
       .scrollIntoViewIfNeeded()
 
     // The thermometer sits just below the heading, so it mounts first.
-    const thermometer = page.locator('iframe[src*="zeffy.com/embed/thermometer"]')
+    // Assert the campaign slug too — a different Zeffy campaign must not
+    // satisfy the guard.
+    const thermometer = page.locator(
+      'iframe[src*="zeffy.com/embed/thermometer/free-for-charity-endowment-fund"]'
+    )
     await expect(thermometer).toBeAttached({ timeout: 15000 })
 
     // The donation form is a further ~1500px down — scroll to the bottom
     // and assert it specifically (a passing thermometer must not mask a
     // broken donation form).
     await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight))
-    const donationForm = page.locator('iframe[src*="zeffy.com/embed/donation-form"]')
+    const donationForm = page.locator(
+      'iframe[src*="zeffy.com/embed/donation-form/free-for-charity-endowment-fund"]'
+    )
     await expect(donationForm).toBeAttached({ timeout: 15000 })
 
     const src = await donationForm.getAttribute('src')
@@ -112,9 +118,12 @@ test.describe('Donation flows', () => {
     await page.waitForTimeout(1000)
     expect(await page.locator('iframe[src*="zeffy.com"]').count()).toBe(0)
 
-    // Scrolling to the donate section mounts the real iframe.
+    // Scrolling to the donate section mounts the real iframe — assert the
+    // exact endowment-fund donation-form embed, not just any Zeffy frame.
     await page.locator('#donate').scrollIntoViewIfNeeded()
-    const zeffyFrame = page.locator('iframe[src*="zeffy.com"]').first()
+    const zeffyFrame = page.locator(
+      'iframe[src*="zeffy.com/embed/donation-form/free-for-charity-endowment-fund"]'
+    )
     await expect(zeffyFrame).toBeAttached({ timeout: 15000 })
   })
 })

--- a/tests/donation-flows.spec.ts
+++ b/tests/donation-flows.spec.ts
@@ -80,10 +80,18 @@ test.describe('Donation flows', () => {
       .getByRole('heading', { name: /Empower Charities with Your Generosity/i })
       .scrollIntoViewIfNeeded()
 
-    const zeffyFrame = page.locator('iframe[src*="zeffy.com"]').first()
-    await expect(zeffyFrame).toBeAttached({ timeout: 15000 })
+    // The thermometer sits just below the heading, so it mounts first.
+    const thermometer = page.locator('iframe[src*="zeffy.com/embed/thermometer"]')
+    await expect(thermometer).toBeAttached({ timeout: 15000 })
 
-    const src = await zeffyFrame.getAttribute('src')
+    // The donation form is a further ~1500px down — scroll to the bottom
+    // and assert it specifically (a passing thermometer must not mask a
+    // broken donation form).
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight))
+    const donationForm = page.locator('iframe[src*="zeffy.com/embed/donation-form"]')
+    await expect(donationForm).toBeAttached({ timeout: 15000 })
+
+    const src = await donationForm.getAttribute('src')
     expect(src).toBeTruthy()
     expect(ZEFFY_EMBED_HOSTS.some((h) => src!.includes(h))).toBe(true)
   })
@@ -98,6 +106,10 @@ test.describe('Donation flows', () => {
     // window plus the 800px preload margin must not reach the #donate
     // section from the top of the page; if a layout change moves #donate
     // that high, eager loading is effectively back and this fails.)
+    // Wait past hydration + the observer's initial callback so a mount
+    // that happens shortly after load is actually caught.
+    await page.waitForLoadState('networkidle')
+    await page.waitForTimeout(1000)
     expect(await page.locator('iframe[src*="zeffy.com"]').count()).toBe(0)
 
     // Scrolling to the donate section mounts the real iframe.

--- a/tests/donation-flows.spec.ts
+++ b/tests/donation-flows.spec.ts
@@ -66,18 +66,43 @@ test.describe('Donation flows', () => {
     })
   })
 
-  test('/free-for-charity-endowment-fund mounts the Zeffy donation iframe', async ({ page }) => {
+  test('/free-for-charity-endowment-fund mounts the Zeffy donation iframe on scroll', async ({
+    page,
+  }) => {
     await page.goto('/free-for-charity-endowment-fund')
 
-    // The Zeffy form is an <iframe src="https://www.zeffy.com/embed/...">.
-    // We wait for the element to be attached, then for its src attribute
-    // to reference zeffy.com — that catches both the "iframe element
-    // never rendered" and "iframe rendered with wrong src" failure modes.
+    // Zeffy iframes are scroll-primed (LazyZeffyIframe): they mount once
+    // the visitor scrolls within ~800px of the section, so Zeffy's ~8MB
+    // embed never loads for visitors who don't reach it. Scroll to the
+    // section, then assert the iframe mounts with the right src — that
+    // catches "never mounts on scroll" and "mounted with wrong src".
+    await page
+      .getByRole('heading', { name: /Empower Charities with Your Generosity/i })
+      .scrollIntoViewIfNeeded()
+
     const zeffyFrame = page.locator('iframe[src*="zeffy.com"]').first()
     await expect(zeffyFrame).toBeAttached({ timeout: 15000 })
 
     const src = await zeffyFrame.getAttribute('src')
     expect(src).toBeTruthy()
     expect(ZEFFY_EMBED_HOSTS.some((h) => src!.includes(h))).toBe(true)
+  })
+
+  test('homepage Zeffy iframe is scroll-primed: absent initially, mounts near #donate', async ({
+    page,
+  }) => {
+    await page.goto('/')
+
+    // Before any scrolling, the ~8MB Zeffy embed must NOT be in the page —
+    // that is the entire point of the lazy mount. (The viewport-height
+    // window plus the 800px preload margin must not reach the #donate
+    // section from the top of the page; if a layout change moves #donate
+    // that high, eager loading is effectively back and this fails.)
+    expect(await page.locator('iframe[src*="zeffy.com"]').count()).toBe(0)
+
+    // Scrolling to the donate section mounts the real iframe.
+    await page.locator('#donate').scrollIntoViewIfNeeded()
+    const zeffyFrame = page.locator('iframe[src*="zeffy.com"]').first()
+    await expect(zeffyFrame).toBeAttached({ timeout: 15000 })
   })
 })


### PR DESCRIPTION
Follow-up to #430/#433, completing the page-weight series. After the video facade and font self-hosting, the last big payload was the **Zeffy donation embed: ~8 MB of third-party script**, loaded eagerly by the iframes on the homepage (`#donate` section) and `/free-for-charity-endowment-fund/` — even for visitors who never scrolled to a form.

## What changed

New `LazyZeffyIframe` client component (`src/components/ui/LazyZeffyIframe.tsx`): the real iframe mounts when the visitor scrolls within **800px** of its reserved box (IntersectionObserver; immediate load if IO is unavailable). Per the operator's direction, the load is scroll-triggered but starts *before* the visitor reaches the form — a full viewport-plus of lead time — so it's typically ready on arrival.

**Why 800px:** measured against the static export, the homepage `#donate` section sits ~1100px below the initial desktop viewport (~1400px mobile). A larger margin (1500px was tried first) put the section inside the observer's window at load time, silently restoring eager loading. 800px keeps the homepage genuinely lazy on all common viewports; the code comment documents the constraint and the new e2e test locks it in.

The reserved boxes keep their exact dimensions, so mounting causes **no layout shift**. All three embeds converted: homepage donation form, endowment-page donation form + thermometer.

## Effect

- Visitors who never scroll to a donation form: **~8 MB less transfer** per page view
- Visitors who do: the form is loading ~1 viewport before they arrive
- Initial homepage payload stays at the post-#433 ~0.95 MB first-party with no third-party script at load

## Tests

`tests/donation-flows.spec.ts`:
- endowment test updated for the scroll-primed flow (scrolls to the section, then asserts the iframe mounts with the right Zeffy src)
- new homepage guard: asserts **zero** `zeffy.com` iframes before scrolling (fails if a layout change ever puts `#donate` back inside the load-time window) and that the iframe mounts near `#donate`

## Verification

- Real-browser checks against the static export at 1280×720, 390×844, and 1920×1080: zero Zeffy iframes at load on both pages; all three iframes mount on scroll
- `npm run lint` — 0 errors, 0 warnings
- `npm run test` — 549/549
- Playwright: donation-flows (5/5 incl. new tests), accessibility (all pages), mission-video — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L25Q6sAFeFRan2rysdRguR

---
_Generated by [Claude Code](https://claude.ai/code/session_01L25Q6sAFeFRan2rysdRguR)_