### PR TITLE
feat: on-page apply + "Help me choose" on help-for-charities

### DIFF
--- a/__tests__/components/ui/apply-options.test.tsx
+++ b/__tests__/components/ui/apply-options.test.tsx
@@ -18,23 +18,24 @@ describe('ApplyOptions', () => {
     for (const h of hrefs) expect(h).not.toContain('confproduct')
   })
 
-  it('opens the "Help me choose" panel and reveals a recommendation inline', () => {
+  it('offers the "Help me choose" guide and reveals a recommendation on choice', () => {
     render(<ApplyOptions />)
-    // Panel is collapsed until requested.
-    expect(screen.queryByText(/Which best describes your organization/i)).not.toBeInTheDocument()
+    // The native <details> disclosure and its single-choice question exist.
+    expect(
+      screen.getByRole('group', { name: /Which best describes your organization/i })
+    ).toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: /Help me choose/i }))
-    expect(screen.getByText(/Which best describes your organization/i)).toBeInTheDocument()
+    // No recommendation until an answer is chosen.
+    expect(screen.queryByText(/use this application/i)).not.toBeInTheDocument()
 
     // Picking the determination-letter answer recommends the 501(c)(3) path.
     fireEvent.click(screen.getByRole('radio', { name: /determination letter/i }))
     expect(screen.getByText(/use this application/i)).toBeInTheDocument()
   })
 
-  it('has no axe violations, collapsed and expanded', async () => {
+  it('has no axe violations before and after choosing', async () => {
     const { container } = render(<ApplyOptions />)
     expect(await axe(container)).toHaveNoViolations()
-    fireEvent.click(screen.getByRole('button', { name: /Help me choose/i }))
     fireEvent.click(screen.getByRole('radio', { name: /determination letter/i }))
     expect(await axe(container)).toHaveNoViolations()
   }, 30000)

--- a/__tests__/components/ui/apply-options.test.tsx
+++ b/__tests__/components/ui/apply-options.test.tsx
@@ -1,0 +1,41 @@
+/**
+ * ApplyOptions — the reusable on-page apply block used on the charity funnel
+ * pages. Guards the two critical outbound onboarding links (pid 33 / pid 16),
+ * the inline "Help me choose" panel behaviour, and component-level a11y.
+ */
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { axe } from '../../utils/axe'
+import ApplyOptions from '@/components/ui/ApplyOptions'
+
+describe('ApplyOptions', () => {
+  it('renders both apply links to the stable WHMCS onboarding products', () => {
+    render(<ApplyOptions />)
+    const hrefs = screen.getAllByRole('link').map((a) => a.getAttribute('href') ?? '')
+    expect(hrefs.some((h) => h.includes('a=add&pid=33'))).toBe(true) // full 501(c)(3)
+    expect(hrefs.some((h) => h.includes('a=add&pid=16'))).toBe(true) // pre-501(c)3
+    for (const h of hrefs) expect(h).not.toContain('confproduct')
+  })
+
+  it('opens the "Help me choose" panel and reveals a recommendation inline', () => {
+    render(<ApplyOptions />)
+    // Panel is collapsed until requested.
+    expect(screen.queryByText(/Which best describes your organization/i)).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /Help me choose/i }))
+    expect(screen.getByText(/Which best describes your organization/i)).toBeInTheDocument()
+
+    // Picking the determination-letter answer recommends the 501(c)(3) path.
+    fireEvent.click(screen.getByRole('button', { name: /determination letter/i }))
+    expect(screen.getByText(/use this application/i)).toBeInTheDocument()
+  })
+
+  it('has no axe violations, collapsed and expanded', async () => {
+    const { container } = render(<ApplyOptions />)
+    expect(await axe(container)).toHaveNoViolations()
+    fireEvent.click(screen.getByRole('button', { name: /Help me choose/i }))
+    fireEvent.click(screen.getByRole('button', { name: /determination letter/i }))
+    expect(await axe(container)).toHaveNoViolations()
+  }, 30000)
+})

--- a/__tests__/components/ui/apply-options.test.tsx
+++ b/__tests__/components/ui/apply-options.test.tsx
@@ -27,7 +27,7 @@ describe('ApplyOptions', () => {
     expect(screen.getByText(/Which best describes your organization/i)).toBeInTheDocument()
 
     // Picking the determination-letter answer recommends the 501(c)(3) path.
-    fireEvent.click(screen.getByRole('button', { name: /determination letter/i }))
+    fireEvent.click(screen.getByRole('radio', { name: /determination letter/i }))
     expect(screen.getByText(/use this application/i)).toBeInTheDocument()
   })
 
