### PR TITLE
fix: resilient sitemap fetch in production link watchdog (#444)

### DIFF
--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -36,6 +36,10 @@ jobs:
           # retry-wait so transient external-host flakes (sdgs.un.org,
           # theleanstartup.com, etc.) stop failing CI on otherwise-healthy
           # PRs. Real 4xx/5xx still surface as non-zero exit.
+          # --user-agent: some hosts (e.g. avepoint.com) serve 404/403 to the
+          # default lychee UA while returning 200 to browsers; a normal browser
+          # UA removes that class of false positives. Genuinely broken links
+          # still fail. Matches the production watchdog (outbound-links-prod.yml).
           args: >-
             --verbose
             --no-progress
@@ -43,6 +47,7 @@ jobs:
             --timeout 60
             --max-retries 5
             --retry-wait-time 5
+            --user-agent 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36'
             --accept 200,206,301,302,307,308
             './src/**/*.tsx'
             './src/**/*.ts'

--- a/.github/workflows/outbound-links-prod.yml
+++ b/.github/workflows/outbound-links-prod.yml
@@ -29,7 +29,15 @@ jobs:
 
       - name: Collect page URLs from the production sitemap
         run: |
-          curl -sSf https://www.freeforcharity.org/sitemap.xml \
+          # The apex sits behind Cloudflare/cPanel edge security that
+          # intermittently 403/415s automated requests from GitHub Actions IPs
+          # (same reason the lychee step below sends a browser UA). Send a normal
+          # browser UA and retry so this setup step doesn't flake and fail the
+          # whole watchdog before the crawl even runs.
+          curl -sSf \
+            --user-agent 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36' \
+            --retry 5 --retry-delay 5 --retry-all-errors \
+            https://www.freeforcharity.org/sitemap.xml \
             | grep -o '<loc>[^<]*</loc>' \
             | sed -e 's/<loc>//' -e 's#</loc>##' > sitemap-urls.txt
           wc -l sitemap-urls.txt


### PR DESCRIPTION
While confirming the clean crawl for #444, the watchdog started failing at its **setup step** — `Collect page URLs from the production sitemap` — with `exit code 1`, before the link crawl even ran. Root cause is the same edge bot-block already handled elsewhere: the apex sits behind Cloudflare/cPanel security that intermittently 403/415s automated requests from GitHub Actions runner IPs (documented in `.lycheeignore`, and the reason #462 added a browser UA to the lychee step). The setup `curl -sSf` used the default curl UA with no retries, so it flakes.

**Fix:** give that `curl` the same resilience as the crawl — a browser `--user-agent` plus `--retry 5 --retry-delay 5 --retry-all-errors`. The `-sSf` + `test -s` guards stay, so a genuinely empty/unfetchable sitemap still fails loudly.

Context: the last *successful* full crawl (run before this flake) showed exactly the 2 residual errors pinned in #464, so the crawl itself is already clean — this just stops the setup step from spuriously failing the run. After merge I'll dispatch once more to capture a green end-to-end run, then close #444.

Refs #444

🤖 Generated with [Claude Code](https://claude.com/claude-code)