### PR TITLE
fix: pin W3C WAI + FB-redirect bot-blocks in .lycheeignore (#444)

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -30,6 +30,18 @@ https://nonprofit.linkedin.com/**
 https://www.facebook.com/**
 https://facebook.com/**
 
+# bringingpeople2people.org (charities-we-support) 301-redirects to the org's
+# Facebook page, so lychee follows it to facebook.com's login wall and reports
+# a 400 on the origin URL. Same bot-block class as facebook.com above (already
+# pinned); the redirect is the org's chosen web presence and works in browsers.
+https://bringingpeople2people.org/
+https://bringingpeople2people.org/**
+
+# W3C WAI resources (WCAG quickref, linked from /accessibility-statement/) return
+# 403 to automated clients from CI IPs — even with a browser UA — while serving
+# 200 in real browsers. Canonical, stable docs; pin the WAI subtree.
+https://www.w3.org/WAI/**
+
 # Twitter/X blocks crawlers
 https://twitter.com/**
 https://x.com/**


### PR DESCRIPTION
Final cleanup for #444. After #461 (fixed 6 real dead links) and #462 (browser UA cleared 16 bot-block false positives), the watchdog re-run came back with **just 2 residual failures**, both persistent bot-blocks — the documented `.lycheeignore` remedy:

- **`https://www.w3.org/WAI/WCAG21/quickref/`** (403) — linked from `/accessibility-statement/`. W3C WAI docs 403 automated clients from CI IPs even with a browser UA, but serve 200 in real browsers. Pinned the `WAI/` subtree.
- **`https://bringingpeople2people.org/`** (400) — the charity's domain 301-redirects to their Facebook page, so lychee follows it to facebook.com's login wall. Same bot-block class as `facebook.com` (already pinned); the redirect is the org's chosen web presence and works in browsers, so the charity stays listed.

After this merges I'll re-dispatch the watchdog to confirm a clean (0-error) crawl, then close #444.

Refs #444

🤖 Generated with [Claude Code](https://claude.com/claude-code)