### PR TITLE
fix: prune dead charity links on /charities-we-support (#444)

### DIFF
--- a/__tests__/data/supported-charities.test.ts
+++ b/__tests__/data/supported-charities.test.ts
@@ -34,7 +34,13 @@ describe('Supported-charities directory', () => {
       expect(c.domain).not.toMatch(/^https?:\/\//i)
       expect(c.domain).not.toMatch(/\/$/)
       expect(c.domain).not.toMatch(/\s/)
-      expect(c.domain).toMatch(/^[a-z0-9.-]+(\/[a-z0-9._~%/-]*)?$/i)
+      // Proper hostname: dot-separated labels that each start and end with an
+      // alphanumeric (hyphens allowed only in the middle), at least two labels,
+      // then an optional path. Rejects malformed hosts like `.example.com`,
+      // `-example.com`, `example..com`, or `example.com-`.
+      expect(c.domain).toMatch(
+        /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+(\/[a-z0-9._~%/-]*)?$/i
+      )
     }
   })
 

--- a/__tests__/data/supported-charities.test.ts
+++ b/__tests__/data/supported-charities.test.ts
@@ -18,6 +18,16 @@ describe('Supported-charities directory', () => {
     expect(charities.length).toBeGreaterThan(0)
   })
 
+  it('carries well-formed snapshot + link-verification dates (both rendered on the page)', () => {
+    const meta = directory as unknown as { snapshotDate: string; linksVerifiedDate: string }
+    for (const d of [meta.snapshotDate, meta.linksVerifiedDate]) {
+      expect(typeof d).toBe('string')
+      expect(d).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+    }
+    // Links can only be verified on or after the inventory snapshot they cover.
+    expect(meta.linksVerifiedDate >= meta.snapshotDate).toBe(true)
+  })
+
   it('every entry has a truthy domain string', () => {
     for (const c of charities) {
       expect(typeof c.domain).toBe('string')

--- a/__tests__/data/supported-charities.test.ts
+++ b/__tests__/data/supported-charities.test.ts
@@ -26,10 +26,11 @@ describe('Supported-charities directory', () => {
     }
   })
 
-  it('domains are bare hosts — no scheme, trailing slash, or whitespace', () => {
+  it('domains are a host with an optional path — no scheme, trailing slash, or whitespace', () => {
     for (const c of charities) {
       // The page prepends `https://` and appends `/`, so a scheme or trailing
-      // slash here would produce a malformed link.
+      // slash here would produce a malformed link. A path segment is allowed
+      // (e.g. `wh1374403.ispot.cc/wp`) — some charities live under a subpath.
       expect(c.domain).not.toMatch(/^https?:\/\//i)
       expect(c.domain).not.toMatch(/\/$/)
       expect(c.domain).not.toMatch(/\s/)

--- a/__tests__/data/supported-charities.test.ts
+++ b/__tests__/data/supported-charities.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Supported-charities directory tests (issue #444)
+ *
+ * The /charities-we-support/ page renders each entry as an outbound link
+ * (`https://<domain>/`). The file's own inclusion criterion is "domains with a
+ * working site", so these tests guard the structural invariants that keep the
+ * rendered links valid and lock in the 2026-07-09 link-rot prune so the dead
+ * destinations can't silently return.
+ */
+
+import directory from '@/data/supported-charities.json'
+
+const charities = directory.charities
+
+describe('Supported-charities directory', () => {
+  it('exports a non-empty charities array', () => {
+    expect(Array.isArray(charities)).toBe(true)
+    expect(charities.length).toBeGreaterThan(0)
+  })
+
+  it('every entry has a truthy domain string', () => {
+    for (const c of charities) {
+      expect(typeof c.domain).toBe('string')
+      expect(c.domain.trim()).toBe(c.domain)
+      expect(c.domain.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('domains are bare hosts — no scheme, trailing slash, or whitespace', () => {
+    for (const c of charities) {
+      // The page prepends `https://` and appends `/`, so a scheme or trailing
+      // slash here would produce a malformed link.
+      expect(c.domain).not.toMatch(/^https?:\/\//i)
+      expect(c.domain).not.toMatch(/\/$/)
+      expect(c.domain).not.toMatch(/\s/)
+      expect(c.domain).toMatch(/^[a-z0-9.-]+(\/[a-z0-9._~%/-]*)?$/i)
+    }
+  })
+
+  it('contains no duplicate domains', () => {
+    const seen = new Set<string>()
+    for (const c of charities) {
+      expect(seen.has(c.domain)).toBe(false)
+      seen.add(c.domain)
+    }
+  })
+
+  it('does not relist the domains pruned for link rot (issue #444)', () => {
+    const pruned = [
+      'foxtrotenterprises.com', // 522 origin offline, no working sibling
+      'ghcd.onlineimpacts.org', // 403 — real per-page restriction (siblings 200)
+      'kieranrunnelsdev.org', // 522 origin offline (a *dev domain)
+      'techforsecurity.com', // dead (000); org still listed as tech4security.com
+      'wonderseed.org', // dead (000); org still listed as wonderseedstudio(s)
+      'bhakthinivedana.com/sandbox', // stale path — replaced by the root host
+    ]
+    const domains = new Set(charities.map((c) => c.domain))
+    for (const p of pruned) {
+      expect(domains.has(p)).toBe(false)
+    }
+  })
+
+  it('keeps each pruned org that still has a working destination', () => {
+    const domains = new Set(charities.map((c) => c.domain))
+    // bhakthinivedana kept at its working root; the two dead duplicates kept
+    // via their live sibling domains.
+    expect(domains.has('bhakthinivedana.com')).toBe(true)
+    expect(domains.has('tech4security.com')).toBe(true)
+    expect(domains.has('wonderseedstudio.com')).toBe(true)
+    expect(domains.has('wonderseedstudios.org')).toBe(true)
+  })
+})

--- a/src/app/charities-we-support/page.tsx
+++ b/src/app/charities-we-support/page.tsx
@@ -9,9 +9,10 @@ export const metadata = pageMetadata({
   canonical: '/charities-we-support/',
 })
 
-const { charities, snapshotDate } = directory as unknown as {
+const { charities, snapshotDate, linksVerifiedDate } = directory as unknown as {
   charities: { domain: string }[]
   snapshotDate: string
+  linksVerifiedDate: string
 }
 
 export default function CharitiesWeSupport() {
@@ -31,8 +32,8 @@ export default function CharitiesWeSupport() {
           . This directory lists only currently-live public sites.)
         </p>
         <p className="font-[var(--font-lato)] text-[14px] leading-[22px] text-[#767672] mb-8">
-          Snapshot from our operational sites inventory ({snapshotDate}) — the full inventory with
-          health and migration detail is public on{' '}
+          Snapshot from our operational sites inventory ({snapshotDate}), outbound links verified{' '}
+          {linksVerifiedDate} — the full inventory with health and migration detail is public on{' '}
           <a
             href="https://ffcadmin.org/sites-list/"
             target="_blank"

--- a/src/app/charities-we-support/page.tsx
+++ b/src/app/charities-we-support/page.tsx
@@ -32,7 +32,7 @@ export default function CharitiesWeSupport() {
           . This directory lists only currently-live public sites.)
         </p>
         <p className="font-[var(--font-lato)] text-[14px] leading-[22px] text-[#767672] mb-8">
-          Snapshot from our operational sites inventory ({snapshotDate}), outbound links verified{' '}
+          Snapshot from our operational sites inventory ({snapshotDate}), outbound links verified on{' '}
           {linksVerifiedDate} — the full inventory with health and migration detail is public on{' '}
           <a
             href="https://ffcadmin.org/sites-list/"

--- a/src/data/supported-charities.json
+++ b/src/data/supported-charities.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Public directory snapshot for /charities-we-support/ (issue #377). Derived from the FFC sites-list (FFC-Cloudflare-Automation sites-list/sites_list.json, commit c18c5c5, 2026-06-08): domains with a working site (Live/Redirect health), excluding organizations that left FFC, staging domains, and FFC's own infrastructure domains. Org domains are public project data (sites-list precedent); no contact or personal data. OPT-OUT: any organization can be removed on request via the contact page - delete its row here and note the request in the PR.",
+  "_comment": "Public directory snapshot for /charities-we-support/ (issue #377). Derived from the FFC sites-list (FFC-Cloudflare-Automation sites-list/sites_list.json, commit c18c5c5, 2026-06-08): domains with a working site (Live/Redirect health), excluding organizations that left FFC, staging domains, and FFC's own infrastructure domains. Org domains are public project data (sites-list precedent); no contact or personal data. OPT-OUT: any organization can be removed on request via the contact page - delete its row here and note the request in the PR. LINK-ROT PRUNE (2026-07-09, issue #444): fixed bhakthinivedana.com (dropped stale /sandbox path, root serves 200) and removed foxtrotenterprises.com (522), ghcd.onlineimpacts.org (403; the umbrella org stays via its other working subdomains), kieranrunnelsdev.org (522), techforsecurity.com (dead; org still listed as tech4security.com), and wonderseed.org (dead; org still listed as wonderseedstudio.com / wonderseedstudios.org) - all failed the working-site criterion in a browser, not just CI.",
   "sourceCommit": "c18c5c5",
   "snapshotDate": "2026-06-08",
   "charities": [
@@ -46,7 +46,7 @@
       "domain": "bearupinternationalministries.org"
     },
     {
-      "domain": "bhakthinivedana.com/sandbox"
+      "domain": "bhakthinivedana.com"
     },
     {
       "domain": "bintobetter.org"
@@ -124,16 +124,10 @@
       "domain": "focus-on-free.com"
     },
     {
-      "domain": "foxtrotenterprises.com"
-    },
-    {
       "domain": "freedomrisingusa.org"
     },
     {
       "domain": "ftnfcog.org"
-    },
-    {
-      "domain": "ghcd.onlineimpacts.org"
     },
     {
       "domain": "graftonareahistory.org"
@@ -170,9 +164,6 @@
     },
     {
       "domain": "kainkaryasri.org"
-    },
-    {
-      "domain": "kieranrunnelsdev.org"
     },
     {
       "domain": "kierstensride.org"
@@ -292,9 +283,6 @@
       "domain": "tech4security.com"
     },
     {
-      "domain": "techforsecurity.com"
-    },
-    {
       "domain": "technologyadoptionbarriers.org"
     },
     {
@@ -359,9 +347,6 @@
     },
     {
       "domain": "wisdomfinancialministries.org"
-    },
-    {
-      "domain": "wonderseed.org"
     },
     {
       "domain": "wonderseedstudio.com"

--- a/src/data/supported-charities.json
+++ b/src/data/supported-charities.json
@@ -1,7 +1,8 @@
 {
   "_comment": "Public directory snapshot for /charities-we-support/ (issue #377). Derived from the FFC sites-list (FFC-Cloudflare-Automation sites-list/sites_list.json, commit c18c5c5, 2026-06-08): domains with a working site (Live/Redirect health), excluding organizations that left FFC, staging domains, and FFC's own infrastructure domains. Org domains are public project data (sites-list precedent); no contact or personal data. OPT-OUT: any organization can be removed on request via the contact page - delete its row here and note the request in the PR. LINK-ROT PRUNE (2026-07-09, issue #444): fixed bhakthinivedana.com (dropped stale /sandbox path, root serves 200) and removed foxtrotenterprises.com (522), ghcd.onlineimpacts.org (403; the umbrella org stays via its other working subdomains), kieranrunnelsdev.org (522), techforsecurity.com (dead; org still listed as tech4security.com), and wonderseed.org (dead; org still listed as wonderseedstudio.com / wonderseedstudios.org) - all failed the working-site criterion in a browser, not just CI.",
   "sourceCommit": "c18c5c5",
-  "snapshotDate": "2026-07-09",
+  "snapshotDate": "2026-06-08",
+  "linksVerifiedDate": "2026-07-09",
   "charities": [
     {
       "domain": "3dmc2.com"

--- a/src/data/supported-charities.json
+++ b/src/data/supported-charities.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Public directory snapshot for /charities-we-support/ (issue #377). Derived from the FFC sites-list (FFC-Cloudflare-Automation sites-list/sites_list.json, commit c18c5c5, 2026-06-08): domains with a working site (Live/Redirect health), excluding organizations that left FFC, staging domains, and FFC's own infrastructure domains. Org domains are public project data (sites-list precedent); no contact or personal data. OPT-OUT: any organization can be removed on request via the contact page - delete its row here and note the request in the PR. LINK-ROT PRUNE (2026-07-09, issue #444): fixed bhakthinivedana.com (dropped stale /sandbox path, root serves 200) and removed foxtrotenterprises.com (522), ghcd.onlineimpacts.org (403; the umbrella org stays via its other working subdomains), kieranrunnelsdev.org (522), techforsecurity.com (dead; org still listed as tech4security.com), and wonderseed.org (dead; org still listed as wonderseedstudio.com / wonderseedstudios.org) - all failed the working-site criterion in a browser, not just CI.",
   "sourceCommit": "c18c5c5",
-  "snapshotDate": "2026-06-08",
+  "snapshotDate": "2026-07-09",
   "charities": [
     {
       "domain": "3dmc2.com"


### PR DESCRIPTION
The production outbound-links watchdog ([#444](https://github.com/FreeForCharity/FFC-IN-freeforcharity.org/issues/444)) flagged **6 failing external links**, all on `/charities-we-support/`. I re-verified each from a normal browser UA (so these are real, not CI bot-blocks) and checked siblings/roots before touching anything.

| URL | Status (browser UA) | Action | Why |
|-----|--------------------|--------|-----|
| `bhakthinivedana.com/sandbox` | 500 | **Fixed → `bhakthinivedana.com`** | Root serves 200; `/sandbox` was a stale path |
| `techforsecurity.com` | 000 (dead) | **Removed** | Org already listed as working `tech4security.com` |
| `wonderseed.org` | 000 (dead) | **Removed** | Org already listed as `wonderseedstudio.com` / `wonderseedstudios.org` (both 200) |
| `foxtrotenterprises.com` | 522 | **Removed** | Origin offline, no working sibling |
| `kieranrunnelsdev.org` | 522 | **Removed** | Origin offline (a `…dev` domain) |
| `ghcd.onlineimpacts.org` | 403 | **Removed** | Real per-page restriction — every sibling `*.onlineimpacts.org` returns 200, so not a platform bot-block; umbrella org stays via its other subdomains |

No org that still has a working destination was dropped: every removed org either keeps a live sibling domain in the list or has no reachable site at all. Directory goes 129 → **124** orgs (the page count is dynamic, no hardcoded number).

**Tests:** new `__tests__/data/supported-charities.test.ts` (6 cases) validates structure (bare hosts, no scheme/trailing-slash, no duplicates) and locks in this prune as a regression guard. Full suite 596 pass, lint + build green.

Refs #444

🤖 Generated with [Claude Code](https://claude.com/claude-code)