@@ -35,7 +35,7 @@ describe('ApplyOptions', () => {
     const { container } = render(<ApplyOptions />)
     expect(await axe(container)).toHaveNoViolations()
     fireEvent.click(screen.getByRole('button', { name: /Help me choose/i }))
-    fireEvent.click(screen.getByRole('button', { name: /determination letter/i }))
+    fireEvent.click(screen.getByRole('radio', { name: /determination letter/i }))
     expect(await axe(container)).toHaveNoViolations()
   }, 30000)
 })

--- a/src/app/help-for-charities/page.tsx
+++ b/src/app/help-for-charities/page.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import HeroSection from '@/components/ui/HeroSection'
 import HelpForCharities from '@/components/ui/help-for-charity'
 import AccordionSection from '@/components/help-for-charities-components/AccordianSection'
-import ReadyToGetStarted from '@/components/help-for-charities-components/Ready-to-Get-Started-Now'
+import ApplyOptions from '@/components/ui/ApplyOptions'
 import CharityNonprofitDirectorFaq from '@/components/ui/Charity-Nonprofit-Director-Faq'
 import CallSection from '@/components/help-for-charities-components/call-section'
 import AdminGuideLink from '@/components/ui/AdminGuideLink'
@@ -12,7 +12,7 @@ import { adminLinks, ffcAdminUrl } from '@/data/admin-links'
 export const metadata = pageMetadata({
   title: 'Help for Charities',
   description:
-    'Resources and support for charity and nonprofit directors. Get instant access to free tools, domains, hosting, and technology services from Free For Charity.',
+    'Free For Charity gives verified nonprofits a complete online presence—a managed website, .org domain, and Microsoft 365 email—plus the tools, directories, and hands-on help to run leaner. Start even while pending 501(c)(3) status.',
   canonical: '/help-for-charities/',
 })
 
