### PR TITLE
feat(journey): gated order — validated GitHub Pages site before the domain purchase

### DIFF
--- a/__tests__/app/charity-onboarding-journey.test.tsx
+++ b/__tests__/app/charity-onboarding-journey.test.tsx
@@ -8,24 +8,29 @@ describe('Charity Onboarding Journey page', () => {
     expect(container).not.toBeEmptyDOMElement()
   })
 
-  it('orders the Website stage before the Email stage', () => {
+  it('orders the Website stage before the Domain stage (the funding gate)', () => {
     const { container } = render(<CharityOnboardingJourney />)
     const text = container.textContent || ''
-    const websiteIndex = text.indexOf('3. Website')
+    const websiteIndex = text.indexOf('2. Website')
+    const domainIndex = text.indexOf('3. Domain')
     const emailIndex = text.indexOf('4. Email')
 
+    // The gated journey: the site is built and validated on GitHub Pages
+    // before FFC spends money on a domain, and email comes after the domain.
     expect(websiteIndex).toBeGreaterThan(-1)
+    expect(domainIndex).toBeGreaterThan(-1)
     expect(emailIndex).toBeGreaterThan(-1)
-    expect(websiteIndex).toBeLessThan(emailIndex)
+    expect(websiteIndex).toBeLessThan(domainIndex)
+    expect(domainIndex).toBeLessThan(emailIndex)
   })
 
-  it('numbers the stages 1 through 5 in the corrected order', () => {
+  it('numbers the stages 1 through 5 in the gated order', () => {
     const { container } = render(<CharityOnboardingJourney />)
     const text = container.textContent || ''
 
     expect(text).toContain('1. Application & validation')
-    expect(text).toContain('2. Domain')
-    expect(text).toContain('3. Website')
+    expect(text).toContain('2. Website — built and proven first')
+    expect(text).toContain('3. Domain — only after your site is proven')
     expect(text).toContain('4. Email')
     expect(text).toContain('5. Handoff & ongoing support')
   })

--- a/src/app/charity-onboarding-journey/page.tsx
+++ b/src/app/charity-onboarding-journey/page.tsx
@@ -21,22 +21,15 @@ interface Stage {
 const stages: Stage[] = [
   {
     name: '1. Application & validation',
-    you: 'Submit the onboarding form with your EIN, legal name, and what you need. Have your IRS determination letter handy (pre-501c3 orgs: your formation documents).',
-    ffc: 'We validate your organization (IRS status, Candid profile) and confirm program fit.',
+    you: 'Submit the onboarding form with your EIN, legal name, charity Facebook and LinkedIn pages, and what you need. Have your IRS determination letter handy (pre-501c3 orgs: your formation documents).',
+    ffc: 'We validate your organization (IRS status, Candid profile) and confirm program fit. Every later stage requires this approval first.',
     duration: 'A few days',
     links: [{ href: '/help-for-charities/', label: 'Start here: Help for Charities' }],
   },
   {
-    name: '2. Domain',
-    you: 'Send us your top three .org name choices — or the details of a domain you already own.',
-    ffc: 'We register (and pay for) the best available name, or take over management of your existing domain, and set up DNS and security.',
-    duration: 'Same week',
-    links: [{ href: '/domains/#check-your-domain', label: 'Guide: choosing your .org domain' }],
-  },
-  {
-    name: '3. Website',
-    you: 'Send your logo, photos, mission text, and program descriptions. A one-page outline is enough — we help with the rest.',
-    ffc: 'A volunteer builds your site from the FFC template (fast, secure static hosting), reviews it with you, and launches it at your domain.',
+    name: '2. Website — built and proven first',
+    you: 'Submit the website application (it requires your approved onboarding), then send your logo, photos, mission text, and program descriptions. A one-page outline is enough — we help with the rest.',
+    ffc: 'A volunteer builds your site from the FFC template (fast, secure static hosting), with the full FFC footer generated from your validated application data. Your site goes live on its free GitHub Pages address — no custom domain yet — and we validate it end to end with you.',
     duration: '2–6 weeks, mostly depending on content readiness',
     links: [
       {
@@ -44,6 +37,13 @@ const stages: Stage[] = [
         label: 'How FFC delivers services',
       },
     ],
+  },
+  {
+    name: '3. Domain — only after your site is proven',
+    you: 'Send us your top three .org name choices — or the details of a domain you already own — along with your live GitHub Pages address. You can check name availability any time; we buy once your site is validated.',
+    ffc: 'Once your website is validated, we spend the funds: we register (and pay for) the best available name, or take over management of your existing domain, set up DNS and security, and point it at your live site.',
+    duration: 'Same week (after website validation)',
+    links: [{ href: '/domains/#check-your-domain', label: 'Guide: choosing your .org domain' }],
   },
   {
     name: '4. Email',
@@ -75,9 +75,11 @@ export default function CharityOnboardingJourney() {
         <div className="prose max-w-none font-[var(--font-lato)] text-[18px] leading-[28px]">
           <p>
             Here&rsquo;s exactly what happens after your charity applies — the five stages, who does
-            what at each one, and honest durations. Volunteers do this work, so timelines are
-            typical rather than guaranteed; content readiness on your side is the biggest factor in
-            how fast a site launches.
+            what at each one, and honest durations. The order matters: your website is built and
+            validated on free GitHub Pages hosting <em>first</em>, and we only spend money on your
+            domain once your site is proven. Volunteers do this work, so timelines are typical
+            rather than guaranteed; content readiness on your side is the biggest factor in how fast
+            a site launches.
           </p>
         </div>
 

--- a/src/app/getting-started-checklist/page.tsx
+++ b/src/app/getting-started-checklist/page.tsx
@@ -59,19 +59,28 @@ export default function GettingStartedChecklist() {
 
           <h2 className={h2}>During onboarding</h2>
           <p className="print:text-[11px]">
-            FFC builds your website first — charity email comes after, because the nonprofit email
-            programs (Microsoft 365 / Google Workspace) expect your organization to have an
-            established web presence.
+            FFC builds your website first, live and validated on its free GitHub Pages address —
+            your domain is purchased only after your site is proven, and charity email comes after
+            that, because the nonprofit email programs (Microsoft 365 / Google Workspace) expect
+            your organization to have an established web presence.
           </p>
           <ul className="space-y-2 list-none pl-0">
             <Item>
-              Application submitted via <Link href="/help-for-charities/">Help for Charities</Link>.{' '}
-              <Link href="/charity-onboarding-journey/">What happens next</Link>
+              Application submitted via <Link href="/help-for-charities/">Help for Charities</Link>{' '}
+              and approved. <Link href="/charity-onboarding-journey/">What happens next</Link>
             </Item>
             <Item>
-              Logo, photos, mission text, and program descriptions sent for the site build.
+              Website application submitted (requires your approved onboarding); logo, photos,
+              mission text, and program descriptions sent for the site build.
             </Item>
-            <Item>Site draft reviewed and launch approved.</Item>
+            <Item>
+              Site draft reviewed and validated live on its GitHub Pages address — this unlocks the
+              domain purchase.
+            </Item>
+            <Item>
+              Domain registered (or transferred) by FFC and pointed at your validated site.{' '}
+              <Link href="/domains/#check-your-domain">Domain guide</Link>
+            </Item>
             <Item>
               Microsoft for Nonprofits or Google Workspace registration started (after the site is
               live). <Link href="/m365-email-guide/">M365 email guide</Link>

--- a/src/components/501c3-components/Ready-to-get-started-and-faqs/index.tsx
+++ b/src/components/501c3-components/Ready-to-get-started-and-faqs/index.tsx
@@ -6,44 +6,16 @@ const index = () => {
     <div className="w-full max-w-[100%]">
       <div className="w-full max-w-[90%] mx-auto">
         <ReadyToGetStarted />
-        <AccordionItem number="3" title=" Free For Charity Domain Name and Email Hosting Request">
-          <p className="pb-[1em]">
-            Free For Charity Provides free .org domain names to US 501c3 organizations. Once your
-            onboarding forms are accepted you will receive an email from the system with the
-            discount code to request a new domain name or to transfer your current domain name to us
-            so we can start managing it and paying the annual fees.
-          </p>
-          <h1 className="pb-[1em] font-[700]">
-            Visit{' '}
-            <a href="/domains/" className="text-[#0567B1]">
-              https://freeforcharity.org/domains
-            </a>{' '}
-            and follow all steps
-          </h1>
-          <p className="pb-[1em]">
-            Once we have the domain name under management we can then set up your professional email
-            addresses e.g. board@yourcharityname.org
-          </p>
-          <p className="pb-[1em]">
-            Professional email can be set up with Microsoft 365 or Google Workspace, both free for
-            eligible 501(c)(3) nonprofits.
-          </p>
-          <h1 className="font-[700]">
-            As always if you run into problems contact us at anytime{' '}
-            <a href="mailto:clarkemoyer@freeforcharity.org" className="text-[#0567B1]">
-              clarkemoyer@freeforcharity.org
-            </a>{' '}
-            <a href="tel:+15202228104">520-222-8104</a>
-          </h1>
-        </AccordionItem>
-        <AccordionItem number="4" title="Your Website (GitHub Pages)">
+        <AccordionItem number="3" title="Your Website (GitHub Pages) — built and proven first">
           <div className="space-y-6 font-[500] text-[#666]">
             {/* Intro Paragraph */}
             <p className="pb-4 leading-relaxed">
-              Once your domain name is set up, a Free For Charity volunteer builds your website from
-              the FFC template as a fast, secure GitHub Pages static site and launches it on your
-              Cloudflare-managed domain. There is no server to maintain and nothing for you to
-              install.
+              Once your onboarding application is approved, you will receive an email from the
+              system with the code to submit your website application. A Free For Charity volunteer
+              then builds your website from the FFC template as a fast, secure GitHub Pages static
+              site. Your site goes live on its free GitHub Pages address first — no custom domain
+              yet — and we validate it with you end to end. There is no server to maintain and
+              nothing for you to install.
             </p>
 
             {/* What we need from you */}
@@ -73,6 +45,37 @@ const index = () => {
               520-222-8104
             </p>
           </div>
+        </AccordionItem>
+        <AccordionItem number="4" title="Free For Charity Domain Name and Email Hosting Request">
+          <p className="pb-[1em]">
+            Free For Charity provides free .org domain names to US 501c3 organizations. Once your
+            website is live and validated on its GitHub Pages address, request your domain — we
+            register a new .org (or transfer your current domain name to us), point it at your
+            validated site, and manage it while paying the annual fees. We only purchase domains for
+            websites that are already working and validated.
+          </p>
+          <h1 className="pb-[1em] font-[700]">
+            Visit{' '}
+            <a href="/domains/" className="text-[#0567B1]">
+              https://freeforcharity.org/domains
+            </a>{' '}
+            and follow all steps
+          </h1>
+          <p className="pb-[1em]">
+            Once we have the domain name under management we can then set up your professional email
+            addresses e.g. board@yourcharityname.org
+          </p>
+          <p className="pb-[1em]">
+            Professional email can be set up with Microsoft 365 or Google Workspace, both free for
+            eligible 501(c)(3) nonprofits.
+          </p>
+          <h1 className="font-[700]">
+            As always if you run into problems contact us at anytime{' '}
+            <a href="mailto:clarkemoyer@freeforcharity.org" className="text-[#0567B1]">
+              clarkemoyer@freeforcharity.org
+            </a>{' '}
+            <a href="tel:+15202228104">520-222-8104</a>
+          </h1>
         </AccordionItem>
       </div>
     </div>

--- a/src/components/domains/Check-Your-Org/index.tsx
+++ b/src/components/domains/Check-Your-Org/index.tsx
@@ -74,7 +74,8 @@ const CheckYourOrg = () => {
         >
           See if your charity’s <strong>.org</strong> is available, and we’ll flag near-matches (a{' '}
           <em>.com</em> or <em>.net</em> someone else owns) that could confuse donors or hurt your
-          SEO. When it’s clear, we register it for you — free.
+          SEO. Check names as early as you like — we register your .org for you, free, once your
+          website is live and validated on its GitHub Pages address.
         </p>
 
         <form

--- a/src/components/domains/Dear-Prospective/index.tsx
+++ b/src/components/domains/Dear-Prospective/index.tsx
@@ -29,8 +29,9 @@ const FFCOnboardingNotice = () => {
           className="font-[600] text-[20px] md:text-[24px] leading-[34px] w-[85%] mx-auto mt-[24px]"
           data-font="raleway-font"
         >
-          The first step is always the same: complete FFC onboarding. Everything else — domain,
-          email, and website — follows from there.
+          The first step is always the same: complete FFC onboarding. Then your website is built and
+          validated on free GitHub Pages hosting — and only after your site is proven do we buy your
+          domain and set up email.
         </p>
       </div>
 

--- a/src/components/domains/Order-Your-Domain/index.tsx
+++ b/src/components/domains/Order-Your-Domain/index.tsx
@@ -16,29 +16,30 @@ const HowToOrderDomain = () => {
     {
       number: 2,
       title: 'Step 2',
-      description: 'We register or transfer your .org domain',
+      description: 'Your website goes live and is validated on its free GitHub Pages address',
+      linkText: 'How your website works',
+      innerbg: 'bg-[#2A6F9E]',
+      outerbg: 'bg-[#2A6F9E]',
+      linkUrl: '/free-charity-web-hosting/',
+    },
+    {
+      number: 3,
+      title: 'Step 3',
+      description: 'We register or transfer your .org domain and point it at your validated site',
       linkText: 'See your options',
       innerbg: 'bg-[#2A6F9E]',
       outerbg: 'bg-[#2A6F9E]',
       linkUrl: '#domain-options',
     },
     {
-      number: 3,
-      title: 'Step 3',
-      description: 'Create a free personal Cloudflare account and send us the email you used',
-      linkText: 'Create a Cloudflare account',
-      innerbg: 'bg-[#2A6F9E]',
-      outerbg: 'bg-[#2A6F9E]',
-      linkUrl: 'https://dash.cloudflare.com/sign-up',
-    },
-    {
       number: 4,
       title: 'Step 4',
-      description: 'We add you as a domain admin and manage DNS for you',
-      linkText: 'Contact us',
+      description:
+        'Create a free personal Cloudflare account — we add you as a domain admin and manage DNS for you',
+      linkText: 'Create a Cloudflare account',
       innerbg: 'bg-[#8A6400]',
       outerbg: 'bg-[#fff]',
-      linkUrl: '/contact-us/',
+      linkUrl: 'https://dash.cloudflare.com/sign-up',
     },
   ]
 
@@ -70,9 +71,10 @@ const HowToOrderDomain = () => {
             style={{ fontFamily: 'Raleway, sans-serif' }}
           >
             Free For Charity holds and manages your domain in our Cloudflare account — you never
-            have to run a registrar or edit DNS yourself. You just complete onboarding, then create
-            a personal Cloudflare login so we can add you (and anyone else on your team) as a domain
-            admin.
+            have to run a registrar or edit DNS yourself. Domains come <b>after</b> your website: we
+            only spend money on a domain once your site is live and validated on its free GitHub
+            Pages address. Then you create a personal Cloudflare login so we can add you (and anyone
+            else on your team) as a domain admin.
           </p>
         </div>
 
@@ -90,9 +92,11 @@ const HowToOrderDomain = () => {
             style={{ fontFamily: 'Raleway, sans-serif' }}
           >
             You have two supported options: have us register a brand new .org domain, or transfer a
-            domain you already own into Free For Charity&apos;s Cloudflare Registrar. Transferring a
-            domain you already own? You&apos;ll need your current registrar, the authorization (EPP)
-            code, and the domain unlocked with WHOIS privacy turned off before you start.
+            domain you already own into Free For Charity&apos;s Cloudflare Registrar. Both order
+            forms ask for the live GitHub Pages address of your validated website — that&apos;s the
+            gate that unlocks the purchase. Transferring a domain you already own? You&apos;ll also
+            need your current registrar, the authorization (EPP) code, and the domain unlocked with
+            WHOIS privacy turned off before you start.
           </p>
           <div
             id="domain-options"

--- a/src/components/free-charity-web-hosting/WhatsIncluded/index.tsx
+++ b/src/components/free-charity-web-hosting/WhatsIncluded/index.tsx
@@ -18,7 +18,7 @@ const features: Feature[] = [
     icon: <Globe className="w-9 h-9" aria-hidden="true" />,
     title: 'Free .org domain name',
     description:
-      'We register (and pay for) your .org domain through Cloudflare at wholesale cost, or take over managing one you already own.',
+      'Once your site is live and validated, we register (and pay for) your .org domain through Cloudflare at wholesale cost, or take over managing one you already own.',
   },
   {
     icon: <Mail className="w-9 h-9" aria-hidden="true" />,


### PR DESCRIPTION
## Summary

Re-sequences all public journey copy to FFC's new gated flow (epic FreeForCharity/FFC-Cloudflare-Automation#669, refs FreeForCharity/FFC-Cloudflare-Automation#673):

1. Charity application approved (WHMCS)
2. Website application approved → site **built and validated on its free GitHub Pages address** (no custom domain), full FFC footer generated from validated application data
3. **Only then** does FFC spend funds: domain registered/transferred in Cloudflare and pointed at the validated site
4. Email after the domain (unchanged)

Pages updated:
- **charity-onboarding-journey** — stages reordered (Website is now stage 2 "built and proven first", Domain is stage 3 "only after your site is proven"), intro states the funding gate
- **getting-started-checklist** — onboarding phase reordered with the validation-unlocks-domain step
- **domains page** — 4-step card sequence reordered; copy states both domain order forms require the live GitHub Pages URL (matches the new WHMCS required fields); Check-your-org tool copy: check names anytime, purchase happens after validation
- **501c3 FAQ accordion** — website item now precedes domain/email item (was exactly backwards)
- **free-charity-web-hosting / Dear-Prospective** — one-line gating clauses

Tests: journey-page unit test updated to assert the gated order (website < domain < email).

## Test plan

- [x] `npm run lint` clean
- [x] `npm run build` static export succeeds
- [x] `npm run test` — 595/595
- [x] `npx playwright test` — 374 passed, 19 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)