### PR TITLE
feat(apply): eligibility out-paths — non-US→TechSoup, fiscal sponsorship, veteran 501(c) types

### DIFF
--- a/__tests__/components/ui/apply-options.test.tsx
+++ b/__tests__/components/ui/apply-options.test.tsx
@@ -33,6 +33,39 @@ describe('ApplyOptions', () => {
     expect(screen.getByText(/use this application/i)).toBeInTheDocument()
   })
 
+  it('routes veterans / other 501(c) types to the 501(c)(3) application', () => {
+    render(<ApplyOptions />)
+    fireEvent.click(screen.getByRole('radio', { name: /veterans post or another 501\(c\) type/i }))
+    expect(screen.getByText(/pick the organization type that matches/i)).toBeInTheDocument()
+    // The apply CTA in the revealed panel still deep-links to pid 33.
+    const links = screen
+      .getAllByRole('link', { name: /Apply as a 501\(c\)\(3\) charity/ })
+      .map((a) => a.getAttribute('href') ?? '')
+    expect(links.every((h) => h.includes('a=add&pid=33'))).toBe(true)
+  })
+
+  it('tells fiscally sponsored projects their sponsor must apply and approve them', () => {
+    render(<ApplyOptions />)
+    fireEvent.click(screen.getByRole('radio', { name: /under a fiscal sponsor/i }))
+    expect(screen.getByText(/must apply and approve your project/i)).toBeInTheDocument()
+    // The email-grant rationale is stated — the reason the sponsor is required.
+    expect(screen.getByText(/email grants attach to the sponsor/i)).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: /How we evaluate fiscal sponsorship/i })
+    ).toHaveAttribute('href', 'https://ffcadmin.org/intake-help/fiscal-sponsorship/')
+  })
+
+  it('routes non-US organizations to TechSoup as the graceful out-path', () => {
+    render(<ApplyOptions />)
+    fireEvent.click(screen.getByRole('radio', { name: /based outside the United States/i }))
+    expect(screen.getByRole('link', { name: 'TechSoup' })).toHaveAttribute(
+      'href',
+      'https://www.techsoup.org/'
+    )
+    // Territories count as US — the copy must say so to avoid false declines.
+    expect(screen.getByText(/Puerto Rico/)).toBeInTheDocument()
+  })
+
   it('has no axe violations before and after choosing', async () => {
     const { container } = render(<ApplyOptions />)
     expect(await axe(container)).toHaveNoViolations()

--- a/src/components/ui/ApplyOptions.tsx
+++ b/src/components/ui/ApplyOptions.tsx
@@ -27,8 +27,10 @@ const ApplyOptions: React.FC<ApplyOptionsProps> = ({ heading = 'Ready to apply?'
           className="text-[17px] font-[500] leading-[27px] text-[#555] max-w-[720px] mx-auto mb-[30px]"
           data-font="lato-font"
         >
-          Pick the option that matches your organization — the application itself walks you through
-          what we need. Not sure which fits? Use <b>Help me choose</b>.
+          Free For Charity serves <b>US-based</b> nonprofits (US territories included) with annual
+          revenue under $1&nbsp;million. Pick the option that matches your organization — the
+          application itself walks you through what we need. Not sure which fits? Use{' '}
+          <b>Help me choose</b>.
         </p>
 
         {/* The two clear apply options */}

--- a/src/components/ui/HelpMeChoose.tsx
+++ b/src/components/ui/HelpMeChoose.tsx
@@ -57,6 +57,61 @@ const choices: ChoiceOutcome[] = [
     ),
   },
   {
+    label: 'We’re a veterans post or another 501(c) type — like a 501(c)(19) or 501(c)(9)',
+    result: (
+      <div>
+        <p className="mb-[16px]">
+          US veterans organizations and other 501(c) types are welcome — veterans missions are one
+          of our priority categories. Use the <b>501(c)(3) application</b> and pick the organization
+          type that matches on the form (for example <i>US State Recognized Nonprofit</i>,{' '}
+          <i>US Not-For-Profit</i>, or <i>Other Charitable Organization</i>).
+        </p>
+        <ApplyButton kind="full501c3" />
+      </div>
+    ),
+  },
+  {
+    label: 'We’re a project under a fiscal sponsor (another organization’s 501(c)(3))',
+    result: (
+      <div>
+        <p className="mb-[16px]">
+          Fiscally sponsored projects join through their sponsor: the <b>sponsoring 501(c)(3)</b>{' '}
+          must apply and approve your project as officially one of theirs. That step is required
+          because the Microsoft 365 and Google Workspace nonprofit email grants attach to the
+          sponsor&apos;s 501(c)(3) — without it we can&apos;t set up your charity email later.
+        </p>
+        <p className="mb-[16px]">
+          Send your sponsor to this application (and if you&apos;re also pursuing your own
+          501(c)(3), apply as a pre-501(c)(3) too):
+        </p>
+        <ApplyButton kind="full501c3" />
+        <p className="mt-[16px]">
+          <a
+            href="https://ffcadmin.org/intake-help/fiscal-sponsorship/"
+            className="text-[#0567B1] font-[600] underline"
+          >
+            How we evaluate fiscal sponsorship
+          </a>
+        </p>
+      </div>
+    ),
+  },
+  {
+    label: 'We’re based outside the United States',
+    result: (
+      <p>
+        Free For Charity supports nonprofits registered in the <b>United States</b> (US territories
+        such as Puerto Rico, the US Virgin Islands, and Guam count). If your organization is
+        registered elsewhere, the best next step is{' '}
+        <a href="https://www.techsoup.org/" className="text-[#0567B1] font-[600] underline">
+          TechSoup
+        </a>
+        , which supports nonprofits internationally through its global partner network — wishing you
+        and your team all the best with your mission.
+      </p>
+    ),
+  },
+  {
     label: 'We haven’t formed an organization yet',
     result: (
       <p>

--- a/tests/wizards.spec.ts
+++ b/tests/wizards.spec.ts
@@ -26,6 +26,48 @@ test.describe('On-page "Help me choose" apply guide', () => {
       result.getByRole('link', { name: /Apply as a 501\(c\)\(3\) charity/ })
     ).toHaveAttribute('href', /cart\.php\?a=add&pid=33/)
   })
+
+  test('non-US organizations get the TechSoup out-path in place', async ({ page }) => {
+    await page.goto('/help-for-charities/')
+
+    const guide = page.locator('details').filter({ hasText: 'Help me choose' }).first()
+    await guide.locator('summary').click()
+    await guide.getByText('We’re based outside the United States').click()
+
+    const result = guide.locator('[aria-live="polite"]')
+    await expect(result.getByRole('link', { name: 'TechSoup' })).toHaveAttribute(
+      'href',
+      'https://www.techsoup.org/'
+    )
+  })
+
+  test('fiscally sponsored projects are told the sponsor must apply', async ({ page }) => {
+    await page.goto('/help-for-charities/')
+
+    const guide = page.locator('details').filter({ hasText: 'Help me choose' }).first()
+    await guide.locator('summary').click()
+    await guide.getByText('We’re a project under a fiscal sponsor').click()
+
+    const result = guide.locator('[aria-live="polite"]')
+    await expect(result.getByText(/must apply and approve your project/i)).toBeVisible()
+    await expect(
+      result.getByRole('link', { name: /Apply as a 501\(c\)\(3\) charity/ })
+    ).toHaveAttribute('href', /cart\.php\?a=add&pid=33/)
+  })
+
+  test('veterans and other 501(c) types route into the 501(c)(3) application', async ({ page }) => {
+    await page.goto('/help-for-charities/')
+
+    const guide = page.locator('details').filter({ hasText: 'Help me choose' }).first()
+    await guide.locator('summary').click()
+    await guide.getByText(/veterans post or another 501\(c\) type/).click()
+
+    const result = guide.locator('[aria-live="polite"]')
+    await expect(result.getByText(/pick the organization type that matches/i)).toBeVisible()
+    await expect(
+      result.getByRole('link', { name: /Apply as a 501\(c\)\(3\) charity/ })
+    ).toHaveAttribute('href', /cart\.php\?a=add&pid=33/)
+  })
 })
 
 test.describe('Volunteer skills quiz', () => {


### PR DESCRIPTION
## Summary

Extends the on-page **Help me choose** eligibility guide with the real intake filters and graceful out-paths, so the applicant pool arrives pre-screened — technically competent, well-organized US charities and future charities — and everyone else gets a clean, kind next step instead of a dead end.

Grounded in the founder-approved ruleset (`ffcadmin.org` application-prerequisites inventory + readiness scoring) and actual application history:

- **Non-US organizations → TechSoup.** US-only is the one hard geographic gate (29 international orders auto-blocked, 5 foreign sites wound down). New choice mirrors the client-tested `international_techsoup` WHMCS ticket template and notes US territories (PR, USVI, GU) count as US so we don't false-decline them.
- **Fiscally sponsored projects → sponsor must apply.** The sponsoring 501(c)(3) must apply and approve the project as officially theirs — required because the Microsoft 365 / Google Workspace nonprofit email grants attach to the *sponsor's* 501(c)(3). Links the fiscal-sponsorship policy on ffcadmin.org. Closes the registration dead end documented in FreeForCharity/FFC-Cloudflare-Automation#469 ("Your registration process doesn't seem to allow for that").
- **Veterans posts and other 501(c) types** — 501(c)(19), 501(c)(9), state-recognized — are explicitly welcomed (veterans missions are a priority category) and routed into the 501(c)(3) application with guidance to pick the matching organization type on the form.
- **ApplyOptions states the filters up front:** US-based (territories included), annual revenue under $1M (the founder-approved hard gate).

## Test plan

- [x] `npm run lint` clean
- [x] `npm run build` static export succeeds
- [x] `npm run test` — 595/595 unit tests (3 new ApplyOptions cases: veterans routing, sponsor-must-apply + email rationale, TechSoup out-path)
- [x] `npx playwright test tests/wizards.spec.ts` — 6/6 e2e (3 new: TechSoup link, fiscal-sponsor message, veterans routing on /help-for-charities/)
- [x] Verified https://ffcadmin.org/intake-help/fiscal-sponsorship/ returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)