### PR TITLE
fix: browser User-Agent for the production link watchdog (#444)

### DIFF
--- a/.github/workflows/outbound-links-prod.yml
+++ b/.github/workflows/outbound-links-prod.yml
@@ -44,6 +44,12 @@ jobs:
           # the links found in the served HTML. Internal links are excluded —
           # the post-deploy smoke suite owns those; this watchdog is only for
           # external destinations (charity sites, Microsoft/Google/IRS docs).
+          # --user-agent: many charity origins sit behind Cloudflare/WAF rules
+          # that 401/403 the default lychee UA from GitHub Actions IPs while
+          # serving 200 to real browsers. Sending a normal browser UA removes
+          # that whole class of false positives; genuinely forbidden pages (403
+          # even to a browser UA) and dead origins (000/5xx) still fail, so real
+          # link rot is still caught.
           args: >-
             --verbose
             --no-progress
@@ -52,6 +58,7 @@ jobs:
             --timeout 60
             --max-retries 5
             --retry-wait-time 5
+            --user-agent 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36'
             --accept 200,201,202,203,204,206,301,302,303,307,308,429
             -- $(cat sitemap-urls.txt | tr '\n' ' ')
           fail: false


### PR DESCRIPTION
Follow-up to #461. After the dead-link prune, re-running the production outbound-links watchdog surfaced **16 charity URLs returning 401/403** — a completely different set from the 6 genuinely-dead links #461 fixed.

I re-checked all 16 with a normal browser User-Agent: **every one returns 200.** They're live charity sites whose Cloudflare/WAF rules block lychee's default UA from GitHub Actions runner IPs — false positives, not link rot. Examples: `veterans.onlineimpacts.org`, `nochaos.org`, `postpartumcarefoundation.org`, `letsdanceactivities.org`, `educationandempowerment.org`.

**Fix:** send a normal browser `--user-agent` from the watchdog. This removes the whole class of bot-block false positives, while:
- genuinely forbidden pages (403 even to a browser UA — like the `ghcd.onlineimpacts.org` page removed in #461) still fail, and
- dead origins (000 / 5xx / 522) still fail.

so real link rot is still caught. The PR-time `lychee.yml` doesn't need this — it scans source files, where charity domains are bare hosts in JSON (not `http://` URLs), so it never fetches them; only this watchdog crawls the rendered HTML.

**Verification:** all 16 URLs return 200 to the browser UA (curl); YAML validated. After merge I'll re-dispatch the watchdog to confirm the crawl comes back clean, then close #444.

Refs #444

🤖 Generated with [Claude Code](https://claude.com/claude-code)