### PR TITLE
feat: sync onboarding pages to new WHMCS charity journey

### DIFF
--- a/__tests__/app/charity-onboarding-journey.test.tsx
+++ b/__tests__/app/charity-onboarding-journey.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import CharityOnboardingJourney from '@/app/charity-onboarding-journey/page'
+
+describe('Charity Onboarding Journey page', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<CharityOnboardingJourney />)
+    expect(container).not.toBeEmptyDOMElement()
+  })
+
+  it('orders the Website stage before the Email stage', () => {
+    const { container } = render(<CharityOnboardingJourney />)
+    const text = container.textContent || ''
+    const websiteIndex = text.indexOf('3. Website')
+    const emailIndex = text.indexOf('4. Email')
+
+    expect(websiteIndex).toBeGreaterThan(-1)
+    expect(emailIndex).toBeGreaterThan(-1)
+    expect(websiteIndex).toBeLessThan(emailIndex)
+  })
+
+  it('numbers the stages 1 through 5 in the corrected order', () => {
+    const { container } = render(<CharityOnboardingJourney />)
+    const text = container.textContent || ''
+
+    expect(text).toContain('1. Application & validation')
+    expect(text).toContain('2. Domain')
+    expect(text).toContain('3. Website')
+    expect(text).toContain('4. Email')
+    expect(text).toContain('5. Handoff & ongoing support')
+  })
+
+  it('offers both Microsoft 365 and Google Workspace as email options', () => {
+    const { container } = render(<CharityOnboardingJourney />)
+    const text = container.textContent || ''
+
+    expect(text).toContain('Microsoft 365')
+    expect(text).toContain('Google Workspace')
+  })
+
+  it('explains that nonprofit email programs require a live website first', () => {
+    const { container } = render(<CharityOnboardingJourney />)
+    const text = container.textContent || ''
+
+    expect(text).toMatch(/require a live website/i)
+  })
+
+  it('links both the Microsoft 365 and Google for Nonprofits guides', () => {
+    const { container } = render(<CharityOnboardingJourney />)
+    const hrefs = Array.from(container.querySelectorAll('a')).map(
+      (a) => a.getAttribute('href') ?? ''
+    )
+
+    expect(hrefs.some((h) => h.includes('/m365-email-guide'))).toBe(true)
+    expect(hrefs.some((h) => h.includes('/google-for-nonprofits-guide'))).toBe(true)
+  })
+})

--- a/__tests__/components/501c3-components/ready-to-get-started-and-faqs.test.tsx
+++ b/__tests__/components/501c3-components/ready-to-get-started-and-faqs.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import ReadyToGetStartedAndFaqs from '@/components/501c3-components/Ready-to-get-started-and-faqs/index'
+
+// Mock the assetPath helper (GitHub Pages base-path helper) so asset URLs
+// resolve to plain paths in the test environment.
+jest.mock('@/lib/assetPath', () => ({
+  assetPath: (path: string) => path,
+}))
+
+describe('501c3-components/Ready-to-get-started-and-faqs', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<ReadyToGetStartedAndFaqs />)
+    expect(container).toBeInTheDocument()
+  })
+
+  it('no longer references the retired InterServer/Softaculous hosting model', () => {
+    const { container } = render(<ReadyToGetStartedAndFaqs />)
+    expect(container.textContent).not.toMatch(/InterServer/i)
+    expect(container.textContent).not.toMatch(/Softaculous/i)
+  })
+
+  it('describes the website as a GitHub Pages static site', () => {
+    const { container } = render(<ReadyToGetStartedAndFaqs />)
+    expect(container.textContent).toContain('GitHub Pages')
+  })
+
+  it('offers both Microsoft 365 and Google Workspace for email', () => {
+    const { container } = render(<ReadyToGetStartedAndFaqs />)
+    expect(container.textContent).toContain('Microsoft 365')
+    expect(container.textContent).toContain('Google Workspace')
+  })
+})

--- a/__tests__/components/domains/onboarding-sync.test.tsx
+++ b/__tests__/components/domains/onboarding-sync.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import VerifyYourDomain from '@/components/domains/Verify-Your-Domain/index'
+import SetupEmailHosting from '@/components/domains/Setup-Email-Hosting/index'
+import GetNewWebsite from '@/components/domains/Get-New-Website/index'
+import OrderYourDomain from '@/components/domains/Order-Your-Domain/index'
+
+// Mock the assetPath helper (matches other component tests)
+jest.mock('@/lib/assetPath', () => ({
+  assetPath: (path: string) => path,
+}))
+
+describe('Onboarding journey sync (Cloudflare / GitHub Pages / M365 + Google)', () => {
+  describe('Verify-Your-Domain', () => {
+    it('no longer references ICANN or SUSPENSION and now points to Cloudflare', () => {
+      const { container } = render(<VerifyYourDomain />)
+      const text = container.textContent ?? ''
+      expect(text).not.toMatch(/ICANN/i)
+      expect(text).not.toMatch(/SUSPENSION/i)
+      expect(text).toMatch(/Cloudflare/i)
+    })
+  })
+
+  describe('Setup-Email-Hosting', () => {
+    it('offers both Microsoft 365 and Google Workspace', () => {
+      const { container } = render(<SetupEmailHosting />)
+      const text = container.textContent ?? ''
+      expect(text).toMatch(/Microsoft 365/i)
+      expect(text).toMatch(/Google Workspace/i)
+    })
+  })
+
+  describe('Get-New-Website', () => {
+    it('describes the GitHub Pages model, not the WordPress plugins/themes model', () => {
+      const { container } = render(<GetNewWebsite />)
+      const text = container.textContent ?? ''
+      expect(text).toMatch(/GitHub Pages/i)
+      expect(text).not.toMatch(/plugins, and themes/i)
+    })
+  })
+
+  describe('Order-Your-Domain', () => {
+    it('presents transfer as a supported option', () => {
+      render(<OrderYourDomain />)
+      const matches = screen.getAllByText(/transfer/i)
+      expect(matches.length).toBeGreaterThan(0)
+    })
+  })
+})

