### PR TITLE
feat: make eligibility check a single committed-journey funnel

### DIFF
--- a/src/app/eligibility-check/page.tsx
+++ b/src/app/eligibility-check/page.tsx
@@ -1,10 +1,11 @@
 import { pageMetadata } from '@/lib/page-metadata'
 import DecisionWizard, { type WizardConfig } from '@/components/wizards/DecisionWizard'
+import { hubAddProduct, ONBOARDING_PID } from '@/lib/config'
 
 export const metadata = pageMetadata({
   title: 'Charity Eligibility Check',
   description:
-    'Answer five quick questions and find out which free Free For Charity programs your nonprofit qualifies for — domain, email, website, or migration.',
+    'Answer a couple of quick questions to confirm your nonprofit qualifies for the Free For Charity program — one all-in package: a managed .org domain, Microsoft 365 email, and a professionally built website — then apply right here.',
   canonical: '/eligibility-check/',
 })
 
@@ -15,42 +16,21 @@ const config: WizardConfig = {
       id: 'org-status',
       prompt: 'What best describes your organization?',
       options: [
-        { label: 'A U.S. 501(c)(3) nonprofit in good standing', next: 'has-domain' },
+        { label: 'A U.S. 501(c)(3) nonprofit in good standing', next: 'outcome:qualified-501c3' },
         {
           label: 'A nonprofit working toward 501(c)(3) determination (pre-501c3)',
-          next: 'pre-domain',
+          next: 'pre-status',
         },
         { label: 'A for-profit business or individual', next: 'outcome:not-eligible' },
       ],
     },
     {
-      id: 'has-domain',
-      prompt: 'Does your organization have its own domain name (like yourcharity.org)?',
-      options: [
-        { label: 'No — we need one', next: 'outcome:full-onboarding' },
-        { label: 'Yes, and we manage it ourselves', next: 'has-site' },
-        { label: "Yes, but we're not sure who controls it", next: 'outcome:domain-rescue' },
-      ],
-    },
-    {
-      id: 'has-site',
-      prompt: 'What does your website situation look like?',
-      options: [
-        { label: "We don't have a website yet", next: 'outcome:site-build' },
-        {
-          label: 'We have an old site (WordPress or similar) that costs money or is fragile',
-          next: 'outcome:migration',
-        },
-        { label: 'Our site is fine — we need email or other help', next: 'outcome:email-tools' },
-      ],
-    },
-    {
-      id: 'pre-domain',
+      id: 'pre-status',
       prompt: 'Where are you in the formation process?',
       options: [
         {
           label: 'We have formation documents (articles of incorporation) and an EIN',
-          next: 'outcome:pre501c3',
+          next: 'outcome:qualified-pre501c3',
         },
         { label: "We're just getting started — no paperwork yet", next: 'outcome:too-early' },
       ],
@@ -58,69 +38,41 @@ const config: WizardConfig = {
   ],
   outcomes: [
     {
-      id: 'full-onboarding',
-      title: 'You qualify for the full program 🎉',
-      body: 'Free .org domain (we pay for it), free Microsoft 365 email at that domain, and a free website built by our volunteers. Start with the application, and gather the items on the checklist while you wait.',
+      id: 'qualified-501c3',
+      title: 'You qualify — apply now 🎉',
+      body: "Free For Charity is one all-in program, not a menu. When you join, we register and manage your .org domain, set up and run your Microsoft 365 email, and build and host your website — and we keep managing all of it for you. Apply below and we'll take it from there.",
+      actions: [
+        {
+          label: 'Apply as a 501(c)(3) charity',
+          href: hubAddProduct(ONBOARDING_PID.full501c3),
+          external: true,
+        },
+      ],
       links: [
-        { label: 'Apply via Help for Charities', href: '/help-for-charities/' },
         { label: 'See the onboarding journey', href: '/charity-onboarding-journey/' },
         { label: 'Getting-started checklist', href: '/getting-started-checklist/' },
       ],
     },
     {
-      id: 'domain-rescue',
-      title: 'Let’s secure that domain first',
-      body: "A domain nobody clearly controls is a ticking risk — if it lapses, your email and website go with it. We'll help you locate the registration, take over renewals (at our cost), and lock down DNS. Then everything else follows.",
-      links: [
-        { label: 'Who controls the domain? (domain guide)', href: '/choosing-your-org-domain/' },
-        { label: 'Security basics for charities', href: '/charity-security-guide/' },
-        { label: 'Contact us to start', href: '/contact-us/' },
-      ],
-    },
-    {
-      id: 'site-build',
-      title: 'You qualify for a free website build',
-      body: 'Our volunteers build charity sites on fast, secure static hosting — free, including ongoing maintenance. Since you already manage a domain, we can point it at the new site (or take over the domain costs too).',
-      links: [
-        { label: 'Apply via Help for Charities', href: '/help-for-charities/' },
+      id: 'qualified-pre501c3',
+      title: 'You qualify for pre-501(c)3 onboarding — apply now 🎉',
+      body: "You don't have to wait for IRS determination to look professional. Pre-501c3 onboarding is the same single, all-in program: we register and manage your .org domain, set up your Microsoft 365 email, and build and host your website — all managed by us — and we guide your path to full 501(c)(3) status. Apply below to get started.",
+      actions: [
         {
-          label: 'How FFC delivers services',
-          href: '/free-for-charity-ffc-service-delivery-stages/',
+          label: 'Apply as a pre-501(c)3 organization',
+          href: hubAddProduct(ONBOARDING_PID.pre501c3),
+          external: true,
         },
       ],
-    },
-    {
-      id: 'migration',
-      title: 'You qualify for a free migration',
-      body: 'We rebuild legacy WordPress (and similar) sites on modern static hosting — no hosting bill, no plugin updates, no hacks. Your content moves; your address stays.',
       links: [
-        { label: 'Start via Help for Charities', href: '/help-for-charities/' },
-        { label: 'Common questions (charity FAQ)', href: '/charity-faq/' },
-      ],
-    },
-    {
-      id: 'email-tools',
-      title: 'Free email and the tool stack',
-      body: "Microsoft grants qualified nonprofits free Microsoft 365 email — we handle the technical setup. While you're at it, claim Google Ad Grants and fee-free donations.",
-      links: [
-        { label: 'Free Microsoft 365 email guide', href: '/m365-email-guide/' },
-        { label: 'Google for Nonprofits & Ad Grants', href: '/google-for-nonprofits-guide/' },
-        { label: 'Fee-free donations with Zeffy', href: '/zeffy-donations-guide/' },
-      ],
-    },
-    {
-      id: 'pre501c3',
-      title: 'Pre-501c3 onboarding is made for you',
-      body: "You don't need to wait for IRS determination to look professional. We help pre-501c3 organizations get a domain and email now, and guide the path to full status.",
-      links: [
-        { label: 'Pre-501c3 onboarding', href: '/pre501c3/' },
+        { label: 'See the onboarding journey', href: '/charity-onboarding-journey/' },
         { label: 'Choosing your .org domain', href: '/choosing-your-org-domain/' },
       ],
     },
     {
       id: 'too-early',
       title: 'A little early — but here’s your roadmap',
-      body: 'Form the organization first (articles of incorporation + EIN). Once you have those, come straight back — pre-501c3 onboarding takes you from there.',
+      body: 'Form the organization first (articles of incorporation + EIN). Once you have those, come straight back and apply — pre-501c3 onboarding takes you the rest of the way into the full program.',
       links: [
         {
           label: 'What validation requires',
@@ -132,7 +84,7 @@ const config: WizardConfig = {
     {
       id: 'not-eligible',
       title: 'Our free programs are for nonprofits — but stay!',
-      body: "FFC's free services are reserved for 501(c)(3) and pre-501c3 organizations. If you're a business that wants to help, volunteers and donors are how this whole thing runs.",
+      body: "FFC's free services are reserved for 501(c)(3) and pre-501c3 organizations. If you're a business or individual who wants to help, volunteers and donors are how this whole thing runs.",
       links: [
         { label: 'Volunteer your skills', href: '/volunteer/' },
         { label: 'Support the mission', href: '/donate/' },
@@ -148,9 +100,14 @@ export default function EligibilityCheck() {
         <h1 className="font-[var(--font-faustina)] text-[48px] leading-[60px] mb-4">
           Does Your Charity Qualify?
         </h1>
+        <p className="font-[var(--font-lato)] text-[18px] leading-[28px] text-[#555] mb-4">
+          Free For Charity is a single, all-in program. When your charity joins, we register and
+          manage your domain, run your Microsoft 365 email, and build and host your website — one
+          committed journey we manage end to end, not a set of services to pick from.
+        </p>
         <p className="font-[var(--font-lato)] text-[18px] leading-[28px] text-[#555] mb-8">
-          Five quick questions, no forms, no email required — just an honest answer about which free
-          programs fit your organization and what to do next.
+          Answer a couple of quick questions to confirm you qualify, then apply right here — no
+          forms, no email required to check.
         </p>
         <DecisionWizard config={config} />
       </div>

--- a/src/components/wizards/DecisionWizard.tsx
+++ b/src/components/wizards/DecisionWizard.tsx
@@ -102,7 +102,7 @@ export default function DecisionWizard({ config }: { config: WizardConfig }) {
             {outcome.actions.map((action) =>
               action.external ? (
                 <a
-                  key={action.href}
+                  key={`${action.href}:${action.label}`}
                   href={action.href}
                   target="_blank"
                   rel="noopener noreferrer"
@@ -111,10 +111,11 @@ export default function DecisionWizard({ config }: { config: WizardConfig }) {
                     transition-colors hover:bg-[#045a9b]"
                 >
                   {action.label}
+                  <span className="sr-only"> (opens in a new tab)</span>
                 </a>
               ) : (
                 <Link
-                  key={action.href}
+                  key={`${action.href}:${action.label}`}
                   href={action.href}
                   className="inline-flex items-center justify-center rounded-lg bg-[#0567B1] px-6 py-3
                     font-[var(--font-lato)] text-[17px] font-[700] text-white

--- a/src/components/wizards/DecisionWizard.tsx
+++ b/src/components/wizards/DecisionWizard.tsx
@@ -10,11 +10,24 @@ import Link from 'next/link'
  * (each answer is a native button; back/restart are buttons too).
  */
 
+export interface WizardAction {
+  label: string
+  href: string
+  /** Opens in a new tab (e.g. the WHMCS hub application forms). */
+  external?: boolean
+}
+
 export interface WizardOutcome {
   id: string
   title: string
   body: string
-  links: { label: string; href: string }[]
+  /**
+   * Prominent call-to-action buttons — the application buttons an eligible
+   * outcome converges on. Rendered as filled buttons above the secondary links.
+   */
+  actions?: WizardAction[]
+  /** Secondary, informational links rendered under the actions. */
+  links?: { label: string; href: string }[]
 }
 
 export interface WizardOption {
@@ -84,18 +97,49 @@ export default function DecisionWizard({ config }: { config: WizardConfig }) {
         <p className="font-[var(--font-lato)] text-[17px] leading-[27px] text-[#555] mb-4">
           {outcome.body}
         </p>
-        <ul className="space-y-2 mb-6">
-          {outcome.links.map((link) => (
-            <li key={link.href}>
-              <Link
-                href={link.href}
-                className="font-[var(--font-lato)] text-[17px] font-[600] text-[#0567B1] underline"
-              >
-                {link.label} →
-              </Link>
-            </li>
-          ))}
-        </ul>
+        {outcome.actions?.length ? (
+          <div className="flex flex-col sm:flex-row flex-wrap gap-3 mb-6">
+            {outcome.actions.map((action) =>
+              action.external ? (
+                <a
+                  key={action.href}
+                  href={action.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center justify-center rounded-lg bg-[#0567B1] px-6 py-3
+                    font-[var(--font-lato)] text-[17px] font-[700] text-white
+                    transition-colors hover:bg-[#045a9b]"
+                >
+                  {action.label}
+                </a>
+              ) : (
+                <Link
+                  key={action.href}
+                  href={action.href}
+                  className="inline-flex items-center justify-center rounded-lg bg-[#0567B1] px-6 py-3
+                    font-[var(--font-lato)] text-[17px] font-[700] text-white
+                    transition-colors hover:bg-[#045a9b]"
+                >
+                  {action.label}
+                </Link>
+              )
+            )}
+          </div>
+        ) : null}
+        {outcome.links?.length ? (
+          <ul className="space-y-2 mb-6">
+            {outcome.links.map((link) => (
+              <li key={link.href}>
+                <Link
+                  href={link.href}
+                  className="font-[var(--font-lato)] text-[17px] font-[600] text-[#0567B1] underline"
+                >
+                  {link.label} →
+                </Link>
+              </li>
+            ))}
+          </ul>
+        ) : null}
         <button
           type="button"
           onClick={restart}

--- a/src/data/guides.json
+++ b/src/data/guides.json
@@ -103,7 +103,7 @@
     {
       "href": "/eligibility-check/",
       "title": "Does your charity qualify? (2-minute check)",
-      "promise": "Five questions, no forms — which free FFC programs fit your organization.",
+      "promise": "A couple of questions, no forms — confirm you qualify for the all-in FFC program, then apply.",
       "group": "Getting started",
       "minutes": 2
     },

--- a/src/data/search-index.json
+++ b/src/data/search-index.json
@@ -141,7 +141,7 @@
     },
     {
       "title": "Charity Eligibility Check",
-      "description": "Answer five quick questions and find out which free Free For Charity programs your nonprofit qualifies for — domain, email, website, or migration.",
+      "description": "Answer a couple of quick questions to confirm your nonprofit qualifies for the Free For Charity program — one all-in package: a managed .org domain, Microsoft 365 email, and a professionally built website — then apply right here.",
       "href": "/eligibility-check/",
       "type": "page"
     },

--- a/tests/wizards.spec.ts
+++ b/tests/wizards.spec.ts
@@ -6,15 +6,25 @@ import { test, expect } from '@playwright/test'
  */
 
 test.describe('Charity eligibility check', () => {
-  test('501c3 with no domain reaches the full-onboarding outcome', async ({ page }) => {
+  test('a 501c3 qualifies and lands directly on the application button', async ({ page }) => {
     await page.goto('/eligibility-check/')
     await page.getByRole('button', { name: /501\(c\)\(3\) nonprofit in good standing/ }).click()
-    await page.getByRole('button', { name: /No — we need one/ }).click()
-    await expect(page.getByText('You qualify for the full program')).toBeVisible()
-    await expect(page.getByRole('link', { name: /Apply via Help for Charities/ })).toHaveAttribute(
-      'href',
-      '/help-for-charities/'
-    )
+    // Single committed journey: no à la carte domain/website/email branches —
+    // an eligible org goes straight to the on-page apply button.
+    await expect(page.getByText(/You qualify — apply now/)).toBeVisible()
+    await expect(
+      page.getByRole('link', { name: /Apply as a 501\(c\)\(3\) charity/ })
+    ).toHaveAttribute('href', /cart\.php\?a=add&pid=33/)
+  })
+
+  test('a pre-501c3 with paperwork reaches the pre-501c3 application button', async ({ page }) => {
+    await page.goto('/eligibility-check/')
+    await page.getByRole('button', { name: /working toward 501\(c\)\(3\) determination/ }).click()
+    await page.getByRole('button', { name: /formation documents/ }).click()
+    await expect(page.getByText(/pre-501\(c\)3 onboarding — apply now/)).toBeVisible()
+    await expect(
+      page.getByRole('link', { name: /Apply as a pre-501\(c\)3 organization/ })
+    ).toHaveAttribute('href', /cart\.php\?a=add&pid=16/)
   })
 
   test('for-profit reaches the not-eligible outcome and can start over', async ({ page }) => {


### PR DESCRIPTION
## Summary

Reworks `/eligibility-check/` so it matches how Free For Charity actually works: **a single, all-in program, not a menu.** When a charity joins, FFC registers and manages the domain, runs Microsoft 365 email, and builds and hosts the website — and keeps managing all of it. The old wizard offered à la carte paths FFC doesn't support (self-manage your own domain and get only a website; keep your site and get only email), and it routed people off-page to *find* how to apply. Now every eligible answer converges on the real application buttons, right on the page.

## Problems fixed

- **Removed unsupported options.** Deleted the domain-ownership branch (incl. "Yes, and we manage it ourselves"), the website-situation branch ("we need email or other help", legacy-site migration), and their à la carte outcomes (`site-build`, `migration`, `email-tools`, `domain-rescue`). These implied you could pick individual services.
- **One committed journey.** The only remaining branch is *applicant type*. Intro copy now states plainly that FFC manages domain + email + website end to end as one journey.
- **All roads lead to the application buttons, on the page.** Eligible outcomes lead with a prominent apply button instead of sending people to `/help-for-charities/` to hunt for it:
  - 501(c)(3) in good standing → **Apply as a 501(c)(3) charity** (WHMCS onboarding `pid=33`)
  - pre-501c3 with articles + EIN → **Apply as a pre-501(c)3 organization** (`pid=16`)
  - "just getting started" → roadmap to form the org, then come back
  - for-profit / individual → volunteer & donor paths

## Changes

- `src/app/eligibility-check/page.tsx` — new two-question flow; outcomes carry real apply buttons via `hubAddProduct(ONBOARDING_PID.*)`; rewritten intro emphasizing the all-in commitment.
- `src/components/wizards/DecisionWizard.tsx` — new optional `actions` on an outcome (prominent buttons, `external` opens in a new tab for the hub forms) rendered above the secondary `links`; `links` is now optional. Backward compatible with the volunteer quiz.
- `src/data/search-index.json`, `src/data/guides.json` — descriptions updated from "which programs fit / five questions" to the single all-in program.
- `tests/wizards.spec.ts` — updated the eligibility e2e for the new flow (501c3 → pid 33 button; pre-501c3 → pid 16 button; for-profit → not-eligible + start-over).

## Verification

- `npm run lint` — clean
- `npm run build` — static export succeeds
- `npm run test` — 596 jest tests pass (596/596)
- Verified against the built page: the new "You qualify — apply now" copy and both apply URLs (`pid=33`, `pid=16`) are bundled, and the removed branches (`site-build`, `domain-rescue`, "manage it ourselves", "need email or other help", "free migration") are gone (0 occurrences).

Refs #367 #397

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JrqnLULSB1GYoiKYDQVA8T)_