### PR TITLE
feat(backup): app-only OneDrive auth — end the monthly device-code re-auth

### DIFF
--- a/.github/workflows/cpanel-softaculous-backup-sync.yml
+++ b/.github/workflows/cpanel-softaculous-backup-sync.yml
@@ -10,18 +10,20 @@ name: 'cPanel Softaculous backups -> OneDrive'
 # -> Restore rebuilds files + DB), with the SQL inside each archive. WHMCS is
 # the priority and is captured daily.
 #
-# Auth (all via the deploy OIDC identity — no stored user credentials):
-#   FTP creds:    Key Vault wr-all-cbm-cpanel-ffc-interserver-ftp-{host,user,password,port}
-#   OneDrive:     app-only Microsoft Graph token minted from the OIDC login
-#                 (`az account get-access-token`). The identity holds a Graph
-#                 application permission (Files.ReadWrite.All or, preferred,
-#                 Sites.Selected on the backup library) granted with admin consent.
-#   Destination:  repo/environment variable ONEDRIVE_DRIVE_BASE, e.g.
-#                 /users/<upn-or-id>/drive or /sites/<site-id>/drive.
+# Auth — two GitHub-OIDC identities, no stored user credentials, no refresh token:
+#   FTP creds:  AZURE_DEPLOY_CLIENT_ID (Key Vault reader) reads
+#               wr-all-cbm-cpanel-ffc-interserver-ftp-{host,user,password,port}.
+#   OneDrive:   AZURE_ONEDRIVE_CLIENT_ID (dedicated backup app, app-only) mints a
+#               Microsoft Graph token via `az account get-access-token`. It holds
+#               ONLY Graph Files.ReadWrite.All (application, admin-consented) and no
+#               Azure subscription — isolating the broad OneDrive grant to one
+#               single-purpose identity.
+#   Dest:       variable ONEDRIVE_DRIVE_BASE, pinned to the backup drive
+#               (e.g. /drives/<drive-id>). App-only tokens have no /me.
 #
-# The Azure identity needs Key Vault *Secrets User* (read) for the FTP secrets.
 # App-only auth has no refresh token and no interactive MFA, so a Conditional
-# Access sign-in-frequency policy can no longer break the daily run.
+# Access sign-in-frequency policy can no longer break the daily run. Setup runbook:
+# docs/onedrive-backup-app-only-auth.md.
 
 on:
   schedule:
@@ -51,43 +53,21 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Azure login (OIDC)
+      - name: 'Azure login (OIDC) — Key Vault reader'
         uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_DEPLOY_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: 'Mint Graph token + load FTP creds from Key Vault'
-        id: secrets
+      - name: 'Load cPanel FTPS creds from Key Vault'
         env:
           KV: kv-ffc-admin-prod-cbm
-          # Drive target for app-only Graph (no /me). Set as a repo/environment
-          # variable, e.g. "/users/<upn-or-id>/drive" or "/sites/<site-id>/drive".
-          DRIVE_BASE: ${{ vars.ONEDRIVE_DRIVE_BASE }}
         run: |
           set -euo pipefail
           kv() { az keyvault secret show --vault-name "$KV" --name "$1" --query value -o tsv; }
 
