### PR TITLE
fix: link both email guides and both domain products (Copilot follow-up)

### DIFF
--- a/src/app/choosing-your-org-domain/page.tsx
+++ b/src/app/choosing-your-org-domain/page.tsx
@@ -100,10 +100,10 @@ export default function ChoosingYourOrgDomain() {
 
           <h2 className={h2}>Next step</h2>
           <p>
-            Once your domain exists, set up{' '}
-            <Link href="/m365-email-guide/">free Microsoft 365 or Google Workspace email</Link> at
-            it — that&rsquo;s the moment your charity starts looking as professional as the work you
-            do.
+            Once your domain exists, set up free{' '}
+            <Link href="/m365-email-guide/">Microsoft 365</Link> or{' '}
+            <Link href="/google-for-nonprofits-guide/">Google Workspace</Link> email at it —
+            that&rsquo;s the moment your charity starts looking as professional as the work you do.
           </p>
         </div>
       </div>

--- a/src/components/domains/Order-Your-Domain/index.tsx
+++ b/src/components/domains/Order-Your-Domain/index.tsx
@@ -90,6 +90,22 @@ const HowToOrderDomain = () => {
             you already own? You&apos;ll need your current registrar, the authorization (EPP) code,
             and the domain unlocked with WHOIS privacy turned off before you start.
           </p>
+          <div className="mt-6 flex flex-col sm:flex-row items-center justify-center gap-4">
+            <a
+              href={hubAddProduct(DOMAIN_PID.register)}
+              className="rounded border-2 border-[#0567B1] px-6 py-2.5 text-[18px] font-medium text-[#0567B1] transition-colors hover:bg-[#0567B1] hover:text-white"
+              data-font="raleway-font"
+            >
+              Register a new .org domain
+            </a>
+            <a
+              href={hubAddProduct(DOMAIN_PID.transfer)}
+              className="rounded border-2 border-[#0567B1] px-6 py-2.5 text-[18px] font-medium text-[#0567B1] transition-colors hover:bg-[#0567B1] hover:text-white"
+              data-font="raleway-font"
+            >
+              Transfer an existing domain
+            </a>
+          </div>
         </div>
       </div>
 

--- a/tests/onboarding-journey.spec.ts
+++ b/tests/onboarding-journey.spec.ts
@@ -105,7 +105,8 @@ test.describe('Round 2 — stale-model cleanup on the rest of the site (#455/#45
     // Word boundaries: "divi" is a substring of "individual", so match the
     // product names as whole words to avoid false positives.
     expect(body).not.toMatch(/\bDivi\b/i)
-    expect(body).not.toMatch(/\bWPMU\b/i)
+    // Substring (not \bWPMU\b) so "WPMUdev" — no word boundary before "dev" — is also caught.
+    expect(body).not.toMatch(/WPMU/i)
     expect(body.toLowerCase()).toContain('github pages')
   })
 
@@ -124,5 +125,7 @@ test.describe('Round 2 — stale-model cleanup on the rest of the site (#455/#45
     ).toHaveCount(0)
     await expect(page.locator('a[href*="confproduct"]')).toHaveCount(0)
     expect(await page.locator('a[href*="a=add&pid=39"]').count()).toBeGreaterThan(0)
+    // both domain products are now linked: register (39) and transfer (41)
+    expect(await page.locator('a[href*="a=add&pid=41"]').count()).toBeGreaterThan(0)
   })
 })


### PR DESCRIPTION
Small follow-up to PR #459 addressing three Copilot review points that arrived just after it merged.

- **choosing-your-org-domain**: the "Google Workspace" text linked to `/m365-email-guide`; now "Microsoft 365" → M365 guide and "Google Workspace" → the Google guide.
- **domains / Order-Your-Domain**: only the register product (pid 39) was linked; added explicit **Register a new .org** (pid 39) and **Transfer an existing domain** (pid 41) CTAs so both journey products are reachable, matching the "two supported options" copy.
- **e2e**: `\bWPMU\b` missed "WPMUdev" (no boundary before "dev") → substring check; added an assertion that the transfer (pid 41) link renders.

Tests: 590 unit pass, 14 e2e pass (incl. new pid-41 assertion), lint + build green.

Refs #446

🤖 Generated with [Claude Code](https://claude.com/claude-code)