--- a/__tests__/components/free-charity-web-hosting/faqs-onboarding-sync.test.tsx
+++ b/__tests__/components/free-charity-web-hosting/faqs-onboarding-sync.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import FAQs from '@/components/free-charity-web-hosting/FAQs/index'
+
+describe('Free Charity Web Hosting FAQs — onboarding model sync', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<FAQs />)
+    expect(container).not.toBeEmptyDOMElement()
+  })
+
+  it('no longer references the legacy eNom reseller model', () => {
+    const { container } = render(<FAQs />)
+    expect(container.textContent || '').not.toMatch(/eNom/i)
+  })
+
+  it('describes domains as managed at Cloudflare', () => {
+    const { container } = render(<FAQs />)
+    expect(container.textContent || '').toContain('Cloudflare')
+  })
+})

--- a/__tests__/components/help-for-charities-components/ready-to-get-started-now.test.tsx
+++ b/__tests__/components/help-for-charities-components/ready-to-get-started-now.test.tsx
@@ -1,0 +1,30 @@
+/**
+ * Ready-to-Get-Started-Now — the shared 501(c)(3)/pre-501(c)(3) onboarding CTA.
+ *
+ * Refs FFC-IN-freeforcharity.org#452: the CTAs must deep-link to the WHMCS
+ * onboarding products by stable id (a=add&pid=) rather than the fragile
+ * cart-index (a=confproduct&i=) that shifts when the catalog is reordered.
+ * pre-501c3 → pid 16, full 501c3 → pid 33.
+ */
+import { render, screen } from '@testing-library/react'
+import ReadyToGetStarted from '@/components/help-for-charities-components/Ready-to-Get-Started-Now'
+
+describe('Ready-to-Get-Started-Now CTA links', () => {
+  beforeEach(() => render(<ReadyToGetStarted />))
+
+  it('links the 501(c)(3) CTA to onboarding product pid 33 via a=add', () => {
+    const link = screen.getByRole('link', { name: /^501\(c\)3 Charities Click Here/i })
+    expect(link).toHaveAttribute('href', expect.stringContaining('a=add&pid=33'))
+  })
+
+  it('links the pre-501(c)(3) CTA to onboarding product pid 16 via a=add', () => {
+    const link = screen.getByRole('link', { name: /^Pre-501\(c\)3 Charities Click Here/i })
+    expect(link).toHaveAttribute('href', expect.stringContaining('a=add&pid=16'))
+  })
+
+  it('no longer uses the fragile confproduct cart-index links', () => {
+    for (const link of screen.getAllByRole('link')) {
+      expect(link.getAttribute('href') ?? '').not.toContain('confproduct')
+    }
+  })
+})

--- a/__tests__/components/pre501c3-components/onboarding-sync.test.tsx
+++ b/__tests__/components/pre501c3-components/onboarding-sync.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import Charity from '@/components/pre501c3-components/charity'
+import Faqs from '@/components/pre501c3-components/Faqs'
+
+describe('pre-501c3 onboarding journey sync', () => {
+  it('package list uses GitHub Pages, not WordPress', () => {
+    const { container } = render(<Faqs />)
+    expect(container.textContent).not.toMatch(/WordPress/i)
+    expect(container.textContent).toContain('GitHub Pages')
+  })
+
+  it('explains the $1 verification charge waived by an emailed discount code', () => {
+    const { container } = render(<Charity />)
+    expect(container.textContent).toContain('$1')
+    expect(container.textContent).toMatch(/email/i)
+  })
+
+  it('notes charity email via Microsoft 365 or Google Workspace after 501(c)(3) approval', () => {
+    const { container } = render(<Charity />)
+    expect(container.textContent).toContain('Microsoft 365')
+    expect(container.textContent).toContain('Google Workspace')
+  })
+
+  it('never prints a literal coupon code on the page', () => {
+    const { container: charityContainer } = render(<Charity />)
+    const { container: faqsContainer } = render(<Faqs />)
+    expect(charityContainer.textContent).not.toContain('freeforcharity2026')
+    expect(faqsContainer.textContent).not.toContain('freeforcharity2026')
+  })
+})

--- a/__tests__/components/pre501c3-components/onboarding-sync.test.tsx
+++ b/__tests__/components/pre501c3-components/onboarding-sync.test.tsx
@@ -22,10 +22,13 @@ describe('pre-501c3 onboarding journey sync', () => {
     expect(container.textContent).toContain('Google Workspace')
   })
 
-  it('never prints a literal coupon code on the page', () => {
+  it('never prints a coupon code on the page', () => {
+    // Match any freeforcharity<year> coupon pattern so the literal secret
+    // is never committed to the repo (epic #446 hard rule).
+    const couponPattern = /freeforcharity\d{4}/i
     const { container: charityContainer } = render(<Charity />)
     const { container: faqsContainer } = render(<Faqs />)
-    expect(charityContainer.textContent).not.toContain('freeforcharity2026')
-    expect(faqsContainer.textContent).not.toContain('freeforcharity2026')
+    expect(charityContainer.textContent).not.toMatch(couponPattern)
+    expect(faqsContainer.textContent).not.toMatch(couponPattern)
   })
 })

--- a/__tests__/lib/config.test.ts
+++ b/__tests__/lib/config.test.ts
@@ -102,6 +102,34 @@ describe('src/lib/config', () => {
     })
   })
 