-          # --- OneDrive: app-only Microsoft Graph token via the OIDC login ---
-          # The azure/login identity holds a Graph *application* permission
-          # (Files.ReadWrite.All or Sites.Selected, admin-consented), so we mint an
-          # app-only token directly. No refresh token, no device-code re-auth, and
-          # nothing a Conditional Access sign-in-frequency policy can invalidate.
-          if [ -z "${DRIVE_BASE:-}" ]; then
-            echo "::error::Set the ONEDRIVE_DRIVE_BASE variable (e.g. /users/<upn>/drive or /sites/<site-id>/drive) — app-only tokens have no /me."
-            exit 1
-          fi
-          echo "DRIVE_BASE=$DRIVE_BASE" >> "$GITHUB_ENV"
-          graph_token=$(az account get-access-token --resource https://graph.microsoft.com --query accessToken -o tsv)
-          if [ -z "$graph_token" ]; then
-            echo "::error::Failed to mint a Graph app token. Confirm the OIDC identity has a Graph application permission (Files.ReadWrite.All or Sites.Selected) with admin consent."
-            exit 1
-          fi
-          echo "::add-mask::$graph_token"
-          echo "GRAPH_TOKEN=$graph_token" >> "$GITHUB_ENV"
-
-          # --- cPanel FTPS creds ---
+          # --- cPanel FTPS creds (read under the Key Vault reader identity) ---
           # Connect by HOSTNAME (derived from the ...-server URL), not the raw
           # IP, so the FTPS certificate's hostname can be verified (the script
           # verifies against the system CA store by default). cPanel AutoSSL
@@ -103,6 +83,39 @@ jobs:
           fp=$(kv wr-all-cbm-cpanel-ffc-interserver-ftp-password)
           echo "::add-mask::$fp"
           echo "FTP_PASS=$fp" >> "$GITHUB_ENV"
+
+      # Switch to the dedicated OneDrive backup identity (app-only). It holds ONLY
+      # Microsoft Graph Files.ReadWrite.All — no Azure subscription, no Key Vault,
+      # no other tenant access — so the broad OneDrive grant is isolated here.
+      - name: 'Azure login (OIDC) — OneDrive backup app'
+        uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.AZURE_ONEDRIVE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
+
+      - name: 'Mint app-only Microsoft Graph token'
+        env:
+          # Drive target for app-only Graph (no /me). Pinned to the exact backup
+          # drive, e.g. "/drives/<drive-id>". Set as repo/environment variable.
+          DRIVE_BASE: ${{ vars.ONEDRIVE_DRIVE_BASE }}
+        run: |
+          set -euo pipefail
+          # App-only token from the dedicated backup identity. No refresh token,
+          # no device-code re-auth, nothing a Conditional Access sign-in-frequency
+          # policy can invalidate.
+          if [ -z "${DRIVE_BASE:-}" ]; then
+            echo "::error::Set the ONEDRIVE_DRIVE_BASE variable (e.g. /drives/<drive-id> or /users/<upn>/drive) — app-only tokens have no /me."
+            exit 1
+          fi
+          echo "DRIVE_BASE=$DRIVE_BASE" >> "$GITHUB_ENV"
+          graph_token=$(az account get-access-token --resource https://graph.microsoft.com --query accessToken -o tsv)
+          if [ -z "$graph_token" ]; then
+            echo "::error::Failed to mint a Graph app token. Confirm AZURE_ONEDRIVE_CLIENT_ID has Graph Files.ReadWrite.All (application) with admin consent."
+            exit 1
+          fi
+          echo "::add-mask::$graph_token"
+          echo "GRAPH_TOKEN=$graph_token" >> "$GITHUB_ENV"
 
       - name: 'Sync Softaculous backups to OneDrive'
         env:

--- a/.github/workflows/cpanel-softaculous-backup-sync.yml
+++ b/.github/workflows/cpanel-softaculous-backup-sync.yml
@@ -10,15 +10,18 @@ name: 'cPanel Softaculous backups -> OneDrive'
 # -> Restore rebuilds files + DB), with the SQL inside each archive. WHMCS is
 # the priority and is captured daily.
 #
-# Auth/secrets (Key Vault, via the deploy OIDC identity):
-#   FTP:      wr-all-cbm-cpanel-ffc-interserver-ftp-{host,user,password,port}
-#   OneDrive: read-all-ffc-onedrive-backup-{client-id,tenant-id}
-#             wr-all-ffc-onedrive-backup-refresh-token   (delegated, rotated)
+# Auth (all via the deploy OIDC identity — no stored user credentials):
+#   FTP creds:    Key Vault wr-all-cbm-cpanel-ffc-interserver-ftp-{host,user,password,port}
+#   OneDrive:     app-only Microsoft Graph token minted from the OIDC login
+#                 (`az account get-access-token`). The identity holds a Graph
+#                 application permission (Files.ReadWrite.All or, preferred,
+#                 Sites.Selected on the backup library) granted with admin consent.
+#   Destination:  repo/environment variable ONEDRIVE_DRIVE_BASE, e.g.
+#                 /users/<upn-or-id>/drive or /sites/<site-id>/drive.
 #
-# The Azure identity needs Key Vault *Secrets User* (read) and, to persist the
-# rotated OneDrive refresh token, *Secrets Officer* (set) on
-# wr-all-ffc-onedrive-backup-refresh-token. If the writeback role is missing,
-# the run still succeeds (the token rotates ~every 90 days otherwise).
+# The Azure identity needs Key Vault *Secrets User* (read) for the FTP secrets.
+# App-only auth has no refresh token and no interactive MFA, so a Conditional
+# Access sign-in-frequency policy can no longer break the daily run.
 
 on:
   schedule:
@@ -59,41 +62,30 @@ jobs:
         id: secrets
         env:
           KV: kv-ffc-admin-prod-cbm
+          # Drive target for app-only Graph (no /me). Set as a repo/environment
+          # variable, e.g. "/users/<upn-or-id>/drive" or "/sites/<site-id>/drive".
+          DRIVE_BASE: ${{ vars.ONEDRIVE_DRIVE_BASE }}
         run: |
           set -euo pipefail
           kv() { az keyvault secret show --vault-name "$KV" --name "$1" --query value -o tsv; }
 
-          # --- OneDrive: refresh-token grant (delegated public client) ---
-          od_tenant=$(kv read-all-ffc-onedrive-backup-tenant-id)
-          od_client=$(kv read-all-ffc-onedrive-backup-client-id)
-          od_rt=$(kv wr-all-ffc-onedrive-backup-refresh-token)
-          echo "::add-mask::$od_rt"
-          # -S surfaces transport errors; not -f, because we must read the JSON
-          # error body (.error_description) when the grant is rejected (e.g. an
-          # expired refresh token) to print an actionable message.
-          resp=$(curl -sS -X POST "https://login.microsoftonline.com/${od_tenant}/oauth2/v2.0/token" \
-            -d "client_id=${od_client}" -d "grant_type=refresh_token" \
-            --data-urlencode "scope=https://graph.microsoft.com/Files.ReadWrite.All offline_access" \
-            --data-urlencode "refresh_token=${od_rt}")
-          graph_token=$(printf '%s' "$resp" | jq -r '.access_token // empty')
-          new_rt=$(printf '%s' "$resp" | jq -r '.refresh_token // empty')
-          [ -n "$new_rt" ] && echo "::add-mask::$new_rt"
+          # --- OneDrive: app-only Microsoft Graph token via the OIDC login ---
+          # The azure/login identity holds a Graph *application* permission
+          # (Files.ReadWrite.All or Sites.Selected, admin-consented), so we mint an
+          # app-only token directly. No refresh token, no device-code re-auth, and
+          # nothing a Conditional Access sign-in-frequency policy can invalidate.
+          if [ -z "${DRIVE_BASE:-}" ]; then
+            echo "::error::Set the ONEDRIVE_DRIVE_BASE variable (e.g. /users/<upn>/drive or /sites/<site-id>/drive) — app-only tokens have no /me."
+            exit 1
+          fi
+          echo "DRIVE_BASE=$DRIVE_BASE" >> "$GITHUB_ENV"
+          graph_token=$(az account get-access-token --resource https://graph.microsoft.com --query accessToken -o tsv)
           if [ -z "$graph_token" ]; then
-            echo "::error::OneDrive refresh-token grant failed. Re-auth the ffc-onedrive-backup app (device code) and update the KV secret."
-            printf '%s' "$resp" | jq -r '.error_description // .error' | head -1
+            echo "::error::Failed to mint a Graph app token. Confirm the OIDC identity has a Graph application permission (Files.ReadWrite.All or Sites.Selected) with admin consent."
             exit 1
           fi
           echo "::add-mask::$graph_token"
           echo "GRAPH_TOKEN=$graph_token" >> "$GITHUB_ENV"
-
-          # Persist the rotated refresh token (best-effort; needs Secrets Officer).
-          if [ -n "$new_rt" ] && [ "$new_rt" != "$od_rt" ]; then
-            if az keyvault secret set --vault-name "$KV" --name wr-all-ffc-onedrive-backup-refresh-token --value "$new_rt" -o none 2>/dev/null; then
-              echo "rotated OneDrive refresh token persisted to Key Vault"
-            else
-              echo "::warning::could not persist rotated refresh token (grant Key Vault Secrets Officer to enable rotation)"
-            fi
-          fi
 
           # --- cPanel FTPS creds ---
           # Connect by HOSTNAME (derived from the ...-server URL), not the raw

--- a/docs/onedrive-backup-app-only-auth.md
+++ b/docs/onedrive-backup-app-only-auth.md
@@ -3,86 +3,58 @@
 ## Why
 `cpanel-softaculous-backup-sync.yml` used to authenticate to OneDrive as a **user**
 (delegated device-code flow → refresh token in Key Vault). A Conditional Access
-**sign-in-frequency** policy invalidates that refresh token roughly monthly
-(`AADSTS50078`), silently breaking every daily backup until someone re-runs the
+**sign-in-frequency** policy invalidated that refresh token roughly monthly
+(`AADSTS50078`), silently breaking every daily backup until someone re-ran the
 device-code login by hand.
 
-This change switches the job to **app-only** Microsoft Graph auth, minted from the
-workflow's existing GitHub-OIDC Azure login. There is **no refresh token, no stored
-secret, and no interactive MFA** — nothing a CA policy can expire. The code is done;
-the steps below are the one-time **tenant-admin** setup (they require Application
-Administrator / Privileged Role Admin + the ability to consent Graph app permissions,
-which is why they aren't automated here).
+The job now uses **app-only** Microsoft Graph auth from a dedicated identity via
+GitHub OIDC. **No refresh token, no stored user credential, no interactive MFA** —
+nothing a Conditional Access policy can expire.
 
-## What the code now expects
-- The workflow mints the token with `az account get-access-token --resource https://graph.microsoft.com`
-  using the **`AZURE_DEPLOY_CLIENT_ID`** identity (the same OIDC SP it already uses for Key Vault).
-- The destination drive comes from a repo/environment **variable** `ONEDRIVE_DRIVE_BASE`
-  (app-only tokens have no `/me`). The run fails fast with a clear message if it's unset.
+## As-built configuration (done 2026-07-08)
+Two GitHub-OIDC identities, split by duty:
 
-## Pick a permission model
-| | Files.ReadWrite.All (drop-in) | **Sites.Selected (recommended)** |
+| Purpose | Identity | Grants |
 |---|---|---|
-| Scope | Tenant-wide read/write to all OneDrive + SharePoint | Write to **only** the one backup library |
-| Where backups live | Keep them in the current user's OneDrive → `ONEDRIVE_DRIVE_BASE=/users/<upn>/drive` | A SharePoint doc library → `ONEDRIVE_DRIVE_BASE=/sites/<site-id>/drive` |
-| Trade-off | No data move; broad grant needs admin comfort | Least privilege; requires the backups to live in SharePoint |
+| Key Vault (FTP creds) | `ffc-admin-kv-writer` (`AZURE_DEPLOY_CLIENT_ID`) | KV Secrets User — unchanged |
+| OneDrive Graph (app-only) | **`ffc-onedrive-backup`** (`0b7ead96-…`, env secret `AZURE_ONEDRIVE_CLIENT_ID`) | **Graph `Files.ReadWrite.All` (application) only** — no subscription, no KV |
 
-## Setup steps
+- **Federated credential** on `ffc-onedrive-backup`: subject
+  `repo:FreeForCharity/FFC-IN-freeforcharity.org:environment:cpanel-apim-deploy`,
+  issuer `https://token.actions.githubusercontent.com`, audience `api://AzureADTokenExchange`.
+- **App-role assignment** grants *only* `Files.ReadWrite.All` (role
+  `75359482-378d-4052-8f01-80520e7db3cd`) on the Microsoft Graph SP — a targeted
+  consent, not a blanket `admin-consent`.
+- **Why `Files.ReadWrite.All` (tenant-wide)?** The backups live in a *personal*
+  OneDrive for Business (`clarkemoyer@freeforcharity.org`), which cannot be scoped
+  with `Sites.Selected`. The broad grant is isolated to this single-purpose app.
+- **Destination pinned, folder unchanged:** repo variable
+  `ONEDRIVE_DRIVE_BASE=/drives/b!f5voUy582UuZMa0-sIt3vd2yDdTEHrVHh5f2iTzm1GJezyqVtgazR4VxjOqVqeiW`
+  — the exact drive used before, so the `/1-Backups/…` folders are untouched.
 
-### 0. Identify the OIDC service principal
-```bash
-# AZURE_DEPLOY_CLIENT_ID is the app (client) id used by the workflow's azure/login.
-# View it (get the value from the repo/environment secret), then:
-az ad sp show --id <AZURE_DEPLOY_CLIENT_ID> --query '{name:displayName, id:id, appId:appId}'
-```
+Validated 2026-07-08 by dispatching the workflow from its branch (dry-run + real
+run both green; lists/retention against the same folders).
 
-### 1a. Option Files.ReadWrite.All
-```bash
-GRAPH=00000003-0000-0000-c000-000000000000
-# Files.ReadWrite.All (application) role id = 75359482-378d-4052-8f01-80520e7db3cd
-az ad app permission add --id <AZURE_DEPLOY_CLIENT_ID> --api $GRAPH \
-  --api-permissions 75359482-378d-4052-8f01-80520e7db3cd=Role
-az ad app permission admin-consent --id <AZURE_DEPLOY_CLIENT_ID>
-# Find the OneDrive owner's user id/upn and set the variable (see step 2).
-```
+## Operating notes
+- **Rotate nothing routinely.** App-only via OIDC has no secret or token to expire.
+  (The FIC and app-role assignment don't lapse.)
+- **Re-verify / re-create** the setup with `az`:
+  ```bash
+  APP=0b7ead96-9c54-470a-be6c-c27db38e3972
+  # app-role assignments (expect Files.ReadWrite.All on Microsoft Graph):
+  sp=$(az ad sp show --id $APP --query id -o tsv)
+  az rest --method GET --url "https://graph.microsoft.com/v1.0/servicePrincipals/$sp/appRoleAssignments"
+  # federated credentials:
+  az ad app federated-credential list --id $APP --query "[].subject"
+  ```
+- **⚠️ Setting `ONEDRIVE_DRIVE_BASE` from Windows Git-Bash** mangles the leading
+  `/drives/...` into `C:/Program Files/Git/drives/...` (MSYS path conversion). Set it
+  with `MSYS_NO_PATHCONV=1 gh variable set …` or from a non-MSYS shell.
+- **Freshness** monitor (`cpanel-backup-freshness.yml`) remains the safety net.
 
-### 1b. Option Sites.Selected  ⭐
-```bash
-GRAPH=00000003-0000-0000-c000-000000000000
-# Sites.Selected (application) role id = 883ea226-0bf2-4a8f-9f9d-92c9162a727d
-az ad app permission add --id <AZURE_DEPLOY_CLIENT_ID> --api $GRAPH \
-  --api-permissions 883ea226-0bf2-4a8f-9f9d-92c9162a727d=Role
-az ad app permission admin-consent --id <AZURE_DEPLOY_CLIENT_ID>
-
-# Grant write to ONLY the backup site (needs a Graph token with Sites.FullControl.All,
-# e.g. run as an admin). site-id: GET /sites/<host>:/sites/<path>
-#   POST https://graph.microsoft.com/v1.0/sites/<site-id>/permissions
-#   { "roles": ["write"],
-#     "grantedToIdentities": [ { "application": { "id": "<AZURE_DEPLOY_CLIENT_ID>", "displayName": "ffc-cpanel-deploy" } } ] }
-```
-
-### 2. Set the destination variable
-```bash
-# Repo-level (or scope to the cpanel-apim-deploy environment):
-gh variable set ONEDRIVE_DRIVE_BASE --repo FreeForCharity/FFC-IN-freeforcharity.org \
-  --body "/users/<upn-or-id>/drive"        # Files.ReadWrite.All
-# or
-gh variable set ONEDRIVE_DRIVE_BASE --repo FreeForCharity/FFC-IN-freeforcharity.org \
-  --body "/sites/<site-id>/drive"          # Sites.Selected
-```
-Make sure the `DEST` folder paths in `scripts/onedrive_backup_sync.py` exist under that drive
-(they're the same `/1-Backups/...` paths used today — move/recreate them if you switch drives).
-
-### 3. Test, then cut over
-```bash
-# Dry run first (lists actions, no writes):
-gh workflow run cpanel-softaculous-backup-sync.yml --repo FreeForCharity/FFC-IN-freeforcharity.org -f dry_run=true
-# Then a real run; confirm it uploads and the freshness monitor stays green.
-gh workflow run cpanel-softaculous-backup-sync.yml --repo FreeForCharity/FFC-IN-freeforcharity.org
-```
-
-### 4. Clean up (after a successful real run)
-- Delete the now-unused Key Vault secret `wr-all-ffc-onedrive-backup-refresh-token`
-  (and optionally `read-all-ffc-onedrive-backup-{client-id,tenant-id}`).
-- Retire the delegated app registration `ffc-onedrive-backup` (`0b7ead96-…`).
-- No more monthly device-code re-auth. 🎉
+## Retiring the old delegated path (optional cleanup — now safe)
+The app-only path is live and validated, so the delegated fallback can go:
+- Delete Key Vault secret `wr-all-ffc-onedrive-backup-refresh-token` (and
+  `read-all-ffc-onedrive-backup-{client-id,tenant-id}` if unused elsewhere).
+- Remove the delegated Graph scopes from `ffc-onedrive-backup` (keep the app — it now
+  carries the application permission). No more monthly device-code re-auth. 🎉

--- a/docs/onedrive-backup-app-only-auth.md
+++ b/docs/onedrive-backup-app-only-auth.md
@@ -1,6 +1,7 @@
 # OneDrive backup — app-only (unattended) auth
 
 ## Why
+
 `cpanel-softaculous-backup-sync.yml` used to authenticate to OneDrive as a **user**
 (delegated device-code flow → refresh token in Key Vault). A Conditional Access
 **sign-in-frequency** policy invalidated that refresh token roughly monthly
@@ -12,20 +13,21 @@ GitHub OIDC. **No refresh token, no stored user credential, no interactive MFA**
 nothing a Conditional Access policy can expire.
 
 ## As-built configuration (done 2026-07-08)
+
 Two GitHub-OIDC identities, split by duty:
 
-| Purpose | Identity | Grants |
-|---|---|---|
-| Key Vault (FTP creds) | `ffc-admin-kv-writer` (`AZURE_DEPLOY_CLIENT_ID`) | KV Secrets User — unchanged |
+| Purpose                   | Identity                                                                        | Grants                                                                      |
+| ------------------------- | ------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| Key Vault (FTP creds)     | `ffc-admin-kv-writer` (`AZURE_DEPLOY_CLIENT_ID`)                                | KV Secrets User — unchanged                                                 |
 | OneDrive Graph (app-only) | **`ffc-onedrive-backup`** (`0b7ead96-…`, env secret `AZURE_ONEDRIVE_CLIENT_ID`) | **Graph `Files.ReadWrite.All` (application) only** — no subscription, no KV |
 
 - **Federated credential** on `ffc-onedrive-backup`: subject
   `repo:FreeForCharity/FFC-IN-freeforcharity.org:environment:cpanel-apim-deploy`,
   issuer `https://token.actions.githubusercontent.com`, audience `api://AzureADTokenExchange`.
-- **App-role assignment** grants *only* `Files.ReadWrite.All` (role
+- **App-role assignment** grants _only_ `Files.ReadWrite.All` (role
   `75359482-378d-4052-8f01-80520e7db3cd`) on the Microsoft Graph SP — a targeted
   consent, not a blanket `admin-consent`.
-- **Why `Files.ReadWrite.All` (tenant-wide)?** The backups live in a *personal*
+- **Why `Files.ReadWrite.All` (tenant-wide)?** The backups live in a _personal_
   OneDrive for Business (`clarkemoyer@freeforcharity.org`), which cannot be scoped
   with `Sites.Selected`. The broad grant is isolated to this single-purpose app.
 - **Destination pinned, folder unchanged:** repo variable
@@ -36,6 +38,7 @@ Validated 2026-07-08 by dispatching the workflow from its branch (dry-run + real
 run both green; lists/retention against the same folders).
 
 ## Operating notes
+
 - **Rotate nothing routinely.** App-only via OIDC has no secret or token to expire.
   (The FIC and app-role assignment don't lapse.)
 - **Re-verify / re-create** the setup with `az`:
@@ -53,7 +56,9 @@ run both green; lists/retention against the same folders).
 - **Freshness** monitor (`cpanel-backup-freshness.yml`) remains the safety net.
 
 ## Retiring the old delegated path (optional cleanup — now safe)
+
 The app-only path is live and validated, so the delegated fallback can go:
+
 - Delete Key Vault secret `wr-all-ffc-onedrive-backup-refresh-token` (and
   `read-all-ffc-onedrive-backup-{client-id,tenant-id}` if unused elsewhere).
 - Remove the delegated Graph scopes from `ffc-onedrive-backup` (keep the app — it now

--- a/docs/onedrive-backup-app-only-auth.md
+++ b/docs/onedrive-backup-app-only-auth.md
@@ -16,23 +16,27 @@ nothing a Conditional Access policy can expire.
 
 Two GitHub-OIDC identities, split by duty:
 
-| Purpose                   | Identity                                                                        | Grants                                                                      |
-| ------------------------- | ------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
-| Key Vault (FTP creds)     | `ffc-admin-kv-writer` (`AZURE_DEPLOY_CLIENT_ID`)                                | KV Secrets User — unchanged                                                 |
-| OneDrive Graph (app-only) | **`ffc-onedrive-backup`** (`0b7ead96-…`, env secret `AZURE_ONEDRIVE_CLIENT_ID`) | **Graph `Files.ReadWrite.All` (application) only** — no subscription, no KV |
+| Purpose                   | Identity                                                          | Grants                                                                      |
+| ------------------------- | ----------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| Key Vault (FTP creds)     | `ffc-admin-kv-writer` (env secret `AZURE_DEPLOY_CLIENT_ID`)       | KV Secrets User — unchanged                                                 |
+| OneDrive Graph (app-only) | **`ffc-onedrive-backup`** (env secret `AZURE_ONEDRIVE_CLIENT_ID`) | **Graph `Files.ReadWrite.All` (application) only** — no subscription, no KV |
+
+The concrete client-id, drive-id, and account are not repeated here (this repo is
+public) — they live in the GitHub env secret `AZURE_ONEDRIVE_CLIENT_ID` and the
+variable `ONEDRIVE_DRIVE_BASE`.
 
 - **Federated credential** on `ffc-onedrive-backup`: subject
   `repo:FreeForCharity/FFC-IN-freeforcharity.org:environment:cpanel-apim-deploy`,
   issuer `https://token.actions.githubusercontent.com`, audience `api://AzureADTokenExchange`.
-- **App-role assignment** grants _only_ `Files.ReadWrite.All` (role
+- **App-role assignment** grants _only_ `Files.ReadWrite.All` (well-known Graph role
   `75359482-378d-4052-8f01-80520e7db3cd`) on the Microsoft Graph SP — a targeted
   consent, not a blanket `admin-consent`.
 - **Why `Files.ReadWrite.All` (tenant-wide)?** The backups live in a _personal_
-  OneDrive for Business (`clarkemoyer@freeforcharity.org`), which cannot be scoped
-  with `Sites.Selected`. The broad grant is isolated to this single-purpose app.
-- **Destination pinned, folder unchanged:** repo variable
-  `ONEDRIVE_DRIVE_BASE=/drives/b!f5voUy582UuZMa0-sIt3vd2yDdTEHrVHh5f2iTzm1GJezyqVtgazR4VxjOqVqeiW`
-  — the exact drive used before, so the `/1-Backups/…` folders are untouched.
+  OneDrive for Business, which cannot be scoped with `Sites.Selected`. The broad
+  grant is isolated to this single-purpose app.
+- **Destination pinned, folder unchanged:** the variable `ONEDRIVE_DRIVE_BASE` holds
+  `/drives/<drive-id>` for the exact drive used before, so the `/1-Backups/…` folders
+  are untouched.
 
 Validated 2026-07-08 by dispatching the workflow from its branch (dry-run + real
 run both green; lists/retention against the same folders).
@@ -43,7 +47,7 @@ run both green; lists/retention against the same folders).
   (The FIC and app-role assignment don't lapse.)
 - **Re-verify / re-create** the setup with `az`:
   ```bash
-  APP=0b7ead96-9c54-470a-be6c-c27db38e3972
+  APP=<value of env secret AZURE_ONEDRIVE_CLIENT_ID>
   # app-role assignments (expect Files.ReadWrite.All on Microsoft Graph):
   sp=$(az ad sp show --id $APP --query id -o tsv)
   az rest --method GET --url "https://graph.microsoft.com/v1.0/servicePrincipals/$sp/appRoleAssignments"

--- a/docs/onedrive-backup-app-only-auth.md
+++ b/docs/onedrive-backup-app-only-auth.md
@@ -1,0 +1,88 @@
+# OneDrive backup — app-only (unattended) auth
+
+## Why
+`cpanel-softaculous-backup-sync.yml` used to authenticate to OneDrive as a **user**
+(delegated device-code flow → refresh token in Key Vault). A Conditional Access
+**sign-in-frequency** policy invalidates that refresh token roughly monthly
+(`AADSTS50078`), silently breaking every daily backup until someone re-runs the
+device-code login by hand.
+
+This change switches the job to **app-only** Microsoft Graph auth, minted from the
+workflow's existing GitHub-OIDC Azure login. There is **no refresh token, no stored
+secret, and no interactive MFA** — nothing a CA policy can expire. The code is done;
+the steps below are the one-time **tenant-admin** setup (they require Application
+Administrator / Privileged Role Admin + the ability to consent Graph app permissions,
+which is why they aren't automated here).
+
+## What the code now expects
+- The workflow mints the token with `az account get-access-token --resource https://graph.microsoft.com`
+  using the **`AZURE_DEPLOY_CLIENT_ID`** identity (the same OIDC SP it already uses for Key Vault).
+- The destination drive comes from a repo/environment **variable** `ONEDRIVE_DRIVE_BASE`
+  (app-only tokens have no `/me`). The run fails fast with a clear message if it's unset.
+
+## Pick a permission model
+| | Files.ReadWrite.All (drop-in) | **Sites.Selected (recommended)** |
+|---|---|---|
+| Scope | Tenant-wide read/write to all OneDrive + SharePoint | Write to **only** the one backup library |
+| Where backups live | Keep them in the current user's OneDrive → `ONEDRIVE_DRIVE_BASE=/users/<upn>/drive` | A SharePoint doc library → `ONEDRIVE_DRIVE_BASE=/sites/<site-id>/drive` |
+| Trade-off | No data move; broad grant needs admin comfort | Least privilege; requires the backups to live in SharePoint |
+
+## Setup steps
+
+### 0. Identify the OIDC service principal
+```bash
+# AZURE_DEPLOY_CLIENT_ID is the app (client) id used by the workflow's azure/login.
+# View it (get the value from the repo/environment secret), then:
+az ad sp show --id <AZURE_DEPLOY_CLIENT_ID> --query '{name:displayName, id:id, appId:appId}'
+```
+
+### 1a. Option Files.ReadWrite.All
+```bash
+GRAPH=00000003-0000-0000-c000-000000000000
+# Files.ReadWrite.All (application) role id = 75359482-378d-4052-8f01-80520e7db3cd
+az ad app permission add --id <AZURE_DEPLOY_CLIENT_ID> --api $GRAPH \
+  --api-permissions 75359482-378d-4052-8f01-80520e7db3cd=Role
+az ad app permission admin-consent --id <AZURE_DEPLOY_CLIENT_ID>
+# Find the OneDrive owner's user id/upn and set the variable (see step 2).
+```
+
+### 1b. Option Sites.Selected  ⭐
+```bash
+GRAPH=00000003-0000-0000-c000-000000000000
+# Sites.Selected (application) role id = 883ea226-0bf2-4a8f-9f9d-92c9162a727d
+az ad app permission add --id <AZURE_DEPLOY_CLIENT_ID> --api $GRAPH \
+  --api-permissions 883ea226-0bf2-4a8f-9f9d-92c9162a727d=Role
+az ad app permission admin-consent --id <AZURE_DEPLOY_CLIENT_ID>
+
+# Grant write to ONLY the backup site (needs a Graph token with Sites.FullControl.All,
+# e.g. run as an admin). site-id: GET /sites/<host>:/sites/<path>
+#   POST https://graph.microsoft.com/v1.0/sites/<site-id>/permissions
+#   { "roles": ["write"],
+#     "grantedToIdentities": [ { "application": { "id": "<AZURE_DEPLOY_CLIENT_ID>", "displayName": "ffc-cpanel-deploy" } } ] }
+```
+
+### 2. Set the destination variable
+```bash
+# Repo-level (or scope to the cpanel-apim-deploy environment):
+gh variable set ONEDRIVE_DRIVE_BASE --repo FreeForCharity/FFC-IN-freeforcharity.org \
+  --body "/users/<upn-or-id>/drive"        # Files.ReadWrite.All
+# or
+gh variable set ONEDRIVE_DRIVE_BASE --repo FreeForCharity/FFC-IN-freeforcharity.org \
+  --body "/sites/<site-id>/drive"          # Sites.Selected
+```
+Make sure the `DEST` folder paths in `scripts/onedrive_backup_sync.py` exist under that drive
+(they're the same `/1-Backups/...` paths used today — move/recreate them if you switch drives).
+
+### 3. Test, then cut over
+```bash
+# Dry run first (lists actions, no writes):
+gh workflow run cpanel-softaculous-backup-sync.yml --repo FreeForCharity/FFC-IN-freeforcharity.org -f dry_run=true
+# Then a real run; confirm it uploads and the freshness monitor stays green.
+gh workflow run cpanel-softaculous-backup-sync.yml --repo FreeForCharity/FFC-IN-freeforcharity.org
+```
+
+### 4. Clean up (after a successful real run)
+- Delete the now-unused Key Vault secret `wr-all-ffc-onedrive-backup-refresh-token`
+  (and optionally `read-all-ffc-onedrive-backup-{client-id,tenant-id}`).
+- Retire the delegated app registration `ffc-onedrive-backup` (`0b7ead96-…`).
+- No more monthly device-code re-auth. 🎉

--- a/scripts/onedrive_backup_sync.py
+++ b/scripts/onedrive_backup_sync.py
@@ -12,13 +12,19 @@ the matching OneDrive folder via Microsoft Graph, then prunes OneDrive to:
 
 Stdlib only (no pip installs). Auth/secrets come from the environment:
 
-  GRAPH_TOKEN   Microsoft Graph access token (delegated Files.ReadWrite.All)
+  GRAPH_TOKEN   Microsoft Graph access token. Either a delegated token
+                (Files.ReadWrite.All) or an app-only token (Files.ReadWrite.All
+                or Sites.Selected). App-only is preferred — it never expires
+                interactively and needs no refresh token.
   FTP_HOST      cPanel FTPS host
   FTP_USER      cPanel FTP username
   FTP_PASS      cPanel FTP password
   FTP_PORT      (optional, default 21)
 
 Config has sensible defaults for this account; override via env if needed:
+  DRIVE_BASE    Graph drive path prefix. Delegated tokens may use the default
+                "/me/drive"; app-only tokens MUST set an explicit drive, e.g.
+                "/users/{user-id-or-upn}/drive" or "/sites/{site-id}/drive".
   SOFTA_DIR     remote dir (default /softaculous_backups, relative to FTP home)
   DRY_RUN       "1" to log actions without uploading/deleting
 """
@@ -27,6 +33,11 @@ import urllib.request, urllib.error, urllib.parse
 
 GRAPH = "https://graph.microsoft.com/v1.0"
 TOKEN = os.environ["GRAPH_TOKEN"]
+# Drive to target, as a Graph path prefix. Delegated (user) tokens can use the
+# default "/me/drive". App-only tokens have no "me", so DRIVE_BASE must name an
+# explicit drive, e.g. "/users/{user-id-or-upn}/drive", "/drives/{drive-id}", or
+# "/sites/{site-id}/drive". Set it in the workflow when using app-only auth.
+DRIVE = os.environ.get("DRIVE_BASE", "/me/drive").rstrip("/")
 DRY_RUN = os.environ.get("DRY_RUN") == "1"
 SOFTA_DIR = os.environ.get("SOFTA_DIR", "/softaculous_backups")
 
@@ -102,7 +113,7 @@ def graph(method, path, data=None, headers=None, raw_url=None):
 
 def list_children(folder):
     """Return {name: item} for a OneDrive folder (drive-root relative path)."""
-    items, url = {}, GRAPH + "/me/drive/root:" + urllib.parse.quote(folder) + ":/children?$select=name,id,size&$top=200"
+    items, url = {}, GRAPH + DRIVE + "/root:" + urllib.parse.quote(folder) + ":/children?$select=name,id,size&$top=200"
     while url:
         st, d = graph("GET", None, raw_url=url)
         if st == 404:
@@ -120,7 +131,7 @@ def upload_large(local_path, folder, name):
     item_path = urllib.parse.quote(folder + "/" + name)
     st, sess = graph(
         "POST",
-        "/me/drive/root:" + item_path + ":/createUploadSession",
+        DRIVE + "/root:" + item_path + ":/createUploadSession",
         {"item": {"@microsoft.graph.conflictBehavior": "replace"}},
     )
     if st >= 400:
@@ -165,7 +176,7 @@ def delete_item(item_id, name):
     if DRY_RUN:
         log(f"    [dry-run] would delete {name}")
         return
-    st, d = graph("DELETE", "/me/drive/items/" + item_id)
+    st, d = graph("DELETE", DRIVE + "/items/" + item_id)
     if st not in (200, 204):
         log(f"    WARN delete {name}: {st} {d}")
     else:

--- a/scripts/onedrive_backup_sync.py
+++ b/scripts/onedrive_backup_sync.py
@@ -37,7 +37,12 @@ TOKEN = os.environ["GRAPH_TOKEN"]
 # default "/me/drive". App-only tokens have no "me", so DRIVE_BASE must name an
 # explicit drive, e.g. "/users/{user-id-or-upn}/drive", "/drives/{drive-id}", or
 # "/sites/{site-id}/drive". Set it in the workflow when using app-only auth.
-DRIVE = os.environ.get("DRIVE_BASE", "/me/drive").rstrip("/")
+# Normalize to exactly one leading slash and no trailing slash, so a value set
+# without the leading "/" (e.g. "drives/<id>") can't build URLs like ".../v1.0drives".
+DRIVE = "/" + os.environ.get("DRIVE_BASE", "/me/drive").strip().strip("/")
+if DRIVE == "/":
+    raise SystemExit("DRIVE_BASE is empty; set it to e.g. /drives/<id> or /users/<upn>/drive")
+DRY_RUN = os.environ.get("DRY_RUN") == "1"
 DRY_RUN = os.environ.get("DRY_RUN") == "1"
 SOFTA_DIR = os.environ.get("SOFTA_DIR", "/softaculous_backups")
 

--- a/scripts/onedrive_backup_sync.py
+++ b/scripts/onedrive_backup_sync.py
@@ -24,7 +24,8 @@ Stdlib only (no pip installs). Auth/secrets come from the environment:
 Config has sensible defaults for this account; override via env if needed:
   DRIVE_BASE    Graph drive path prefix. Delegated tokens may use the default
                 "/me/drive"; app-only tokens MUST set an explicit drive, e.g.
-                "/users/{user-id-or-upn}/drive" or "/sites/{site-id}/drive".
+                "/drives/{drive-id}", "/users/{user-id-or-upn}/drive", or
+                "/sites/{site-id}/drive".
   SOFTA_DIR     remote dir (default /softaculous_backups, relative to FTP home)
   DRY_RUN       "1" to log actions without uploading/deleting
 """
@@ -42,7 +43,6 @@ TOKEN = os.environ["GRAPH_TOKEN"]
 DRIVE = "/" + os.environ.get("DRIVE_BASE", "/me/drive").strip().strip("/")
 if DRIVE == "/":
     raise SystemExit("DRIVE_BASE is empty; set it to e.g. /drives/<id> or /users/<upn>/drive")
-DRY_RUN = os.environ.get("DRY_RUN") == "1"
 DRY_RUN = os.environ.get("DRY_RUN") == "1"
 SOFTA_DIR = os.environ.get("SOFTA_DIR", "/softaculous_backups")
 


### PR DESCRIPTION
## Why
The cPanel→OneDrive backup authenticated as a **user** (delegated device-code → refresh token in Key Vault). A Conditional Access **sign-in-frequency** policy invalidates that token ~monthly (`AADSTS50078`), silently breaking every daily backup until someone re-does the device-code login by hand (most recently 2026-07-08, after ~11 days stale).

This moves the job to **app-only** Microsoft Graph auth minted from the workflow's existing GitHub-OIDC Azure login. **No refresh token, no stored secret, no interactive MFA** — nothing a CA policy can expire.

## Code changes (this PR)
- **workflow**: replace the delegated refresh-token grant with `az account get-access-token --resource https://graph.microsoft.com` off the existing OIDC identity; drop the KV refresh-token read + best-effort writeback; add `ONEDRIVE_DRIVE_BASE` (fails fast if unset).
- **script**: the 3 hard-coded `/me/drive` paths become `DRIVE_BASE` (app-only tokens have no `/me`). Default stays `/me/drive` for backward compat.
- **docs/onedrive-backup-app-only-auth.md**: the one-time tenant-admin runbook.

## ⚠️ Requires one-time admin setup before it will run (see the runbook)
These need Application Admin + Graph app-permission consent, so they're **not** automated:
1. Grant the OIDC SP (`AZURE_DEPLOY_CLIENT_ID`) a Graph **application** permission — **`Sites.Selected`** (recommended, least privilege) or `Files.ReadWrite.All` (drop-in) — with admin consent.
2. If `Sites.Selected`: grant the app `write` on the specific backup library.
3. Set the `ONEDRIVE_DRIVE_BASE` variable (`/sites/<id>/drive` or `/users/<upn>/drive`).
4. Dispatch with `dry_run=true`, then a real run; confirm the freshness monitor stays green.
5. Clean up: delete KV `wr-all-ffc-onedrive-backup-refresh-token` and retire the `ffc-onedrive-backup` app.

**Decision for you:** `Sites.Selected` (tightest, but backups must live in a SharePoint library) vs `Files.ReadWrite.All` (keeps backups in the current OneDrive, broader grant). I defaulted the code to work with either — you just set the variable.

## Test plan
- [ ] Admin setup per runbook.
- [ ] `dry_run=true` dispatch lists actions with no errors.
- [ ] Real dispatch uploads; freshness monitor `✅ healthy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)