### PR TITLE
feat: redesign homepage Our Programs into a projects showcase

### DIFF
--- a/src/components/home-page/Our-Programs/index.tsx
+++ b/src/components/home-page/Our-Programs/index.tsx
@@ -2,252 +2,241 @@ import React from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
 import OrangeFaqItem from '@/components/ui/OrangeFaqItem'
-import AdminGuideLink from '@/components/ui/AdminGuideLink'
-import { adminLinks, ffcAdminUrl } from '@/data/admin-links'
 import { assetPath } from '@/lib/assetPath'
+
+/**
+ * Homepage "Our Programs" showcase. Speaks to both audiences the homepage
+ * serves: charities looking for services, and donors who fund them. Each of the
+ * three FFC programs is a self-contained card — icon, one-line value prop, the
+ * value accordions (leading with the charity/donor benefit, then the reciprocal
+ * "For us" so the transparency is intact), and a single clear CTA to its page.
+ */
+
+interface ValueItem {
+  title: string
+  /** The benefit to the charity/donor — always shown first. */
+  forYou: string
+  /** How Free For Charity benefits — the reciprocal, transparent half. */
+  forUs?: string
+}
+
+interface Project {
+  icon: string
+  name: string
+  valueProp: string
+  href: string
+  ctaLabel: string
+  items: ValueItem[]
+}
+
+const projects: Project[] = [
+  {
+    icon: '/Svgs/FFC-Domains.svg',
+    name: 'FFC Domains',
+    valueProp:
+      'Free .org domain names, Microsoft 365 email, and Teams for verified 501(c)(3) charities — registered and managed for you.',
+    href: '/domains/',
+    ctaLabel: 'Explore FFC Domains',
+    items: [
+      {
+        title: '.org Domain Registration',
+        forYou:
+          "A .org name boosts your charity's credibility, trustworthiness, and online presence — making it easier to attract donors and supporters.",
+        forUs:
+          'Managing every charity domain in one place lets us keep them secure and automatically renewed.',
+      },
+      {
+        title: 'Cloudflare DNS',
+        forYou: 'Faster website load times and enhanced security.',
+        forUs: 'Centralized management and automation tools.',
+      },
+      {
+        title: 'Charity Email Address',
+        forYou:
+          'A professional address (e.g. yourname@yourcharity.org) builds trust with donors, volunteers, and stakeholders.',
+        forUs:
+          'Professional email keeps our platform secure and gives volunteers a reliable way to support you.',
+      },
+      {
+        title: 'Microsoft 365',
+        forYou: 'Professional email and collaboration tools.',
+        forUs: 'Streamlined communication and support processes.',
+      },
+    ],
+  },
+  {
+    icon: '/Svgs/FFC-Hosting.svg',
+    name: 'FFC Hosting',
+    valueProp:
+      'Free, fast, secure websites on GitHub Pages — built for your charity by AI development agents (Claude and GitHub Copilot).',
+    href: '/free-charity-web-hosting/',
+    ctaLabel: 'Explore FFC Hosting',
+    items: [
+      {
+        title: 'GitHub Pages Hosting',
+        forYou:
+          'Free, reliable static-site hosting with automatic HTTPS and custom-domain support.',
+        forUs: 'Simplified deployment and maintenance with version-controlled websites.',
+      },
+      {
+        title: 'GitHub Copilot AI Development',
+        forYou:
+          'Professional, modern websites built with AI-assisted development for faster delivery.',
+        forUs: 'Efficient website creation and consistent code quality across every charity.',
+      },
+      {
+        title: 'Static Site Architecture',
+        forYou: 'Fast-loading, secure websites with no server maintenance required.',
+        forUs: 'Zero hosting costs and fewer security vulnerabilities for partner organizations.',
+      },
+      {
+        title: 'Modern Web Technologies',
+        forYou: 'Beautiful, responsive websites built with React, Next.js, and Tailwind CSS.',
+        forUs: 'A standardized stack that makes support and volunteer training efficient.',
+      },
+    ],
+  },
+  {
+    icon: '/Svgs/FFC-Consulting.svg',
+    name: 'FFC Consulting',
+    valueProp:
+      'Introductions to the trusted partners and services that help your charity do more with less.',
+    href: '/consulting/',
+    ctaLabel: 'Explore FFC Consulting',
+    items: [
+      {
+        title: 'Northwest Registered Agent',
+        forYou:
+          'Stay compliant with state requirements — registered-agent service, nonprofit incorporation, and your initial IRS charity application.',
+        forUs:
+          'We help charities meet legal requirements and train volunteers on formation and IRS filings.',
+      },
+      {
+        title: 'Idealist.org / VolunteerMatch.org',
+        forYou: 'Access to a large pool of potential volunteers.',
+        forUs: 'Validation of your active community engagement.',
+      },
+      {
+        title: 'TechSoup.org',
+        forYou: 'Access to discounted software and technology resources.',
+        forUs: 'Additional validation of your nonprofit status.',
+      },
+      {
+        title: 'PayPal / Zeffy',
+        forYou: 'Easy, secure online donation processing.',
+        forUs: 'A standardized financial-transaction system across all partners.',
+      },
+    ],
+  },
+]
+
+const ValueItemBody = ({ item }: { item: ValueItem }) => (
+  <div className="space-y-3">
+    <p>
+      <span className="font-[700] text-[#2A6682]">For you:</span> {item.forYou}
+    </p>
+    {item.forUs ? (
+      <p className="text-[#555]">
+        <span className="font-[700] text-[#b35000]">For us:</span> {item.forUs}
+      </p>
+    ) : null}
+  </div>
+)
+
+const ProjectShowcase = ({ project }: { project: Project }) => (
+  <div className="bg-white rounded-[16px] shadow-[0px_2px_18px_0px_rgba(0,0,0,0.12)] border border-[#eef2f6] p-[28px] lg:p-[40px]">
+    {/* Header: icon + name + value prop + primary CTA */}
+    <div className="flex flex-col lg:flex-row lg:items-center gap-[24px] lg:gap-[32px] mb-[32px]">
+      <div className="flex items-center gap-[20px] flex-1">
+        <div className="flex-shrink-0 w-[88px] h-[88px] flex items-center justify-center p-2 bg-[#2A6682] rounded-full">
+          <div className="relative w-[50px] h-[50px]">
+            <Image src={assetPath(project.icon)} alt={`${project.name} icon`} fill />
+          </div>
+        </div>
+        <div>
+          <h3 className="text-[30px] lg:text-[36px] font-[400] leading-tight" data-font="lato-font">
+            {project.name}
+          </h3>
+          <p
+            className="mt-[6px] text-[19px] lg:text-[21px] font-[400] text-[#333]"
+            data-font="lato-font"
+          >
+            {project.valueProp}
+          </p>
+        </div>
+      </div>
+      <Link
+        href={project.href}
+        className="inline-flex items-center justify-center gap-[8px] rounded-[12px] bg-[#2A6682] px-[24px] py-[14px] text-[18px] font-[500] text-white transition-colors hover:bg-[#1f4f63] whitespace-nowrap self-start lg:self-auto"
+        data-font="lato-font"
+      >
+        <span>{project.ctaLabel}</span>
+        <span aria-hidden="true">→</span>
+      </Link>
+    </div>
+
+    {/* Value accordions */}
+    <div>
+      {project.items.map((item) => (
+        <OrangeFaqItem key={item.title} title={item.title}>
+          <ValueItemBody item={item} />
+        </OrangeFaqItem>
+      ))}
+    </div>
+  </div>
+)
 
 const index = () => {
   return (
     <div id="programs" className="py-[52px]">
-      <div className="w-[90%] lg:px-[20px] mx-auto">
+      <div className="w-[90%] lg:px-[20px] mx-auto max-w-[1200px]">
         <h2
-          className="font-[400] text-[40px] lg:text-[48px]  tracking-[0] text-center mx-auto mb-[50px]"
+          className="font-[400] text-[40px] lg:text-[48px] tracking-[0] text-center mx-auto mb-[16px]"
           data-font="faustina-font"
         >
-          Help for Charities
+          Our Programs
         </h2>
+        <p
+          className="text-[20px] lg:text-[22px] font-[400] text-center text-[#444] max-w-[860px] mx-auto mb-[50px]"
+          data-font="lato-font"
+        >
+          Three programs give nonprofits the tools most charities pay dearly for — and give donors a
+          direct, transparent way to power real impact. Here&apos;s what each delivers, and how it
+          works for everyone involved.
+        </p>
 
-        <div className="lg:pl-[50px]">
-          <div className="mb-[40px]  flex items-center gap-[20px]">
-            <div className="w-[100px] flex items-center justify-center p-2 h-[100px] bg-[#2A6682] rounded-full">
-              <div className="relative w-[56px] h-[56px]">
-                <Image src={assetPath('/Svgs/FFC-Domains.svg')} alt="FFC-Domains" fill></Image>
-              </div>
-            </div>
-            <h3 className="text-[36px] font-[400] " data-font="lato-font">
-              FFC Domains
-            </h3>
-          </div>
-          <p className="text-[25px] font-[400] " data-font="lato-font">
-            Provides free .org domain names, Microsoft 365 with Outlook email, & Microsoft Teams to
-            501c3 charities.
-          </p>
-          <Link
-            href="/domains/"
-            className="inline-flex items-center gap-[8px] mt-[16px] text-[20px] font-[500] text-[#b35000] hover:underline"
-            data-font="lato-font"
-          >
-            <span>Learn more about FFC Domains</span>
-            <span aria-hidden="true">→</span>
-          </Link>
+        <div className="space-y-[32px]">
+          {projects.map((project) => (
+            <ProjectShowcase key={project.name} project={project} />
+          ))}
         </div>
 
-        {/* faqs  */}
-        <div>
-          <OrangeFaqItem title=".org Domain Registration">
-            <ul className="list-disc list-inside">
-              <li className="">
-                For You: Leverage a .org domain name to enhance your charitys credibility,
-                trustworthiness, and online presence, making it easier to attract donors and
-                supporters
-              </li>
-            </ul>
-          </OrangeFaqItem>
-          <OrangeFaqItem title="Cloudflare DNS">
-            <ul className="list-disc list-inside">
-              <li className="">For You: Faster website load times and enhanced security</li>
-              <li className="">For Us: Centralized management and automation tools.</li>
-            </ul>
-          </OrangeFaqItem>
-          <OrangeFaqItem title="Charity Email Address">
-            <ul className="list-disc list-inside">
-              <li className="">
-                For You: Using a charity email address (e.g., yourname@yourcharity.org) enhances
-                your organizations credibility and professionalism, making it easier to build trust
-                with donors, volunteers, and stakeholders
-              </li>
-              <li className="">
-                For Us: We benefit by ensuring charities use professional email addresses, which
-                helps maintain our servers integrity and provides a more secure and reliable
-                communication platform for our volunteers
-              </li>
-            </ul>
-          </OrangeFaqItem>
-          <OrangeFaqItem title="Microsoft 365">
-            <ul className="list-disc list-inside">
-              <li className="">For You: Professional email and collaboration tools</li>
-              <li className="">For Us: Streamlined communication and support processes</li>
-            </ul>
-          </OrangeFaqItem>
-        </div>
-
-        <div className="mt-[60px]">
-          <div className="lg:pl-[50px] mb-[40px]  flex items-center gap-[20px]">
-            <div className="w-[100px] flex items-center justify-center p-2 h-[100px] bg-[#2A6682] rounded-full">
-              <div className="relative w-[56px] h-[56px]">
-                <Image src={assetPath('/Svgs/FFC-Hosting.svg')} alt="FFC-Domains" fill></Image>
-              </div>
-            </div>
-            <h3 className="text-[36px] font-[400]  " data-font="lato-font">
-              FFC Hosting
-            </h3>
-          </div>
-          <p className="text-[25px] font-[400]  " data-font="lato-font">
-            Free static-site hosting for nonprofits on GitHub Pages, with modern websites built by
-            AI development agents (Claude and GitHub Copilot):
-          </p>
-          <Link
-            href="/free-charity-web-hosting/"
-            className="inline-flex items-center gap-[8px] mt-[16px] text-[20px] font-[500] text-[#b35000] hover:underline"
-            data-font="lato-font"
-          >
-            <span>Learn more about FFC Hosting</span>
-            <span aria-hidden="true">→</span>
-          </Link>
-        </div>
-
-        {/* faqs  */}
-        <div>
-          <OrangeFaqItem title="GitHub Pages Hosting">
-            <ul className="list-disc list-inside">
-              <li className="">
-                For You: Free, reliable static site hosting with automatic HTTPS and custom domain
-                support
-              </li>
-              <li className="">
-                For Us: Simplified deployment and maintenance with version-controlled websites
-              </li>
-            </ul>
-          </OrangeFaqItem>
-          <OrangeFaqItem title="GitHub Copilot AI Development">
-            <ul className="list-disc list-inside">
-              <li className="">
-                For You: Professional, modern websites built using AI-assisted development for
-                faster delivery
-              </li>
-              <li className="">
-                For Us: Efficient website creation and consistent code quality across all charity
-                projects
-              </li>
-            </ul>
-          </OrangeFaqItem>
-          <OrangeFaqItem title="Static Site Architecture">
-            <ul className="list-disc list-inside">
-              <li className="">
-                For You: Fast-loading, secure websites with no server maintenance required
-              </li>
-              <li className="">
-                For Us: Zero hosting costs and reduced security vulnerabilities for partner
-                organizations
-              </li>
-            </ul>
-          </OrangeFaqItem>
-          <OrangeFaqItem title="Modern Web Technologies">
-            <ul className="list-disc list-inside">
-              <li className="">
-                For You: Beautiful, responsive websites built with React, Next.js, and Tailwind CSS
-              </li>
-              <li className="">
-                For Us: Standardized tech stack enabling efficient support and training for our
-                volunteers
-              </li>
-            </ul>
-          </OrangeFaqItem>
-        </div>
-
-        <div className="lg:pl-[50px] mt-[24px] max-w-[680px]">
-          <AdminGuideLink
-            href={ffcAdminUrl(adminLinks['build-from-template'].newModel)}
-            description="Ready to build? Charities and volunteers follow the full step-by-step site build on the FFC Admin portal."
-          />
-        </div>
-
-        <div className="mt-[60px]">
-          <div className="lg:pl-[50px] mb-[40px]  flex items-center gap-[20px]">
-            <div className="w-[100px] flex items-center justify-center p-2 h-[100px] bg-[#2A6682] rounded-full">
-              <div className="relative w-[56px] h-[56px]">
-                <Image src={assetPath('/Svgs/FFC-Consulting.svg')} alt="FFC-Domains" fill></Image>
-              </div>
-            </div>
-            <h3 className="text-[36px] font-[400]  " data-font="lato-font">
-              FFC Consulting
-            </h3>
-          </div>
-          <p className="text-[25px] font-[400]  " data-font="lato-font">
-            FFC Consulting is about helping charities get the most out of their digital
-            infrastructure including from other charities for charities like ours or from partners.
-            We introduce charities to each major service that supports the charity mission of our
-            sponsored organizations. We benefit when you use these services as well as your
-            organization benefiting.
-          </p>
-          <Link
-            href="/consulting/"
-            className="inline-flex items-center gap-[8px] mt-[16px] text-[20px] font-[500] text-[#b35000] hover:underline"
-            data-font="lato-font"
-          >
-            <span>Learn more about FFC Consulting</span>
-            <span aria-hidden="true">→</span>
-          </Link>
-        </div>
-
-        {/* faqs  */}
-        <div>
-          <OrangeFaqItem title="Northwest Registered Agent">
-            <ul className="list-disc list-inside">
-              <li className="">
-                For You: Leverage Northwest Registered Agents services to maintain compliance with
-                state requirements, including registered agent services, nonprofit corporation
-                filing, and initial charity IRS application.
-              </li>
-              <li className="">
-                For Us: Efficiently support charities by ensuring they meet legal requirements and
-                train our volunteers on managing compliance, business formation processes, and IRS
-                applications.
-              </li>
-            </ul>
-          </OrangeFaqItem>
-          <OrangeFaqItem title="Idealist.org / VolunteerMatch.org">
-            <ul className="list-disc list-inside">
-              <li className="">For You: Access to a large pool of potential volunteers</li>
-              <li className="">For Us: Validation of your active community engagement</li>
-            </ul>
-          </OrangeFaqItem>
-          <OrangeFaqItem title="TechSoup.org">
-            <ul className="list-disc list-inside">
-              <li className="">For You: Access to discounted software and technology resources</li>
-              <li className="">For Us: Additional validation of your non-profit status</li>
-            </ul>
-          </OrangeFaqItem>
-          <OrangeFaqItem title="PayPal / Zeffy">
-            <ul className="list-disc list-inside">
-              <li className="">For You: Easy, secure online donation processing</li>
-              <li className="">
-                For Us: Standardized financial transaction system for all partners
-              </li>
-            </ul>
-          </OrangeFaqItem>
-        </div>
-
-        <div className="lg:w-[90%] mx-auto text-center pb-[54px] pt-[20px]">
-          <h3 className="text-[36px] font-[400] pt-[22px] pb-[30px]" data-font="lato-font">
-            Ready to Get Started Now?
+        {/* Two-audience CTA: charities apply, donors fund */}
+        <div className="mt-[60px] text-center">
+          <h3 className="text-[30px] lg:text-[36px] font-[400] pb-[10px]" data-font="lato-font">
+            Ready to get involved?
           </h3>
-
-          <div className="flex flex-col lg:flex-row items-center justify-between gap-o sm:gap-6 w-[100%] gap-[20px]">
-            <a
-              href="/501c3/"
-              className="rounded-[20px] border-[5px] border-[#2A6682] flex items-center justify-center text-black font-[400] text-[25px] px-[28px] py-[16px]"
+          <p
+            className="text-[19px] font-[400] text-[#444] max-w-[680px] mx-auto mb-[30px]"
+            data-font="lato-font"
+          >
+            Run a nonprofit, or want to help power these programs? Pick your path.
+          </p>
+          <div className="flex flex-col sm:flex-row items-center justify-center gap-[20px]">
+            <Link
+              href="/eligibility-check/"
+              className="inline-flex items-center justify-center rounded-[16px] bg-[#2A6682] px-[32px] py-[18px] text-[22px] font-[400] text-white transition-colors hover:bg-[#1f4f63]"
               data-font="lato-font"
             >
-              501 (c)3 Charities Click Here To Get Started!
-            </a>
-            <a
-              href="/pre501c3/"
-              className="rounded-[20px] border-[5px] border-[#2A6682] flex items-center justify-center text-black font-[400] text-[25px] px-[28px] py-[16px]"
+              Check your charity&apos;s eligibility
+            </Link>
+            <Link
+              href="/donate/"
+              className="inline-flex items-center justify-center rounded-[16px] border-[3px] border-[#b35000] px-[32px] py-[16px] text-[22px] font-[400] text-[#b35000] transition-colors hover:bg-[#b35000] hover:text-white"
               data-font="lato-font"
             >
-              Pre-501 (c)3 Charities Click Here To Get Started!
-            </a>
+              Donate to fund these programs
+            </Link>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Redesigns the homepage programs section (`Our-Programs`, `id="programs"`) so it reads as a clean **projects showcase** instead of a long, "linky" wall of text — while keeping the value story intact and speaking to **both** homepage audiences: charities and donors.

## Problem

The old section was cluttered and process-heavy: each of the three programs had a paragraph, a scattered "Learn more" link, four accordions, an admin link, and then a shared pair of raw `/501c3/` `/pre501c3/` onboarding buttons. It buried the value, read as a link dump, and only addressed charities even though the homepage also talks to donors.

## Changes

- **Each program is now a self-contained card** — icon, name, a strong one-line value prop, its value accordions, and **one clear CTA** to its project page (`/domains/`, `/free-charity-web-hosting/`, `/consulting/`).
- **Kept the value accordions and both halves**, but now **lead with "For you:"** (the charity/donor benefit) and follow with the reciprocal, transparent **"For us:"**.
- **Speaks to two audiences.** The intro frames the programs for charities *and* donors, and the closing CTA offers two clear paths — **Check your charity's eligibility** (`/eligibility-check/`) and **Donate to fund these programs** (`/donate/`) — replacing the raw onboarding button pair.
- **Cut the scattered inline links** and routed everything through `next/link` (basePath-safe).

Aligns the homepage with the recently redesigned hosting, eligibility, and domains pages.

## Verification

- `npm run lint` — clean
- `npm run build` — static export succeeds
- `npm run test` — 594 jest tests pass (all suites)
- Verified against the built homepage: `id="programs"` present; all three programs render with their "For you:" / "For us:" value content; per-project CTAs and both the eligibility and donate CTAs present; the old raw "Click Here To Get Started" buttons are gone.

Note: the "Help for Charities" header nav item is unchanged — only this homepage section's own heading/content changed.

Refs #455

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JrqnLULSB1GYoiKYDQVA8T)_