+  describe('hubAddProduct()', () => {
+    beforeEach(() => {
+      delete process.env.NEXT_PUBLIC_SITE_ORIGIN
+      reloadModule()
+    })
+
+    it('builds an a=add&pid= URL that targets the product by stable id', () => {
+      expect(mod.hubAddProduct(16)).toBe('https://freeforcharity.org/hub/cart.php?a=add&pid=16')
+      expect(mod.hubAddProduct(33)).toBe('https://freeforcharity.org/hub/cart.php?a=add&pid=33')
+    })
+
+    it('does not use the fragile confproduct index format', () => {
+      expect(mod.hubAddProduct(16)).not.toContain('confproduct')
+    })
+  })
+
+  describe('ONBOARDING_PID', () => {
+    beforeEach(() => {
+      delete process.env.NEXT_PUBLIC_SITE_ORIGIN
+      reloadModule()
+    })
+
+    it('maps each charity type to its WHMCS onboarding product id', () => {
+      expect(mod.ONBOARDING_PID.pre501c3).toBe(16)
+      expect(mod.ONBOARDING_PID.full501c3).toBe(33)
+    })
+  })
+
   describe('hubStore()', () => {
     beforeEach(() => {
       delete process.env.NEXT_PUBLIC_SITE_ORIGIN

--- a/src/app/charity-onboarding-journey/page.tsx
+++ b/src/app/charity-onboarding-journey/page.tsx
@@ -15,7 +15,7 @@ interface Stage {
   you: string
   ffc: string
   duration: string
-  link?: { href: string; label: string }
+  links?: { href: string; label: string }[]
 }
 
 const stages: Stage[] = [
@@ -24,38 +24,43 @@ const stages: Stage[] = [
     you: 'Submit the onboarding form with your EIN, legal name, and what you need. Have your IRS determination letter handy (pre-501c3 orgs: your formation documents).',
     ffc: 'We validate your organization (IRS status, Candid profile) and confirm program fit.',
     duration: 'A few days',
-    link: { href: '/help-for-charities/', label: 'Start here: Help for Charities' },
+    links: [{ href: '/help-for-charities/', label: 'Start here: Help for Charities' }],
   },
   {
     name: '2. Domain',
     you: 'Send us your top three .org name choices — or the details of a domain you already own.',
     ffc: 'We register (and pay for) the best available name, or take over management of your existing domain, and set up DNS and security.',
     duration: 'Same week',
-    link: { href: '/choosing-your-org-domain/', label: 'Guide: choosing your .org domain' },
+    links: [{ href: '/choosing-your-org-domain/', label: 'Guide: choosing your .org domain' }],
   },
   {
-    name: '3. Email',
-    you: 'Register with Microsoft for Nonprofits and tell us when the DNS verification codes appear.',
-    ffc: 'We add the DNS records so your free Microsoft 365 mailboxes go live, and confirm MFA is on.',
-    duration: '2–5 business days (Microsoft validation)',
-    link: { href: '/m365-email-guide/', label: 'Guide: free Microsoft 365 email' },
-  },
-  {
-    name: '4. Website',
+    name: '3. Website',
     you: 'Send your logo, photos, mission text, and program descriptions. A one-page outline is enough — we help with the rest.',
     ffc: 'A volunteer builds your site from the FFC template (fast, secure static hosting), reviews it with you, and launches it at your domain.',
     duration: '2–6 weeks, mostly depending on content readiness',
-    link: {
-      href: '/free-for-charity-ffc-service-delivery-stages/',
-      label: 'How FFC delivers services',
-    },
+    links: [
+      {
+        href: '/free-for-charity-ffc-service-delivery-stages/',
+        label: 'How FFC delivers services',
+      },
+    ],
+  },
+  {
+    name: '4. Email',
+    you: 'Choose Microsoft 365 or Google Workspace, then register with Microsoft for Nonprofits or Google for Nonprofits and tell us when the DNS verification codes appear. Both nonprofit email programs require a live website before they approve your 501(c)(3) — which is exactly why your website comes first.',
+    ffc: 'We add the DNS records so your free Microsoft 365 or Google Workspace mailboxes go live, and confirm MFA is on.',
+    duration: '2–5 business days (Microsoft or Google validation)',
+    links: [
+      { href: '/m365-email-guide/', label: 'Guide: free Microsoft 365 email' },
+      { href: '/google-for-nonprofits-guide/', label: 'Guide: free Google Workspace email' },
+    ],
   },
   {
     name: '5. Handoff & ongoing support',
     you: 'Learn where to send changes and questions; add the trust-builders (Candid seal, donation form) when ready.',
     ffc: 'We keep the domain renewed, DNS secure, and hosting healthy — and stay reachable for changes and fixes.',
     duration: 'Ongoing',
-    link: { href: '/guides/', label: 'All guides' },
+    links: [{ href: '/guides/', label: 'All guides' }],
   },
 ]
 
@@ -96,16 +101,16 @@ export default function CharityOnboardingJourney() {
                   <dd className="inline">{stage.duration}</dd>
                 </div>
               </dl>
-              {stage.link ? (
-                <p className="mt-3">
+              {stage.links?.map((link) => (
+                <p key={link.href} className="mt-3">
                   <Link
-                    href={stage.link.href}
+                    href={link.href}
                     className="font-[var(--font-lato)] text-[16px] text-[#0567B1] underline"
                   >
-                    {stage.link.label} →
+                    {link.label} →
                   </Link>
                 </p>
-              ) : null}
+              ))}
             </li>
           ))}
         </ol>

--- a/src/components/501c3-components/Ready-to-get-started-and-faqs/index.tsx
+++ b/src/components/501c3-components/Ready-to-get-started-and-faqs/index.tsx
@@ -6,10 +6,7 @@ const index = () => {
     <div className="w-full max-w-[100%]">
       <div className="w-full max-w-[90%] mx-auto">
         <ReadyToGetStarted />
-        <AccordionItem
-          number="3"
-          title=" Free For Charity Domain Name and Microsoft 365 Email Hosting Request"
-        >
+        <AccordionItem number="3" title=" Free For Charity Domain Name and Email Hosting Request">
           <p className="pb-[1em]">
             Free For Charity Provides free .org domain names to US 501c3 organizations. Once your
             onboarding forms are accepted you will receive an email from the system with the
@@ -27,6 +24,10 @@ const index = () => {
             Once we have the domain name under management we can then set up your professional email
             addresses e.g. board@yourcharityname.org
           </p>
+          <p className="pb-[1em]">
+            Professional email can be set up with Microsoft 365 or Google Workspace, both free for
+            eligible 501(c)(3) nonprofits.
+          </p>
           <h1 className="font-[700]">
             As always if you run into problems contact us at anytime{' '}
             <a href="mailto:clarkemoyer@freeforcharity.org" className="text-[#0567B1]">
@@ -35,146 +36,33 @@ const index = () => {
             <a href="tel:+15202228104">520-222-8104</a>
           </h1>
         </AccordionItem>
-        <AccordionItem number="4" title="InterServer Nonprofit Hosting Request">
+        <AccordionItem number="4" title="Your Website (GitHub Pages)">
           <div className="space-y-6 font-[500] text-[#666]">
             {/* Intro Paragraph */}
             <p className="pb-4 leading-relaxed">
-              A very small number of hosting providers provide free hosting for nonprofits. We
-              recommend InterServer, and use them for our own site to host the core WordPress files
-              for your website. Below are instructions for how to get free hosting from InterServer
-              and set it up so that we can help manage your site. Once we have access to your
-              hosting and website we can then add in the extra WPMUDEV and DIVI capabilities to
-              either create a totally new site or update your current site.
+              Once your domain name is set up, a Free For Charity volunteer builds your website from
+              the FFC template as a fast, secure GitHub Pages static site and launches it on your
+              Cloudflare-managed domain. There is no server to maintain and nothing for you to
+              install.
             </p>
 
-            {/* Section 1: Get Free Hosting */}
-            <div>
-              <ol className="list-decimal list-outside pl-5">
-                <li>
-                  Visit{' '}
-                  <a
-                    href="https://my.interserver.net/login.php"
-                    className="text-[#0567B1] underline"
-                  >
-                    https://my.interserver.net
-                  </a>{' '}
-                  to create a free account with your organizational email address{' '}
-                  <span className="">accounts@yourcharityname.org</span>
-                </li>
-
-                <li>
-                  Send an email to{' '}
-                  <a
-                    href="mailto:sales@interserver.net"
-                    className="text-[#0567B1] underline"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    sales@interserver.net
-                  </a>{' '}
-                  with:
-                  <ul className="list-disc list-inside ml-6 mt-2 ">
-                    <li>A copy of your IRS 501(c)(3) tax identification letter</li>
-                    <li>
-                      The domain name you want hosted with InterServer (from the Free For Charity
-                      Domain Service)
-                    </li>
-                  </ul>
-                </li>
-
-                <li>Wait for InterServer to set up your account (they will do this promptly)</li>
-                <li>Once your account is set up, log in to your DirectAdmin panel</li>
-              </ol>
-            </div>
-
-            {/* Section 2: Setting Up WordPress */}
-            <div>
-              <h2 className="text-[22px] font-[500] text-[#333] mt-6 mb-3">Setting Up WordPress</h2>
-              <ol className="list-decimal list-outside  pl-5">
-                <li>In DirectAdmin, locate and open Softaculous</li>
-                <li>Find WordPress in the list of available applications</li>
-                <li>Click “Install” next to WordPress</li>
-                <li>
-                  Fill out the installation form:
-                  <ul className="list-disc list-inside mt-2 ">
-                    <li>Choose your domain</li>
-                    <li>Leave the directory field blank for installation in the root directory</li>
-                    <li>Set up an admin username and strong password</li>
-                    <li>Choose a site name and description of your charity</li>
-                  </ul>
-                </li>
-                <li>Click “Install” to complete the WordPress setup</li>
-              </ol>
-            </div>
-
-            {/* Section 3: Adding Admin */}
+            {/* What we need from you */}
             <div>
               <h2 className="text-[22px] font-[500] text-[#333] mt-6 mb-3">
-                Adding Free For Charity Admin
+                What we need from you
               </h2>
-              <ol className="list-decimal list-outside  pl-5">
-                <li>Log in to your new WordPress dashboard</li>
-                <li>Go to Users → Add New</li>
-                <li>
-                  Fill out the form:
-                  <ul className="list-disc list-inside ml-6 mt-2 ">
-                    <li>Username: globaladmin</li>
-                    <li>
-                      Email:{' '}
-                      <a
-                        href="mailto:globaladmin@freeforcharity.org"
-                        className="text-[#0567B1] underline"
-                      >
-                        globaladmin@freeforcharity.org
-                      </a>
-                    </li>
-                    <li>Set a strong password</li>
-                    <li>Role: Administrator</li>
-                  </ul>
-                </li>
-                <li>Click “Add New User”</li>
-              </ol>
-            </div>
-
-            {/* Section 4: Footer Link */}
-            <div>
-              <h2 className="text-[22px] font-[500] text-[#333] mt-6 mb-3">
-                Adding InterServer Link to Footer
-              </h2>
-              <ol className="list-decimal list-outside  pl-5">
-                <li>In your WordPress dashboard, go to Appearance → Customize</li>
-                <li>Navigate to the footer section</li>
-                <li>Add the following text: “Powered by InterServer”</li>
-                <li>
-                  Make the text “InterServer” a hyperlink to{' '}
-                  <a
-                    href="https://www.interserver.net/"
-                    className="text-[#0567B1] underline"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    https://www.interserver.net
-                  </a>
-                </li>
-                <li>Save and publish your changes</li>
-              </ol>
-            </div>
-
-            {/* Important Notes */}
-            <div>
-              <h2 className="text-[22px] font-[500] text-[#333] mt-6 mb-3">Important Notes:</h2>
               <ul className="list-disc list-inside pl-1">
-                <li>
-                  You <strong>must</strong> add the “Powered by InterServer” link within{' '}
-                  <strong>30 days</strong>, or you’ll need to pay for the hosting package
-                </li>
-                <li>
-                  InterServer is a for-profit US company that provides free hosting. Free For
-                  Charity is a 501(c)(3) technology adoption charity; they are{' '}
-                  <em>separate entities</em>
-                </li>
+                <li>Your logo</li>
+                <li>Photos of your organization and its work</li>
+                <li>Your mission text</li>
+                <li>Descriptions of your programs</li>
               </ul>
             </div>
+
+            <p className="leading-relaxed">
+              Having this content ready is the main factor in how quickly your site can launch. Once
+              we have it, our volunteers handle the build and go-live for you.
+            </p>
 
             {/* Contact */}
             <p>

--- a/src/components/domains/Get-New-Website/index.tsx
+++ b/src/components/domains/Get-New-Website/index.tsx
@@ -41,9 +41,12 @@ const index = () => {
               data-font="raleway-font"
             >
               New site design has a backlog with Free For Charity but please reach out to get on the
-              list for a new free charity website. We try to support 100 Charities a year. If you
-              have your own design team and just need our hosting, plugins, and themes; follow the
-              steps at either the 501c3 or pre-501c3 onboarding pages to complete next steps.
+              list for a new free charity website. We try to support 100 Charities a year. Free For
+              Charity builds each charity a fast, secure static website on GitHub Pages from the FFC
+              template, and a volunteer sets it up and launches it on your Cloudflare-managed
+              domain. How quickly your site goes live depends mainly on how ready your content is.
+              Follow the steps at either the 501c3 or pre-501c3 onboarding pages to complete next
+              steps.
             </p>
           </div>
         </div>

--- a/src/components/domains/Order-Your-Domain/index.tsx
+++ b/src/components/domains/Order-Your-Domain/index.tsx
@@ -25,7 +25,7 @@ const HowToOrderDomain = () => {
     {
       number: 3,
       title: 'Step 3',
-      description: 'Select Register a New Domain',
+      description: 'Register a new .org domain or transfer a domain you already own',
       linkText: 'Follow Steps',
       innerbg: 'bg-[#2A6F9E]',
       outerbg: 'bg-[#2A6F9E]',
@@ -78,6 +78,18 @@ const HowToOrderDomain = () => {
               <StepCard key={step.number} step={step} />
             ))}
           </div>
+        </div>
+
+        <div className="pt-[30px] w-[80%] max-w-6xl mx-auto">
+          <p
+            className="md:w-[85%] mx-auto text-center text-[20px] font-medium leading-[30px]"
+            style={{ fontFamily: 'Raleway, sans-serif' }}
+          >
+            You have two supported options: register a brand new .org domain, or transfer a domain
+            you already own into Free For Charity&apos;s Cloudflare Registrar. Transferring a domain
+            you already own? You&apos;ll need your current registrar, the authorization (EPP) code,
+            and the domain unlocked with WHOIS privacy turned off before you start.
+          </p>
         </div>
       </div>
 

--- a/src/components/domains/Setup-Email-Hosting/index.tsx
+++ b/src/components/domains/Setup-Email-Hosting/index.tsx
@@ -19,7 +19,9 @@ const index = () => {
             className="mb-[13px] w-[85%] mx-auto font-[500] text-[20px] leading-[30px] text-center"
             data-font="raleway-font"
           >
-            Email hosting means that you can have email addresses at your domain name. e.g.
+            Email hosting means that you can have email addresses at your domain name. e.g. Hosted
+            email is a 501(c)(3) benefit — eligible nonprofits get it free through Microsoft 365 or
+            Google Workspace.
           </p>
         </div>
       </div>
@@ -59,7 +61,7 @@ const index = () => {
         </a>
       </div>
 
-      <div className="w-[90%] md:w-[80%] max-w-[1080px] mx-auto grid grid-cols-1 md:grid-cols-2 py-[27] gap-[33px] items-stretch justify-between">
+      <div className="w-[90%] md:w-[80%] max-w-[1080px] mx-auto grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 py-[27] gap-[33px] items-stretch justify-between">
         <div className="p-[20px] text-center bg-white rounded-[10px] overflow-hidden pt-[30px] pr-[20px] pb-[30px] pl-[20px] shadow-[0px_2px_18px_0px_rgba(0,0,0,0.3)]">
           {/* Circle Image */}
           <div className="mx-auto flex-shrink-0 w-[100px] h-[100px] overflow-hidden mb-[30px]">
@@ -87,8 +89,9 @@ const index = () => {
 
           {/* Text Content */}
           <p className="text-[18px] leading-[32px] font-[500]" data-font="raleway-font">
-            Free For Charity recommends Microsoft as your email provider as it is free to charities
-            and comes with many additional services at no cost
+            Choose the provider that fits your charity: Microsoft 365 or Google Workspace. Both are
+            free for eligible 501(c)(3) nonprofits and come with many additional collaboration
+            services at no cost.
           </p>
         </div>
 
@@ -129,12 +132,57 @@ const index = () => {
             See the Microsoft 365 setup steps
           </a>
         </div>
+
+        <div className="p-[20px] text-center bg-white rounded-[10px] overflow-hidden pt-[30px] pr-[20px] pb-[30px] pl-[20px] shadow-[0px_2px_18px_0px_rgba(0,0,0,0.3)]">
+          {/* Circle Image */}
+          <div className="mx-auto flex-shrink-0 w-[100px] h-[100px] overflow-hidden mb-[30px]">
+            <Image
+              src={assetPath('/Images/3.webp')}
+              alt="Step Illustration"
+              width={56}
+              height={56}
+              className="w-full h-full object-contain rounded-full"
+            />
+          </div>
+
+          <h2
+            className="text-[31px] font-[700] leading-[31px] pb-[30px] text-[#0567B1]"
+            data-font="cantata-font"
+          >
+            Step 3
+          </h2>
+          <p
+            className="text-[#333] text-[22px] font-[700] leading-[22px] text-center pb-[10px]"
+            data-font="raleway-font"
+          >
+            Or set up a Google Workspace account
+          </p>
+
+          {/* Text Content */}
+          <p className="text-[18px] leading-[32px] font-[500] pb-[1em]" data-font="raleway-font">
+            Prefer Google? Follow these simple steps to set up your Google Workspace for Nonprofits
+            account
+          </p>
+          <a
+            href="/domains/#setupstep3"
+            className="text-[25px] leading-[32px] font-[600] text-[#0460C0]"
+            data-font="raleway-font"
+          >
+            See the Google Workspace setup steps
+          </a>
+        </div>
       </div>
 
-      <div className="w-[90%] md:w-[80%] max-w-[680px] mx-auto mt-[40px]">
+      <div className="w-[90%] md:w-[80%] max-w-[680px] mx-auto mt-[40px] flex flex-col gap-[20px]">
         <AdminGuideLink
           href={ffcAdminUrl(adminLinks.domains.newModel)}
+          label="Full Microsoft 365 email guide on FFC Admin"
           description="Follow the full Microsoft 365 email setup guide on the FFC Admin portal."
+        />
+        <AdminGuideLink
+          href="/google-for-nonprofits-guide/"
+          label="Full Google Workspace email guide"
+          description="Prefer Google? Follow the full Google Workspace for Nonprofits setup guide."
         />
       </div>
     </div>

--- a/src/components/domains/Setup-Email-Hosting/index.tsx
+++ b/src/components/domains/Setup-Email-Hosting/index.tsx
@@ -61,7 +61,7 @@ const index = () => {
         </a>
       </div>
 
-      <div className="w-[90%] md:w-[80%] max-w-[1080px] mx-auto grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 py-[27] gap-[33px] items-stretch justify-between">
+      <div className="w-[90%] md:w-[80%] max-w-[1080px] mx-auto grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 py-[27px] gap-[33px] items-stretch justify-between">
         <div className="p-[20px] text-center bg-white rounded-[10px] overflow-hidden pt-[30px] pr-[20px] pb-[30px] pl-[20px] shadow-[0px_2px_18px_0px_rgba(0,0,0,0.3)]">
           {/* Circle Image */}
           <div className="mx-auto flex-shrink-0 w-[100px] h-[100px] overflow-hidden mb-[30px]">
@@ -164,7 +164,7 @@ const index = () => {
             account
           </p>
           <a
-            href="/domains/#setupstep3"
+            href="/google-for-nonprofits-guide/"
             className="text-[25px] leading-[32px] font-[600] text-[#0460C0]"
             data-font="raleway-font"
           >

--- a/src/components/domains/Verify-Your-Domain/index.tsx
+++ b/src/components/domains/Verify-Your-Domain/index.tsx
@@ -15,20 +15,21 @@ const index = () => {
             className="mt-[2px] mb-[12px] pb-[10px] text-[30px] md:text-[35px] font-[700] leading-[46px] text-[#0567B1] text-center"
             data-font="cantata-font"
           >
-            HOW TO VERIFY YOUR DOMAIN WITH ICANN
+            YOUR DOMAIN IS MANAGED IN CLOUDFLARE
           </h1>
           <p
             className="mb-[13px] w-full lg:w-[85%] mx-auto font-[500] text-[20px] leading-[30px] text-center"
             data-font="raleway-font"
           >
-            Please note that you will now own this domain but several emails from the domain
-            registrar system will need to be accepted as they verify your account to own the domain.
+            Your domain is registered and managed for you in Cloudflare by Free For Charity. There
+            is nothing for you to verify — unlike a traditional registrar, there are no verification
+            emails that you need to act on.
           </p>
           <p
             className="mt-[30px] font-[600] text-[27px] leading-[35px] text-center"
             data-font="raleway-font"
           >
-            What to do then?
+            So what do you need to do?
           </p>
         </div>
       </div>
@@ -42,7 +43,7 @@ const index = () => {
                 <Image
                   src={assetPath('/Images/1.webp')}
                   fill
-                  alt="domain verification email"
+                  alt="Cloudflare managed domain"
                   className="object-contain"
                 />
               </div>
@@ -57,8 +58,8 @@ const index = () => {
                 Step 1
               </h2>
               <p className="text-[23px] font-[500] leading-[30px]" data-font="raleway-font">
-                Check for emails about verification to the email address you used to register this
-                domain
+                Nothing to verify. Free For Charity registers, manages, and renews your domain for
+                you in Cloudflare, so no action is required on your part.
               </p>
             </div>
           </div>
@@ -66,25 +67,25 @@ const index = () => {
 
         {/* Bottom note */}
         <p className="font-[500] text-[20px] leading-[30px] text-center" data-font="raleway-font">
-          There are three main things to keep in mind.
+          There are a few things to keep in mind.
         </p>
       </div>
 
       <div className="w-[87%] max-w-[1300px] mx-auto py-[22px] grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-[35px] items-stretch">
         <DomainCard
           imageSrc="/Images/1.webp"
-          imageAlt="Email verification icon"
-          text="Check for emails about verification to the email address you used to register this domain"
+          imageAlt="Cloudflare managed domain icon"
+          text="There are no verification emails to accept — Free For Charity manages your domain in Cloudflare on your behalf."
         />
         <DomainCard
           imageSrc="/Images/2.webp"
-          imageAlt="Email verification icon"
-          text="FAILING TO RESPOND TO THESE EMAILS WILL RESULT IN SUSPENSION OF YOUR DOMAIN"
+          imageAlt="Support ticket icon"
+          text="Need a DNS record or any domain change? Open a support ticket and an FFC volunteer will take care of it for you."
         />
         <DomainCard
           imageSrc="/Images/3.webp"
-          imageAlt="Email verification icon"
-          text="Free For Charity does not send or control these emails but we will be notified if you did not verify your ownership in the time provided."
+          imageAlt="Domain hub icon"
+          text="You can view your domain anytime from the Free For Charity hub using the account you created at checkout."
         />
       </div>
 
@@ -97,7 +98,7 @@ const index = () => {
                 <Image
                   src={assetPath('/Images/2.webp')}
                   fill
-                  alt="domain verification email"
+                  alt="domain management hub"
                   className="object-contain"
                 />
               </div>
@@ -115,8 +116,8 @@ const index = () => {
                 className="text-[23px] font-[500] leading-[30px] pb-[1em]"
                 data-font="raleway-font"
               >
-                You can manage your domain anytime by accessing our system with the account you
-                created at checkout.
+                Any DNS or domain change goes through a support ticket. You can view your domain
+                anytime by accessing our system with the account you created at checkout.
               </p>
               <a
                 href={hubUrl()}
@@ -145,8 +146,8 @@ const index = () => {
             className="w-full md:w-[85%] mx-auto text-[27px] font-[600] leading-[35px] text-center"
             data-font="raleway-font"
           >
-            If at anytime 72 hours after your order has been placed you have any questions about
-            these verifications please contact
+            If at anytime after your order has been placed you have any questions about your domain
+            please contact
           </p>
         </div>
 

--- a/src/components/free-charity-web-hosting/FAQs/index.tsx
+++ b/src/components/free-charity-web-hosting/FAQs/index.tsx
@@ -166,10 +166,11 @@ const AccordionLayout = () => {
                 isOpen={openRight === 'right1'}
                 onToggle={() => toggleRight('right1')}
               >
-                We are a registered reseller of eNom domain names. eNom has graciously provided us
-                with a Platinum account to support other non profits providing the lowest cost
-                domain names for a charity of our size. As we get more and more charities into the
-                domain system we expect the costs to freeforcharity.org to drop even further.
+                Domains are registered and managed directly at Cloudflare Registrar by Free For
+                Charity. Cloudflare offers domains at wholesale, at-cost pricing with no markup,
+                which lets us provide free .org names to the charities we serve. Managing everything
+                in one Cloudflare account also gives us DNS, CDN, and SSL security for every charity
+                domain out of the box.
               </AccordionItem>
 
               <AccordionItem
@@ -189,8 +190,9 @@ const AccordionLayout = () => {
                     </a>
                   </li>
                   <li>
-                    If you can provide your own qualified WordPress webmaster you may be moved up in
-                    the list.
+                    If you arrive with your content ready to go — logo, photos, mission text, and
+                    program descriptions — your GitHub Pages site can be built and launched much
+                    faster, which may move you up in the list.
                   </li>
                 </ul>
               </AccordionItem>

--- a/src/components/help-for-charities-components/Ready-to-Get-Started-Now/index.tsx
+++ b/src/components/help-for-charities-components/Ready-to-Get-Started-Now/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import Transparentbtn from '@/components/ui/Transparentbtn'
-import { hubCart } from '@/lib/config'
+import { hubAddProduct, ONBOARDING_PID } from '@/lib/config'
 
 const index: React.FC = () => {
   return (
@@ -14,10 +14,13 @@ const index: React.FC = () => {
         </h1>
 
         <div className="flex flex-col sm:flex-row items-center justify-center gap-0 sm:gap-6">
-          <Transparentbtn text="501(c)3 Charities Click Here To Get Started!" href={hubCart(0)} />
+          <Transparentbtn
+            text="501(c)3 Charities Click Here To Get Started!"
+            href={hubAddProduct(ONBOARDING_PID.full501c3)}
+          />
           <Transparentbtn
             text="Pre-501(c)3 Charities Click Here to Get Started!"
-            href={hubCart(1)}
+            href={hubAddProduct(ONBOARDING_PID.pre501c3)}
           />
         </div>
       </div>

--- a/src/components/pre501c3-components/Faqs/index.tsx
+++ b/src/components/pre501c3-components/Faqs/index.tsx
@@ -113,7 +113,10 @@ const index = () => {
                   info@yourcharityname.org
                 </a>
               </li>
-              <li>Initial Charity WordPress Website for IRS application</li>
+              <li>
+                Initial Charity GitHub Pages Website for IRS application (a fast, secure static
+                site)
+              </li>
               <li>Initial Facebook Page for volunteers / location / region management</li>
               <li>Initial LinkedIn Page for volunteers / location / region management</li>
               <li>

--- a/src/components/pre501c3-components/charity/index.tsx
+++ b/src/components/pre501c3-components/charity/index.tsx
@@ -22,6 +22,11 @@ const index = () => {
             description="Looking to establish and govern your charity? We’ve got you covered. Our services include support for Charity Mission Plan “Pitch Deck” assistance, full plan development with budgeting and mission sections for IRS 1023 501c3 application, and consultation on initial board considerations. We also provide support for state and local nonprofit establishment, federal 501c3 nonprofit establishment, charity banking services, charity donation processing, and more. With Free For Charity, we connect students, professionals, and businesses with charities in need. Contact us today to get started on your charity’s mission!"
             descriptionAlign="left"
           />
+          <HelpForCharities
+            title="–What Happens Next–"
+            description="Ready to get your website live? Once you’re accepted, you’ll order your free domain name and GitHub Pages website services. At checkout you’ll see a small $1 verification charge — it simply confirms that each request comes from a real charity — and a discount code that brings your total down to $0 arrives in your onboarding acceptance email (we never post the code publicly). Charity email through Microsoft 365 or Google Workspace becomes available once your 501(c)(3) status is approved."
+            descriptionAlign="left"
+          />
         </div>
       </div>
     </div>

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -48,6 +48,24 @@ export function hubCart(productId: number | string): string {
 }
 
 /**
+ * WHMCS "add to cart" URL for a specific product id. Preferred over
+ * hubCart() index links when deep-linking to a known product, because
+ * `a=add&pid=` targets the product by its stable id rather than a
+ * cart-position index that shifts when the catalog is reordered.
+ *   hubAddProduct(16) → https://freeforcharity.org/hub/cart.php?a=add&pid=16
+ */
+export function hubAddProduct(pid: number): string {
+  return `${HUB_BASE}/cart.php?a=add&pid=${pid}`
+}
+
+/**
+ * WHMCS product ids for the charity onboarding application forms.
+ * These are the stable entry points for each charity type; see
+ * FreeForCharity/FFC-Cloudflare-Automation#657 / #658.
+ */
+export const ONBOARDING_PID = { pre501c3: 16, full501c3: 33 } as const
+
+/**
  * WHMCS store-listing URL for a slug under /hub/store/.
  *   hubStore('ffc-consulting/nonprofit-charity-onboarding')
  *     → https://freeforcharity.org/hub/store/ffc-consulting/nonprofit-charity-onboarding

--- a/tests/onboarding-journey.spec.ts
+++ b/tests/onboarding-journey.spec.ts
@@ -1,0 +1,74 @@
+/**
+ * Onboarding-journey sync (epic #446) — end-to-end verification that the
+ * public onboarding pages match the rebuilt WHMCS charity journey:
+ *   - CTAs deep-link to onboarding products by stable id (#452)
+ *   - domains page reflects the Cloudflare-registrar model, not eNom/ICANN (#447)
+ *   - website is GitHub Pages, not WordPress/InterServer (#448)
+ *   - email offers Microsoft 365 AND Google Workspace (#449)
+ *   - the journey lists Website before Email (#450)
+ *   - the coupon code is NEVER published on a public page (#453 hard rule)
+ */
+import { test, expect } from '@playwright/test'
+
+test.describe('Onboarding journey — CTA deep links (#452)', () => {
+  test('501c3 page links Get Started to onboarding product pid 33', async ({ page }) => {
+    await page.goto('/501c3')
+    await expect(page.locator('a[href*="a=add&pid=33"]').first()).toHaveCount(1)
+    await expect(page.locator('a[href*="confproduct"]')).toHaveCount(0)
+  })
+
+  test('pre501c3 page links Get Started to onboarding product pid 16', async ({ page }) => {
+    await page.goto('/pre501c3')
+    await expect(page.locator('a[href*="a=add&pid=16"]').first()).toHaveCount(1)
+    await expect(page.locator('a[href*="confproduct"]')).toHaveCount(0)
+  })
+})
+
+test.describe('Domains page — Cloudflare model, dual email (#447/#448/#449)', () => {
+  test('reflects Cloudflare, GitHub Pages, and both email providers; drops eNom/ICANN/InterServer', async ({
+    page,
+  }) => {
+    await page.goto('/domains')
+    const body = (await page.locator('main').innerText()).toLowerCase()
+    expect(body).toContain('cloudflare')
+    expect(body).toContain('github pages')
+    expect(body).toContain('microsoft 365')
+    expect(body).toContain('google workspace')
+    expect(body).not.toContain('icann')
+    expect(body).not.toContain('interserver')
+    expect(body).not.toContain('suspension of your domain')
+  })
+})
+
+test.describe('Onboarding journey page — Website before Email (#450)', () => {
+  test('website stage precedes email stage and both providers appear', async ({ page }) => {
+    await page.goto('/charity-onboarding-journey')
+    const body = await page.locator('body').innerText()
+    expect(body).toContain('Google Workspace')
+    // Stage headings are numbered; the Website stage must come before Email.
+    const websiteIdx = body.indexOf('Website')
+    const emailIdx = body.lastIndexOf('Email')
+    expect(websiteIdx).toBeGreaterThan(-1)
+    expect(emailIdx).toBeGreaterThan(-1)
+    expect(websiteIdx).toBeLessThan(emailIdx)
+  })
+})
+
+test.describe('Free charity web hosting — no legacy registrar (#447)', () => {
+  test('drops eNom reseller language, keeps Cloudflare', async ({ page }) => {
+    await page.goto('/free-charity-web-hosting')
+    const body = (await page.locator('body').innerText()).toLowerCase()
+    expect(body).not.toContain('enom')
+    expect(body).toContain('cloudflare')
+  })
+})
+
+test.describe('Coupon secrecy — hard rule (#453)', () => {
+  for (const route of ['/501c3', '/pre501c3', '/domains', '/charity-onboarding-journey']) {
+    test(`does not publish the coupon code on ${route}`, async ({ page }) => {
+      await page.goto(route)
+      const body = (await page.locator('body').innerText()).toLowerCase()
+      expect(body).not.toContain('freeforcharity2026')
+    })
+  }
+})

--- a/tests/onboarding-journey.spec.ts
+++ b/tests/onboarding-journey.spec.ts
@@ -13,13 +13,13 @@ import { test, expect } from '@playwright/test'
 test.describe('Onboarding journey — CTA deep links (#452)', () => {
   test('501c3 page links Get Started to onboarding product pid 33', async ({ page }) => {
     await page.goto('/501c3')
-    await expect(page.locator('a[href*="a=add&pid=33"]').first()).toHaveCount(1)
+    expect(await page.locator('a[href*="a=add&pid=33"]').count()).toBeGreaterThan(0)
     await expect(page.locator('a[href*="confproduct"]')).toHaveCount(0)
   })
 
   test('pre501c3 page links Get Started to onboarding product pid 16', async ({ page }) => {
     await page.goto('/pre501c3')
-    await expect(page.locator('a[href*="a=add&pid=16"]').first()).toHaveCount(1)
+    expect(await page.locator('a[href*="a=add&pid=16"]').count()).toBeGreaterThan(0)
     await expect(page.locator('a[href*="confproduct"]')).toHaveCount(0)
   })
 })
@@ -41,16 +41,19 @@ test.describe('Domains page — Cloudflare model, dual email (#447/#448/#449)', 
 })
 
 test.describe('Onboarding journey page — Website before Email (#450)', () => {
-  test('website stage precedes email stage and both providers appear', async ({ page }) => {
+  // The strict numbered stage ordering (3. Website before 4. Email) is
+  // asserted in the unit test __tests__/app/charity-onboarding-journey.test.tsx,
+  // which parses the headings directly. Here we assert the customer-visible
+  // outcome: the email stage states the live-website prerequisite and both
+  // providers are offered.
+  test('email stage states the live-website prerequisite and offers both providers', async ({
+    page,
+  }) => {
     await page.goto('/charity-onboarding-journey')
-    const body = await page.locator('body').innerText()
-    expect(body).toContain('Google Workspace')
-    // Stage headings are numbered; the Website stage must come before Email.
-    const websiteIdx = body.indexOf('Website')
-    const emailIdx = body.lastIndexOf('Email')
-    expect(websiteIdx).toBeGreaterThan(-1)
-    expect(emailIdx).toBeGreaterThan(-1)
-    expect(websiteIdx).toBeLessThan(emailIdx)
+    const main = await page.locator('main').innerText()
+    expect(main).toContain('Google Workspace')
+    expect(main).toContain('Microsoft 365')
+    expect(main).toMatch(/require a live website/i)
   })
 })
 
@@ -67,8 +70,10 @@ test.describe('Coupon secrecy — hard rule (#453)', () => {
   for (const route of ['/501c3', '/pre501c3', '/domains', '/charity-onboarding-journey']) {
     test(`does not publish the coupon code on ${route}`, async ({ page }) => {
       await page.goto(route)
-      const body = (await page.locator('body').innerText()).toLowerCase()
-      expect(body).not.toContain('freeforcharity2026')
+      const body = await page.locator('body').innerText()
+      // Match any freeforcharity<year> coupon pattern so the literal secret
+      // never needs to live in the repo (epic #446 hard rule).
+      expect(body).not.toMatch(/freeforcharity\d{4}/i)
     })
   }
 })


### PR DESCRIPTION
Implements the onboarding-sync epic — brings the public onboarding funnel in line with the rebuilt WHMCS charity journey.

## New journey reflected on the site
Onboarding (free) → **Domain** (register a new .org **or** transfer, in Cloudflare) → **Website** (GitHub Pages) → **Email, 501(c)(3) only** (Microsoft 365 **or** Google Workspace). Post-onboarding products are $1 (anti-spam), waived by a coupon that arrives **in the onboarding acceptance email** — the code is never published on a public page.

## Changes (by sub-issue)
- **#452** `config.ts`: `hubAddProduct()` + `ONBOARDING_PID`; onboarding CTAs deep-link to `pid 16`/`33` (a=add) instead of fragile `confproduct&i=` index links.
- **#447** domains + hosting: Cloudflare-managed (no ICANN/registrar-verification/eNom copy).
- **#448** 501c3 / pre501c3 / domains: InterServer + WordPress hosting content → **GitHub Pages**.
- **#449** domains / 501c3 / journey: **Microsoft 365 + Google Workspace** (was Microsoft-only); links both guides.
- **#450** `charity-onboarding-journey`: reordered **Website before Email** (email needs a live site to validate).
- **#451** domains: **register-new vs transfer** presented as first-class options.
- **#453** pre501c3: $1 + emailed-coupon note — **literal coupon code never published** (grep-guarded in e2e).

## Tests (each new capability covered)
- **Unit (Jest):** 576 passed. New: config CTA helpers, shared CTA links, domains, 501c3, pre501c3, journey page, hosting FAQs.
- **E2E (Playwright):** new `tests/onboarding-journey.spec.ts` (9 tests) + full suite **379 passed, 0 failed**.
- `npm run lint` clean; `npm run build` (static export) green.

## Test plan
`npm run lint && npm run build && npm run test && npx playwright test` — all green locally.

Refs #446
Fixes #447, fixes #448, fixes #449, fixes #450, fixes #451, fixes #452, fixes #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)