@@ -21,9 +21,27 @@ const index = () => {
     <div className="bg-[#FCFCFC]">
       <HeroSection
         heading="Help For Charities"
-        paragraph="If you are representing a charity or you currently work for a charity and want to improve your own skills start here to get help for your organization. You get instant access to many of our free tools and products right away!"
+        paragraph="Free For Charity gives verified nonprofits a complete online presence—a managed website, .org domain, and Microsoft 365 email—plus the tools, directories, and hands-on help to run leaner. You can start even while you're still pending 501(c)(3) status."
         heroImg="/Images/volunteer.webp"
       />
+
+      {/* On-page CTAs — no separate wizard page to bounce out to. */}
+      <div className="w-[90%] max-w-[860px] mx-auto mt-[36px] flex flex-col sm:flex-row items-center justify-center gap-[16px]">
+        <a
+          href="#apply"
+          className="inline-flex items-center justify-center rounded-[10px] bg-[#0567B1] px-[28px] py-[15px] text-[17px] font-[700] text-white transition-transform duration-200 hover:scale-[1.03] hover:bg-[#045a9b]"
+          data-font="lato-font"
+        >
+          How to apply
+        </a>
+        <a
+          href="#whats-included"
+          className="inline-flex items-center justify-center rounded-[10px] border-2 border-[#0567B1] px-[28px] py-[15px] text-[17px] font-[700] text-[#0567B1] transition-colors duration-200 hover:bg-[#0567B1]/5"
+          data-font="lato-font"
+        >
+          See what&apos;s included
+        </a>
+      </div>
 
       <div className="w-[90%] max-w-[720px] mx-auto mt-[32px]">
         <AdminGuideLink
@@ -32,7 +50,7 @@ const index = () => {
         />
       </div>
 
-      <div className="w-full h-[80px]" />
+      <div className="w-full h-[60px]" />
 
       <div className="flex w-full max-w-[90%] mx-auto">
         <HelpForCharities
@@ -42,7 +60,9 @@ const index = () => {
         />
       </div>
 
-      <AccordionSection />
+      <div id="whats-included" className="scroll-mt-[120px]">
+        <AccordionSection />
+      </div>
 
       <div className="w-[90%] max-w-[720px] mx-auto py-[20px] text-center">
         <p className="text-[18px] font-[500] leading-[28px] text-[#333]" data-font="lato-font">
@@ -57,9 +77,9 @@ const index = () => {
         </p>
       </div>
 
-      <ReadyToGetStarted />
       <CharityNonprofitDirectorFaq />
-      <ReadyToGetStarted />
+
+      <ApplyOptions />
       <CallSection />
     </div>
   )

--- a/src/components/ui/ApplyOptions.tsx
+++ b/src/components/ui/ApplyOptions.tsx
@@ -19,7 +19,7 @@ const APPLY = {
     href: hubAddProduct(ONBOARDING_PID.full501c3),
   },
   pre501c3: {
-    label: 'Apply as a pre-501(c)3 organization',
+    label: 'Apply as a pre-501(c)(3) organization',
     href: hubAddProduct(ONBOARDING_PID.pre501c3),
   },
 } as const
@@ -58,7 +58,7 @@ const choices: ChoiceOutcome[] = [
     result: (
       <div>
         <p className="mb-[16px]">
-          You&apos;re a <b>pre-501(c)3</b> organization — start here, and we&apos;ll guide you to
+          You&apos;re a <b>pre-501(c)(3)</b> organization — start here, and we&apos;ll guide you to
           full status.
         </p>
         <ApplyButton kind="pre501c3" />
@@ -70,7 +70,7 @@ const choices: ChoiceOutcome[] = [
     result: (
       <div>
         <p className="mb-[16px]">
-          You&apos;re a <b>pre-501(c)3</b> organization — start here, and we&apos;ll guide you to
+          You&apos;re a <b>pre-501(c)(3)</b> organization — start here, and we&apos;ll guide you to
           full status.
         </p>
         <ApplyButton kind="pre501c3" />
@@ -82,7 +82,7 @@ const choices: ChoiceOutcome[] = [
     result: (
       <p>
         Form your nonprofit first — you&apos;ll need articles of incorporation and an EIN. Once you
-        have those, come back and apply as a pre-501(c)3 organization. Our{' '}
+        have those, come back and apply as a pre-501(c)(3) organization. Our{' '}
         <a href="/consulting/" className="text-[#0567B1] font-[600] underline">
           consulting resources
         </a>{' '}
@@ -94,7 +94,7 @@ const choices: ChoiceOutcome[] = [
     label: 'We’re a for-profit business or individual',
     result: (
       <p>
-        Free For Charity&apos;s free programs are for 501(c)(3) and pre-501(c)3 nonprofits. If
+        Free For Charity&apos;s free programs are for 501(c)(3) and pre-501(c)(3) nonprofits. If
         you&apos;d like to help, you can{' '}
         <a href="/volunteer/" className="text-[#0567B1] font-[600] underline">
           volunteer
@@ -151,7 +151,7 @@ const ApplyOptions: React.FC<ApplyOptionsProps> = ({ heading = 'Ready to apply?'
 
           <div className="bg-white rounded-[12px] border border-[#e6edf3] shadow-[0px_2px_18px_0px_rgba(0,0,0,0.1)] p-[28px] flex flex-col">
             <h3 className="text-[20px] font-[700] text-[#1a2e35] mb-[8px]" data-font="lato-font">
-              Pre-501(c)3 organizations
+              Pre-501(c)(3) organizations
             </h3>
             <p className="text-[16px] leading-[25px] text-[#555] mb-[22px]" data-font="lato-font">
               You&apos;re formed (articles of incorporation + EIN) and still working toward IRS

--- a/src/components/ui/ApplyOptions.tsx
+++ b/src/components/ui/ApplyOptions.tsx
@@ -116,7 +116,6 @@ interface ApplyOptionsProps {
 }
 
 const ApplyOptions: React.FC<ApplyOptionsProps> = ({ heading = 'Ready to apply?' }) => {
-  const [helpOpen, setHelpOpen] = useState(false)
   const [choice, setChoice] = useState<number | null>(null)
 
   return (
@@ -164,64 +163,57 @@ const ApplyOptions: React.FC<ApplyOptionsProps> = ({ heading = 'Ready to apply?'
           </div>
         </div>
 
-        {/* Help me choose — inline, no navigation */}
-        <div className="mt-[28px]">
-          <button
-            type="button"
-            onClick={() => setHelpOpen((v) => !v)}
-            aria-expanded={helpOpen}
-            aria-controls={helpOpen ? 'help-me-choose-panel' : undefined}
-            className="inline-flex items-center gap-[8px] rounded-[10px] border-2 border-[#0567B1] px-[24px] py-[12px] text-[16px] font-[700] text-[#0567B1] transition-colors hover:bg-[#0567B1]/5 cursor-pointer"
-            data-font="lato-font"
-          >
-            <span>Help me choose</span>
-            <span aria-hidden="true">{helpOpen ? '▲' : '▼'}</span>
-          </button>
+        {/* Help me choose — a native <details> disclosure with native radios,
+            so the toggle and single-choice keyboard/screen-reader semantics are
+            correct by default (no ARIA to hand-maintain). */}
+        <details className="mt-[28px] text-left max-w-[720px] mx-auto">
+          <summary className="inline-flex items-center gap-[8px] rounded-[10px] border-2 border-[#0567B1] px-[24px] py-[12px] text-[16px] font-[700] text-[#0567B1] transition-colors hover:bg-[#0567B1]/5 cursor-pointer list-none [&::-webkit-details-marker]:hidden">
+            <span data-font="lato-font">Help me choose</span>
+          </summary>
 
-          {helpOpen ? (
-            <div
-              id="help-me-choose-panel"
-              className="mt-[20px] max-w-[720px] mx-auto text-left bg-[#F5F8FB] rounded-[12px] border border-[#e6edf3] p-[24px]"
-            >
-              <p
-                id="help-me-choose-q"
+          <div className="mt-[20px] bg-[#F5F8FB] rounded-[12px] border border-[#e6edf3] p-[24px]">
+            <fieldset>
+              <legend
                 className="text-[17px] font-[700] text-[#1a2e35] mb-[14px]"
                 data-font="lato-font"
               >
                 Which best describes your organization?
-              </p>
-              <div role="radiogroup" aria-labelledby="help-me-choose-q" className="space-y-[10px]">
+              </legend>
+              <div className="space-y-[10px]">
                 {choices.map((c, i) => (
-                  <button
+                  <label
                     key={c.label}
-                    type="button"
-                    role="radio"
-                    aria-checked={choice === i}
-                    onClick={() => setChoice(i)}
-                    className={`block w-full text-left rounded-[8px] border px-[16px] py-[12px] text-[16px] transition-colors cursor-pointer ${
+                    className={`block w-full rounded-[8px] border px-[16px] py-[12px] text-[16px] cursor-pointer transition-colors focus-within:ring-2 focus-within:ring-[#0567B1] focus-within:ring-offset-1 ${
                       choice === i
                         ? 'border-[#0567B1] bg-white text-[#0567B1] font-[700]'
                         : 'border-[#d7e0e8] bg-white text-[#333] hover:border-[#0567B1]'
                     }`}
                     data-font="lato-font"
                   >
+                    <input
+                      type="radio"
+                      name="apply-choice"
+                      className="sr-only"
+                      checked={choice === i}
+                      onChange={() => setChoice(i)}
+                    />
                     {c.label}
-                  </button>
+                  </label>
                 ))}
               </div>
+            </fieldset>
 
-              {choice !== null ? (
-                <div
-                  className="mt-[18px] rounded-[10px] bg-white border border-[#cfe0ee] p-[20px] text-[16px] leading-[25px] text-[#333]"
-                  data-font="lato-font"
-                  aria-live="polite"
-                >
-                  {choices[choice].result}
-                </div>
-              ) : null}
-            </div>
-          ) : null}
-        </div>
+            {choice !== null ? (
+              <div
+                className="mt-[18px] rounded-[10px] bg-white border border-[#cfe0ee] p-[20px] text-[16px] leading-[25px] text-[#333]"
+                data-font="lato-font"
+                aria-live="polite"
+              >
+                {choices[choice].result}
+              </div>
+            ) : null}
+          </div>
+        </details>
       </div>
     </section>
   )

--- a/src/components/ui/ApplyOptions.tsx
+++ b/src/components/ui/ApplyOptions.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React, { useState } from 'react'
+import Link from 'next/link'
 import { hubAddProduct, ONBOARDING_PID } from '@/lib/config'
 
 /**
@@ -83,9 +84,9 @@ const choices: ChoiceOutcome[] = [
       <p>
         Form your nonprofit first — you&apos;ll need articles of incorporation and an EIN. Once you
         have those, come back and apply as a pre-501(c)(3) organization. Our{' '}
-        <a href="/consulting/" className="text-[#0567B1] font-[600] underline">
+        <Link href="/consulting/" className="text-[#0567B1] font-[600] underline">
           consulting resources
-        </a>{' '}
+        </Link>{' '}
         can point you to help with formation.
       </p>
     ),
@@ -96,13 +97,13 @@ const choices: ChoiceOutcome[] = [
       <p>
         Free For Charity&apos;s free programs are for 501(c)(3) and pre-501(c)(3) nonprofits. If
         you&apos;d like to help, you can{' '}
-        <a href="/volunteer/" className="text-[#0567B1] font-[600] underline">
+        <Link href="/volunteer/" className="text-[#0567B1] font-[600] underline">
           volunteer
-        </a>{' '}
+        </Link>{' '}
         or{' '}
-        <a href="/donate/" className="text-[#0567B1] font-[600] underline">
+        <Link href="/donate/" className="text-[#0567B1] font-[600] underline">
           support the mission
-        </a>
+        </Link>
         .
       </p>
     ),

--- a/src/components/ui/ApplyOptions.tsx
+++ b/src/components/ui/ApplyOptions.tsx
@@ -169,6 +169,7 @@ const ApplyOptions: React.FC<ApplyOptionsProps> = ({ heading = 'Ready to apply?'
             type="button"
             onClick={() => setHelpOpen((v) => !v)}
             aria-expanded={helpOpen}
+            aria-controls={helpOpen ? 'help-me-choose-panel' : undefined}
             className="inline-flex items-center gap-[8px] rounded-[10px] border-2 border-[#0567B1] px-[24px] py-[12px] text-[16px] font-[700] text-[#0567B1] transition-colors hover:bg-[#0567B1]/5 cursor-pointer"
             data-font="lato-font"
           >
@@ -177,29 +178,36 @@ const ApplyOptions: React.FC<ApplyOptionsProps> = ({ heading = 'Ready to apply?'
           </button>
 
           {helpOpen ? (
-            <div className="mt-[20px] max-w-[720px] mx-auto text-left bg-[#F5F8FB] rounded-[12px] border border-[#e6edf3] p-[24px]">
-              <p className="text-[17px] font-[700] text-[#1a2e35] mb-[14px]" data-font="lato-font">
+            <div
+              id="help-me-choose-panel"
+              className="mt-[20px] max-w-[720px] mx-auto text-left bg-[#F5F8FB] rounded-[12px] border border-[#e6edf3] p-[24px]"
+            >
+              <p
+                id="help-me-choose-q"
+                className="text-[17px] font-[700] text-[#1a2e35] mb-[14px]"
+                data-font="lato-font"
+              >
                 Which best describes your organization?
               </p>
-              <ul className="space-y-[10px]">
+              <div role="radiogroup" aria-labelledby="help-me-choose-q" className="space-y-[10px]">
                 {choices.map((c, i) => (
-                  <li key={c.label}>
-                    <button
-                      type="button"
-                      onClick={() => setChoice(i)}
-                      aria-pressed={choice === i}
-                      className={`block w-full text-left rounded-[8px] border px-[16px] py-[12px] text-[16px] transition-colors cursor-pointer ${
-                        choice === i
-                          ? 'border-[#0567B1] bg-white text-[#0567B1] font-[700]'
-                          : 'border-[#d7e0e8] bg-white text-[#333] hover:border-[#0567B1]'
-                      }`}
-                      data-font="lato-font"
-                    >
-                      {c.label}
-                    </button>
-                  </li>
+                  <button
+                    key={c.label}
+                    type="button"
+                    role="radio"
+                    aria-checked={choice === i}
+                    onClick={() => setChoice(i)}
+                    className={`block w-full text-left rounded-[8px] border px-[16px] py-[12px] text-[16px] transition-colors cursor-pointer ${
+                      choice === i
+                        ? 'border-[#0567B1] bg-white text-[#0567B1] font-[700]'
+                        : 'border-[#d7e0e8] bg-white text-[#333] hover:border-[#0567B1]'
+                    }`}
+                    data-font="lato-font"
+                  >
+                    {c.label}
+                  </button>
                 ))}
-              </ul>
+              </div>
 
               {choice !== null ? (
                 <div

--- a/src/components/ui/ApplyOptions.tsx
+++ b/src/components/ui/ApplyOptions.tsx
@@ -187,6 +187,7 @@ const ApplyOptions: React.FC<ApplyOptionsProps> = ({ heading = 'Ready to apply?'
                     <button
                       type="button"
                       onClick={() => setChoice(i)}
+                      aria-pressed={choice === i}
                       className={`block w-full text-left rounded-[8px] border px-[16px] py-[12px] text-[16px] transition-colors cursor-pointer ${
                         choice === i
                           ? 'border-[#0567B1] bg-white text-[#0567B1] font-[700]'

--- a/src/components/ui/ApplyOptions.tsx
+++ b/src/components/ui/ApplyOptions.tsx
@@ -1,0 +1,220 @@
+'use client'
+
+import React, { useState } from 'react'
+import { hubAddProduct, ONBOARDING_PID } from '@/lib/config'
+
+/**
+ * On-page apply block: the two clear application options for the people who
+ * already know how to apply, plus an inline "Help me choose" guide for anyone
+ * unsure of the IRS jargon. Everything happens on the page — no separate
+ * eligibility-wizard page to bounce out to — and the WHMCS application forms do
+ * the real screening. Reused across the charity funnel pages.
+ */
+
+type ApplyKind = 'full501c3' | 'pre501c3'
+
+const APPLY = {
+  full501c3: {
+    label: 'Apply as a 501(c)(3) charity',
+    href: hubAddProduct(ONBOARDING_PID.full501c3),
+  },
+  pre501c3: {
+    label: 'Apply as a pre-501(c)3 organization',
+    href: hubAddProduct(ONBOARDING_PID.pre501c3),
+  },
+} as const
+
+const ApplyButton = ({ kind, className = '' }: { kind: ApplyKind; className?: string }) => (
+  <a
+    href={APPLY[kind].href}
+    className={`inline-flex items-center justify-center rounded-[10px] bg-[#0567B1] px-[26px] py-[14px] text-[17px] font-[700] text-white transition-transform duration-200 hover:scale-[1.03] hover:bg-[#045a9b] ${className}`}
+    data-font="lato-font"
+  >
+    {APPLY[kind].label}
+  </a>
+)
+
+interface ChoiceOutcome {
+  /** Plain-language answer shown as the option label. */
+  label: string
+  /** What we tell them, rendered inline. */
+  result: React.ReactNode
+}
+
+const choices: ChoiceOutcome[] = [
+  {
+    label: 'We have our IRS 501(c)(3) determination letter',
+    result: (
+      <div>
+        <p className="mb-[16px]">
+          You&apos;re a <b>501(c)(3)</b> — use this application. Have your EIN handy.
+        </p>
+        <ApplyButton kind="full501c3" />
+      </div>
+    ),
+  },
+  {
+    label: 'We applied for 501(c)(3) but aren’t approved yet',
+    result: (
+      <div>
+        <p className="mb-[16px]">
+          You&apos;re a <b>pre-501(c)3</b> organization — start here, and we&apos;ll guide you to
+          full status.
+        </p>
+        <ApplyButton kind="pre501c3" />
+      </div>
+    ),
+  },
+  {
+    label: 'We’re formed (articles of incorporation + EIN) but haven’t applied yet',
+    result: (
+      <div>
+        <p className="mb-[16px]">
+          You&apos;re a <b>pre-501(c)3</b> organization — start here, and we&apos;ll guide you to
+          full status.
+        </p>
+        <ApplyButton kind="pre501c3" />
+      </div>
+    ),
+  },
+  {
+    label: 'We haven’t formed an organization yet',
+    result: (
+      <p>
+        Form your nonprofit first — you&apos;ll need articles of incorporation and an EIN. Once you
+        have those, come back and apply as a pre-501(c)3 organization. Our{' '}
+        <a href="/consulting/" className="text-[#0567B1] font-[600] underline">
+          consulting resources
+        </a>{' '}
+        can point you to help with formation.
+      </p>
+    ),
+  },
+  {
+    label: 'We’re a for-profit business or individual',
+    result: (
+      <p>
+        Free For Charity&apos;s free programs are for 501(c)(3) and pre-501(c)3 nonprofits. If
+        you&apos;d like to help, you can{' '}
+        <a href="/volunteer/" className="text-[#0567B1] font-[600] underline">
+          volunteer
+        </a>{' '}
+        or{' '}
+        <a href="/donate/" className="text-[#0567B1] font-[600] underline">
+          support the mission
+        </a>
+        .
+      </p>
+    ),
+  },
+]
+
+interface ApplyOptionsProps {
+  /** Optional heading; pass '' to omit. */
+  heading?: string
+}
+
+const ApplyOptions: React.FC<ApplyOptionsProps> = ({ heading = 'Ready to apply?' }) => {
+  const [helpOpen, setHelpOpen] = useState(false)
+  const [choice, setChoice] = useState<number | null>(null)
+
+  return (
+    <section id="apply" className="w-full py-[50px] scroll-mt-[120px]">
+      <div className="w-[90%] md:w-[80%] max-w-[1000px] mx-auto text-center">
+        {heading ? (
+          <h2 className="text-[26px] md:text-[30px] font-[700] text-[#0567B1] mb-[10px]">
+            {heading}
+          </h2>
+        ) : null}
+        <p
+          className="text-[17px] font-[500] leading-[27px] text-[#555] max-w-[720px] mx-auto mb-[30px]"
+          data-font="lato-font"
+        >
+          Pick the option that matches your organization — the application itself walks you through
+          what we need. Not sure which fits? Use <b>Help me choose</b>.
+        </p>
+
+        {/* The two clear apply options */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-[24px] text-left">
+          <div className="bg-white rounded-[12px] border border-[#e6edf3] shadow-[0px_2px_18px_0px_rgba(0,0,0,0.1)] p-[28px] flex flex-col">
+            <h3 className="text-[20px] font-[700] text-[#1a2e35] mb-[8px]" data-font="lato-font">
+              501(c)(3) charities
+            </h3>
+            <p className="text-[16px] leading-[25px] text-[#555] mb-[22px]" data-font="lato-font">
+              Your nonprofit already has its IRS 501(c)(3) determination letter. Have your EIN
+              handy.
+            </p>
+            <div className="mt-auto">
+              <ApplyButton kind="full501c3" className="w-full" />
+            </div>
+          </div>
+
+          <div className="bg-white rounded-[12px] border border-[#e6edf3] shadow-[0px_2px_18px_0px_rgba(0,0,0,0.1)] p-[28px] flex flex-col">
+            <h3 className="text-[20px] font-[700] text-[#1a2e35] mb-[8px]" data-font="lato-font">
+              Pre-501(c)3 organizations
+            </h3>
+            <p className="text-[16px] leading-[25px] text-[#555] mb-[22px]" data-font="lato-font">
+              You&apos;re formed (articles of incorporation + EIN) and still working toward IRS
+              501(c)(3) determination.
+            </p>
+            <div className="mt-auto">
+              <ApplyButton kind="pre501c3" className="w-full" />
+            </div>
+          </div>
+        </div>
+
+        {/* Help me choose — inline, no navigation */}
+        <div className="mt-[28px]">
+          <button
+            type="button"
+            onClick={() => setHelpOpen((v) => !v)}
+            aria-expanded={helpOpen}
+            className="inline-flex items-center gap-[8px] rounded-[10px] border-2 border-[#0567B1] px-[24px] py-[12px] text-[16px] font-[700] text-[#0567B1] transition-colors hover:bg-[#0567B1]/5 cursor-pointer"
+            data-font="lato-font"
+          >
+            <span>Help me choose</span>
+            <span aria-hidden="true">{helpOpen ? '▲' : '▼'}</span>
+          </button>
+
+          {helpOpen ? (
+            <div className="mt-[20px] max-w-[720px] mx-auto text-left bg-[#F5F8FB] rounded-[12px] border border-[#e6edf3] p-[24px]">
+              <p className="text-[17px] font-[700] text-[#1a2e35] mb-[14px]" data-font="lato-font">
+                Which best describes your organization?
+              </p>
+              <ul className="space-y-[10px]">
+                {choices.map((c, i) => (
+                  <li key={c.label}>
+                    <button
+                      type="button"
+                      onClick={() => setChoice(i)}
+                      className={`block w-full text-left rounded-[8px] border px-[16px] py-[12px] text-[16px] transition-colors cursor-pointer ${
+                        choice === i
+                          ? 'border-[#0567B1] bg-white text-[#0567B1] font-[700]'
+                          : 'border-[#d7e0e8] bg-white text-[#333] hover:border-[#0567B1]'
+                      }`}
+                      data-font="lato-font"
+                    >
+                      {c.label}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+
+              {choice !== null ? (
+                <div
+                  className="mt-[18px] rounded-[10px] bg-white border border-[#cfe0ee] p-[20px] text-[16px] leading-[25px] text-[#333]"
+                  data-font="lato-font"
+                  aria-live="polite"
+                >
+                  {choices[choice].result}
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export default ApplyOptions

--- a/src/components/ui/Charity-Nonprofit-Director-Faq.tsx
+++ b/src/components/ui/Charity-Nonprofit-Director-Faq.tsx
@@ -233,7 +233,7 @@ const CharityFAQ: React.FC = () => {
           <AccordionItem number="8" title="What do I need to get started?">
             All you need to do to get Free For Charity to provide help for your charity’s mission
             today is to apply with a little information about your organization. Use the apply
-            options just below — 501(c)(3) or pre-501(c)3 — and if you’re not sure which fits, the
+            options just below — 501(c)(3) or pre-501(c)(3) — and if you’re not sure which fits, the
             “Help me choose” guide there will point you to the right one. Prefer to talk it through
             first? Give us a call using the number below.
           </AccordionItem>

--- a/src/components/ui/Charity-Nonprofit-Director-Faq.tsx
+++ b/src/components/ui/Charity-Nonprofit-Director-Faq.tsx
@@ -232,9 +232,10 @@ const CharityFAQ: React.FC = () => {
 
           <AccordionItem number="8" title="What do I need to get started?">
             All you need to do to get Free For Charity to provide help for your charity’s mission
-            today is to contact us with some basic information about your charity. We need to know
-            what type of projects you would like us to look at or undertake. Please fill out the
-            form below and we will be in touch shortly.
+            today is to apply with a little information about your organization. Use the apply
+            options just below — 501(c)(3) or pre-501(c)3 — and if you’re not sure which fits, the
+            “Help me choose” guide there will point you to the right one. Prefer to talk it through
+            first? Give us a call using the number below.
           </AccordionItem>
         </div>
       </div>

--- a/src/components/ui/Charity-Nonprofit-Director-Faq.tsx
+++ b/src/components/ui/Charity-Nonprofit-Director-Faq.tsx
@@ -235,7 +235,11 @@ const CharityFAQ: React.FC = () => {
             today is to apply with a little information about your organization. Use the apply
             options just below — 501(c)(3) or pre-501(c)(3) — and if you’re not sure which fits, the
             “Help me choose” guide there will point you to the right one. Prefer to talk it through
-            first? Give us a call using the number below.
+            first? Reach out by phone or through our{' '}
+            <Link href="/contact-us/" className="text-[#0567B1]">
+              contact page
+            </Link>
+            .
           </AccordionItem>
         </div>
       </div>

--- a/src/data/search-index.json
+++ b/src/data/search-index.json
@@ -207,7 +207,7 @@
     },
     {
       "title": "Help for Charities",
-      "description": "Resources and support for charity and nonprofit directors. Get instant access to free tools, domains, hosting, and technology services from Free For Charity.",
+      "description": "Free For Charity gives verified nonprofits a complete online presence—a managed website, .org domain, and Microsoft 365 email—plus the tools, directories, and hands-on help to run leaner. Start even while pending 501(c)(3) status.",
       "href": "/help-for-charities/",
       "type": "page"
     },


### PR DESCRIPTION
## Summary

Reworks the **Help for Charities** apply flow so eligibility happens **on the page** instead of bouncing visitors out to the separate `/eligibility-check/` wizard (which felt jarring) — while keeping the **two clear apply buttons front and center** for people who already know how to apply. The application forms themselves already screen applicants, so the on-page step is about helping people pick the right funnel, not gatekeeping.

## New: `ui/ApplyOptions` (reusable, client)

- **Two prominent apply buttons**, each with a plain-language "who this is for / what you'll need" blurb:
  - **501(c)(3) charities** → onboarding `pid=33` ("already has its IRS determination letter; have your EIN handy")
  - **Pre-501(c)3 organizations** → onboarding `pid=16` ("formed with articles + EIN, working toward determination")
- An inline **"Help me choose"** guide for anyone who doesn't follow the IRS jargon: a single plain-language question that reveals — **right on the page, no navigation** — which button fits, or routes "not formed yet" / "for-profit or individual" to the right next step (form first / volunteer / donate).

## help-for-charities changes

- Hero CTAs now scroll **on-page** (**How to apply** → `#apply`, **See what's included** → `#whats-included`) instead of linking the separate wizard.
- Removed the **duplicate** "Ready to Get Started" block — replaced by a single `ApplyOptions` section at the decision point.
- Fixed the FAQ **"fill out the form below"** answer (there was no form) to point at the on-page apply options and the phone number.

## Follow-up (the bigger picture)

This is the **reference implementation** of the on-page eligibility pattern. Planned next steps, to confirm with you: roll `ApplyOptions` into the **hosting, domains, and homepage** funnels (replacing their `/eligibility-check/` links) and then **retire the standalone `/eligibility-check/` page** (301 it, and clean up the nav/sitemap/search/inbound links). Not done here to keep this PR focused and reviewable.

## Verification

- `npm run lint` — clean
- `npm run build` — static export succeeds
- `npm run test` — 582 jest tests pass (all suites)
- Verified against the built page: no `/eligibility-check/` links remain on Help for Charities; the `#apply` anchor + "Help me choose" render; both apply pids (33/16) are present; the "form below" text is gone; and the tech-stack section still leads with GitHub Pages (guards the #455 test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JrqnLULSB1GYoiKYDQVA8T)_