### PR TITLE
chore: add run-ffc-site skill to build, serve, and drive the site

### DIFF
--- a/.claude/skills/run-ffc-site/.gitignore
+++ b/.claude/skills/run-ffc-site/.gitignore
@@ -1,0 +1,1 @@
+screenshots/

--- a/.claude/skills/run-ffc-site/SKILL.md
+++ b/.claude/skills/run-ffc-site/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: run-ffc-site
+description: Build, run, and drive the Free For Charity site (freeforcharity.org). Use when asked to start, build, preview, screenshot, or interact with the FFC website, or verify a page renders. Static Next.js export driven with headless Chromium via .claude/skills/run-ffc-site/driver.mjs.
+---
+
+The Free For Charity site is a Next.js 16 App Router project that ships as a
+**static export** (`output: export` → `out/`). "Running it" means building the
+export, serving `out/` over HTTP, and driving a headless Chromium against it
+with `.claude/skills/run-ffc-site/driver.mjs` — which navigates routes,
+screenshots each full page, and fails on real errors (bad HTTP status,
+uncaught page errors, or same-origin request failures).
+
+All paths below are relative to the repo root.
+
+## Prerequisites
+
+No `apt-get` needed in the Claude Code web container: Node and a Chromium
+build are already present. The driver launches the pre-installed browser at
+`/opt/pw-browsers/chromium` (override with `CHROME_PATH=...`), so you do **not**
+run `npx playwright install` — the repo's pinned Playwright may want a
+different browser build than the container ships, and pointing at the existing
+one avoids the mismatch.
+
+Built and verified on Node v22.22.2 (README targets Node 24.x; the static
+export builds fine on 22).
+
+## Setup
+
+```bash
+npm install        # ~40s; runs husky prepare
+```
+
+## Build
+
+```bash
+npm run build      # static export → out/ (~35 routes, 60+ html files). Do not cancel.
+```
+
+## Run (agent path)
+
+Serve the export in the background, wait for the port, then drive it:
+
+```bash
+# 1. Serve out/ on :4173 (this is `npm run preview`)
+nohup npx serve out -l 4173 >/tmp/serve.log 2>&1 &
+echo $! > /tmp/serve.pid
+timeout 30 bash -c 'until curl -sf http://localhost:4173 >/dev/null; do sleep 1; done'
+
+# 2. Drive it — screenshots a representative route set
+node .claude/skills/run-ffc-site/driver.mjs
+
+# 3. Stop the server when done
+kill $(cat /tmp/serve.pid)
+```
+
+Expected output — every route green, third-party embeds noted as blocked:
+
+```
+✓ / (2 third-party blocked) -> screenshots/home.png
+✓ /about-us/ (2 third-party blocked) -> screenshots/about-us.png
+✓ /501c3/ (2 third-party blocked) -> screenshots/501c3.png
+✓ /privacy-policy/ (2 third-party blocked) -> screenshots/privacy-policy.png
+✓ /search/ (2 third-party blocked) -> screenshots/search.png
+
+✓ 5/5 routes clean
+```
+
+Screenshots (full-page) land in
+`.claude/skills/run-ffc-site/screenshots/<slug>.png`. **Open them** — a green
+run only means nothing threw; look at the image to confirm the page rendered.
+
+### driver.mjs usage
+
+| invocation                                             | what it does                                                      |
+| ------------------------------------------------------ | ----------------------------------------------------------------- |
+| `node .../driver.mjs`                                  | Smoke the default route set (home, about, 501c3, privacy, search) |
+| `node .../driver.mjs / /donate/ /volunteer/`           | Screenshot specific routes                                        |
+| `EXPECT="Free For Charity" node .../driver.mjs /`      | Also assert the text is present in the HTML                       |
+| `BASE_URL=http://localhost:3000 node .../driver.mjs /` | Drive `npm run dev` instead of the export                         |
+| `CHROME_PATH=/path/to/chrome node .../driver.mjs`      | Use a different Chromium binary                                   |
+
+Exit code is 0 only when every route is clean, so it works in a script.
+
+### Driving an interaction
+
+The served export hydrates, so client-side features work. Import Playwright's
+Chromium directly for anything beyond a screenshot — e.g. the `/search/` page's
+live filter:
+
+```bash
+node --input-type=module <<'EOF'
+import { chromium } from 'playwright'
+const b = await chromium.launch({ executablePath:'/opt/pw-browsers/chromium', args:['--no-sandbox'] })
+const p = await (await b.newContext({ viewport:{width:1280,height:800} })).newPage()
+await p.goto('http://localhost:4173/search/', { waitUntil:'networkidle' })
+await p.locator('input').first().fill('domain')
+await p.waitForTimeout(800)
+console.log('matches:', await p.locator('a').filter({ hasText:/domain/i }).count())
+await p.screenshot({ path:'.claude/skills/run-ffc-site/screenshots/search-domain.png' })
+await b.close()
+EOF
+```
+
+## Run (human path)
+
+```bash
+npm run dev        # → http://localhost:3000 with Turbopack HMR. Ctrl-C to stop.
+```
+
+Useless headless on its own (no window); use it as a `BASE_URL` target for the
+driver when iterating on a component, since it rebuilds on save.
+
+## Test
+
+```bash
+npm run lint       # eslint
+npm run build      # verify the static export
+npm run test       # jest unit/component/a11y (jsdom) — not the browser
+npm run test:e2e   # playwright e2e — needs the pinned browser; see gotcha below
+```
+
+## Gotchas
+
+- **Two "console errors" per page are not bugs.** The Zeffy donation embed
+  (`zeffy-scripts.s3.ca-central-1.amazonaws.com`) and the GuideStar seal
+  (`widgets.guidestar.org`) are third-party hosts the sandbox proxy blocks
+  with `ERR_CONNECTION_RESET`. The driver reports these as
+  "N third-party blocked" and does **not** fail on them — it only fails on
+  same-origin problems. The donation iframe and seal render blank in
+  screenshots as a result; that's expected here, not a regression.
+- **`localhost` requests in a raw `requestfailed` listener are prefetches.**
+  Next.js `<Link>` prefetches the RSC payload and aborts them on navigate
+  (`ERR_ABORTED`). The driver filters those out; don't treat them as failures.
+- **Trailing slashes matter.** The export writes `out/about-us/index.html`, so
+  hit `/about-us/`, not `/about-us`. `serve` will 200 either way, but keep the
+  slash to match the deployed cPanel paths.
+- **The repo's Playwright browser build ≠ the container's.** `npm run test:e2e`
+  and any bare `chromium.launch()` try build 1228 and error with "Executable
+  doesn't exist … run npx playwright install". Do not install; pass
+  `executablePath: '/opt/pw-browsers/chromium'` (the driver already does).
+
+## Troubleshooting
+
+- **`browserType.launch: Executable doesn't exist at …chrome-headless-shell`**:
+  Playwright version/browser mismatch. Use the driver (it sets
+  `executablePath`) or export `CHROME_PATH=/opt/pw-browsers/chromium`.
+- **`EADDRINUSE` on :4173 or :3000**: a previous server is still up. Stop it by
+  pidfile (`kill $(cat /tmp/serve.pid)`) or port (`fuser -k 4173/tcp`). Avoid
+  `pkill -f 'serve out'` — that substring also matches the shell running it and
+  kills your own command.
+- **Driver hangs on `networkidle`**: usually a blocked third-party request never
+  settling — it resolves after the 30s nav timeout and the page still
+  screenshots. If it persists, target `BASE_URL` at the built export (`:4173`),
+  which has no live data fetches.

--- a/.claude/skills/run-ffc-site/SKILL.md
+++ b/.claude/skills/run-ffc-site/SKILL.md
@@ -56,11 +56,11 @@ kill $(cat /tmp/serve.pid)
 Expected output — every route green, third-party embeds noted as blocked:
 
 ```
-✓ / (2 third-party blocked) -> screenshots/home.png
-✓ /about-us/ (2 third-party blocked) -> screenshots/about-us.png
-✓ /501c3/ (2 third-party blocked) -> screenshots/501c3.png
-✓ /privacy-policy/ (2 third-party blocked) -> screenshots/privacy-policy.png
-✓ /search/ (2 third-party blocked) -> screenshots/search.png
+✓ / (2 third-party blocked) -> .claude/skills/run-ffc-site/screenshots/home.png
+✓ /about-us/ (2 third-party blocked) -> .claude/skills/run-ffc-site/screenshots/about-us.png
+✓ /501c3/ (2 third-party blocked) -> .claude/skills/run-ffc-site/screenshots/501c3.png
+✓ /privacy-policy/ (2 third-party blocked) -> .claude/skills/run-ffc-site/screenshots/privacy-policy.png
+✓ /search/ (2 third-party blocked) -> .claude/skills/run-ffc-site/screenshots/search.png
 
 ✓ 5/5 routes clean
 ```
@@ -121,13 +121,14 @@ npm run test:e2e   # playwright e2e — needs the pinned browser; see gotcha bel
 
 ## Gotchas
 
-- **Two "console errors" per page are not bugs.** The Zeffy donation embed
-  (`zeffy-scripts.s3.ca-central-1.amazonaws.com`) and the GuideStar seal
-  (`widgets.guidestar.org`) are third-party hosts the sandbox proxy blocks
-  with `ERR_CONNECTION_RESET`. The driver reports these as
-  "N third-party blocked" and does **not** fail on them — it only fails on
-  same-origin problems. The donation iframe and seal render blank in
-  screenshots as a result; that's expected here, not a regression.
+- **Two failed third-party requests per page are not bugs.** The Zeffy donation
+  embed (`zeffy-scripts.s3.ca-central-1.amazonaws.com`) and the GuideStar seal
+  (`widgets.guidestar.org`) are third-party hosts the sandbox proxy blocks with
+  `ERR_CONNECTION_RESET`. The driver counts these (as `requestfailed` events off
+  the target's origin) and reports them as "N third-party blocked" — it does
+  **not** fail on them; it only fails on same-origin problems. The donation
+  iframe and seal render blank in screenshots as a result; that's expected here,
+  not a regression.
 - **`localhost` requests in a raw `requestfailed` listener are prefetches.**
   Next.js `<Link>` prefetches the RSC payload and aborts them on navigate
   (`ERR_ABORTED`). The driver filters those out; don't treat them as failures.

--- a/.claude/skills/run-ffc-site/SKILL.md
+++ b/.claude/skills/run-ffc-site/SKILL.md
@@ -16,10 +16,12 @@ All paths below are relative to the repo root.
 
 No `apt-get` needed in the Claude Code web container: Node and a Chromium
 build are already present. The driver launches the pre-installed browser at
-`/opt/pw-browsers/chromium` (override with `CHROME_PATH=...`), so you do **not**
-run `npx playwright install` — the repo's pinned Playwright may want a
-different browser build than the container ships, and pointing at the existing
-one avoids the mismatch.
+`/opt/pw-browsers/chromium` (override with `CHROME_PATH=...`). **In that
+container** you do **not** run `npx playwright install` — the repo's pinned
+Playwright may want a different browser build than the container ships, and
+pointing at the existing one avoids the mismatch. On a local machine or CI
+without a pre-installed browser, run `npx playwright install chromium` once, or
+set `CHROME_PATH` to a system Chrome/Chromium.
 
 Built and verified on Node v22.22.2 (README targets Node 24.x; the static
 export builds fine on 22).

--- a/.claude/skills/run-ffc-site/SKILL.md
+++ b/.claude/skills/run-ffc-site/SKILL.md
@@ -107,8 +107,9 @@ EOF
 npm run dev        # → http://localhost:3000 with Turbopack HMR. Ctrl-C to stop.
 ```
 
-Useless headless on its own (no window); use it as a `BASE_URL` target for the
-driver when iterating on a component, since it rebuilds on save.
+On its own this is useless in a headless container, since there is no window to
+view. Point the driver at it with `BASE_URL=http://localhost:3000` when
+iterating on a component, because it rebuilds on save.
 
 ## Test
 

--- a/.claude/skills/run-ffc-site/SKILL.md
+++ b/.claude/skills/run-ffc-site/SKILL.md
@@ -132,9 +132,10 @@ npm run test:e2e   # playwright e2e — needs the pinned browser; see gotcha bel
   **not** fail on them; it only fails on same-origin problems. The donation
   iframe and seal render blank in screenshots as a result; that's expected here,
   not a regression.
-- **`localhost` requests in a raw `requestfailed` listener are prefetches.**
-  Next.js `<Link>` prefetches the RSC payload and aborts them on navigate
-  (`ERR_ABORTED`). The driver filters those out; don't treat them as failures.
+- **`ERR_ABORTED` request failures are prefetches, not bugs.** Next.js `<Link>`
+  prefetches the RSC payload and aborts those requests on navigate. The driver
+  drops any `requestfailed` whose error text contains `ERR_ABORTED` (regardless
+  of host), so they never count against a route.
 - **Trailing slashes matter.** The export writes `out/about-us/index.html`, so
   hit `/about-us/`, not `/about-us`. `serve` will 200 either way, but keep the
   slash to match the deployed cPanel paths.
@@ -152,7 +153,9 @@ npm run test:e2e   # playwright e2e — needs the pinned browser; see gotcha bel
   pidfile (`kill $(cat /tmp/serve.pid)`) or port (`fuser -k 4173/tcp`). Avoid
   `pkill -f 'serve out'` — that substring also matches the shell running it and
   kills your own command.
-- **Driver hangs on `networkidle`**: usually a blocked third-party request never
-  settling — it resolves after the 30s nav timeout and the page still
-  screenshots. If it persists, target `BASE_URL` at the built export (`:4173`),
-  which has no live data fetches.
+- **A route is slow to settle**: navigation (`page.goto`, `waitUntil:'load'`) is
+  capped at 30s, and the post-load `networkidle` wait is capped at 5s and
+  ignored on timeout — so a blocked third-party request delays a route by at
+  most ~5s rather than hanging it. A route that exceeds the 30s nav cap fails
+  with a timeout; target `BASE_URL` at the built export (`:4173`), which has no
+  live data fetches.

--- a/.claude/skills/run-ffc-site/driver.mjs
+++ b/.claude/skills/run-ffc-site/driver.mjs
@@ -24,7 +24,7 @@
 import { chromium } from 'playwright'
 import { mkdir } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
-import { dirname, resolve } from 'node:path'
+import { dirname, resolve, relative } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 // The repo's Playwright pins a browser build that may not match the one
@@ -64,6 +64,16 @@ async function main() {
 
   for (const path of targets) {
     const url = path.startsWith('http') ? path : `${BASE_URL}${path}`
+    // Classify by the target's own origin, not BASE_URL — an absolute-URL
+    // arg has its own origin, and BASE_URL wouldn't match it.
+    const origin = new URL(url).origin
+    const sameOrigin = (u) => {
+      try {
+        return new URL(u).origin === origin
+      } catch {
+        return false
+      }
+    }
     const page = await context.newPage()
     const pageErrors = []
     const localFails = [] // same-origin resource failures — real bugs
@@ -72,18 +82,23 @@ async function main() {
     page.on('requestfailed', (r) => {
       const err = r.failure()?.errorText || ''
       if (err.includes('ERR_ABORTED')) return // aborted <Link> prefetches are normal
-      if (r.url().startsWith(BASE_URL)) localFails.push(`${r.url()} (${err})`)
+      if (sameOrigin(r.url())) localFails.push(`${r.url()} (${err})`)
       else extBlocks.push(r.url())
     })
     page.on('response', (r) => {
-      if (r.url().startsWith(BASE_URL) && r.status() >= 400)
+      if (sameOrigin(r.url()) && r.status() >= 400)
         localFails.push(`${r.url()} (HTTP ${r.status()})`)
     })
 
+    const shot = resolve(shotDir, `${slug(path)}.png`)
+    const shotRel = relative(process.cwd(), shot)
     let ok = true
     let detail = ''
     try {
-      const res = await page.goto(url, { waitUntil: 'networkidle', timeout: 30000 })
+      const res = await page.goto(url, { waitUntil: 'load', timeout: 30000 })
+      // Best-effort quiet-network wait: blocked third-party embeds can keep
+      // the network busy indefinitely, so cap it instead of failing on it.
+      await page.waitForLoadState('networkidle', { timeout: 5000 }).catch(() => {})
       const status = res?.status() ?? 0
       if (status >= 400) {
         ok = false
@@ -93,7 +108,6 @@ async function main() {
         ok = false
         detail = `${detail} missing text "${EXPECT}"`.trim()
       }
-      const shot = resolve(shotDir, `${slug(path)}.png`)
       await page.screenshot({ path: shot, fullPage: true })
       if (pageErrors.length) {
         ok = false
@@ -111,7 +125,7 @@ async function main() {
     if (!ok) failures++
     const note = extBlocks.length ? ` (${extBlocks.length} third-party blocked)` : ''
     process.stdout.write(
-      `${ok ? PASS : FAIL} ${path}${detail ? ` — ${detail}` : ''}${note} -> screenshots/${slug(path)}.png\n`
+      `${ok ? PASS : FAIL} ${path}${detail ? ` — ${detail}` : ''}${note} -> ${shotRel}\n`
     )
     await page.close()
   }

--- a/.claude/skills/run-ffc-site/driver.mjs
+++ b/.claude/skills/run-ffc-site/driver.mjs
@@ -81,7 +81,9 @@ async function main() {
 
   for (const path of targets) {
     const rel = path.startsWith('/') ? path : `/${path}`
-    const url = path.startsWith('http') ? path : `${BASE_URL}${rel}`
+    // Only a real scheme counts as absolute — otherwise a route like
+    // `http-status/` would be mistaken for a URL and crash `new URL()`.
+    const url = /^https?:\/\//.test(path) ? path : `${BASE_URL}${rel}`
     // Classify by the target's own origin, not BASE_URL — an absolute-URL
     // arg has its own origin, and BASE_URL wouldn't match it.
     const origin = new URL(url).origin
@@ -155,10 +157,11 @@ async function main() {
   process.stdout.write(
     `\n${failures ? FAIL : PASS} ${targets.length - failures}/${targets.length} routes clean\n`
   )
-  process.exit(failures ? 1 : 0)
+  // Set exitCode rather than process.exit() so stdout flushes fully first.
+  process.exitCode = failures ? 1 : 0
 }
 
 main().catch((e) => {
   console.error(e)
-  process.exit(1)
+  process.exitCode = 1
 })

--- a/.claude/skills/run-ffc-site/driver.mjs
+++ b/.claude/skills/run-ffc-site/driver.mjs
@@ -3,8 +3,10 @@
  * driver.mjs — headless-Chromium harness for the FFC static site.
  *
  * `chromium-cli` isn't available in this container, so this drives
- * Playwright's bundled Chromium directly (the same `playwright` import
- * the repo's visual-regression script uses). It navigates one or more
+ * Chromium through Playwright's API (the same `playwright` import the
+ * repo's visual-regression script uses) — pointed at the container's
+ * pre-installed browser via executablePath, not a Playwright-bundled
+ * download. It navigates one or more
  * routes against a running server, screenshots each, and reports
  * same-origin request failures, bad HTTP responses (>=400), and uncaught
  * page errors. A page that throws or 404s makes the run exit non-zero;
@@ -133,6 +135,9 @@ async function main() {
     } catch (e) {
       ok = false
       detail = String(e).split('\n')[0]
+      // Best-effort artifact even when navigation failed, so the printed
+      // screenshot path points at something on a failing route.
+      await page.screenshot({ path: shot, fullPage: true }).catch(() => {})
     }
 
     if (!ok) failures++

--- a/.claude/skills/run-ffc-site/driver.mjs
+++ b/.claude/skills/run-ffc-site/driver.mjs
@@ -26,7 +26,7 @@
 
 import { chromium } from 'playwright'
 import { mkdir } from 'node:fs/promises'
-import { existsSync } from 'node:fs'
+import { existsSync, statSync, accessSync, constants } from 'node:fs'
 import { dirname, resolve, relative } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -38,8 +38,11 @@ import { fileURLToPath } from 'node:url'
 function resolveChrome() {
   const override = process.env.CHROME_PATH
   if (override) {
-    if (!existsSync(override)) {
-      console.error(`CHROME_PATH="${override}" does not exist.`)
+    try {
+      if (!statSync(override).isFile()) throw new Error('not a file')
+      accessSync(override, constants.X_OK)
+    } catch {
+      console.error(`CHROME_PATH="${override}" is not an executable file.`)
       process.exit(1)
     }
     return override

--- a/.claude/skills/run-ffc-site/driver.mjs
+++ b/.claude/skills/run-ffc-site/driver.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+/*
+ * driver.mjs — headless-Chromium harness for the FFC static site.
+ *
+ * `chromium-cli` isn't available in this container, so this drives
+ * Playwright's bundled Chromium directly (the same `playwright` import
+ * the repo's visual-regression script uses). It navigates one or more
+ * routes against a running server, screenshots each, and reports any
+ * console errors / failed requests / uncaught page errors. A page that
+ * throws or 404s makes the run exit non-zero.
+ *
+ * Prereqs: `npm run build` then a server on BASE_URL (see SKILL.md).
+ *
+ * Usage:
+ *   node .claude/skills/run-ffc-site/driver.mjs                 # smoke a default route set
+ *   node .claude/skills/run-ffc-site/driver.mjs / /about-us/    # specific routes
+ *   BASE_URL=http://localhost:3000 node .../driver.mjs /        # against `npm run dev`
+ *   EXPECT="Free For Charity" node .../driver.mjs /             # assert text is present
+ *
+ * Screenshots land in .claude/skills/run-ffc-site/screenshots/<slug>.png
+ * Exit code: 0 = every route clean, 1 = any route failed.
+ */
+
+import { chromium } from 'playwright'
+import { mkdir } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// The repo's Playwright pins a browser build that may not match the one
+// pre-installed in the container. Prefer the container's stable chromium
+// symlink so we never need `npx playwright install`. Override with
+// CHROME_PATH if needed.
+const CHROME =
+  process.env.CHROME_PATH || ['/opt/pw-browsers/chromium'].find((p) => existsSync(p)) || undefined
+
+const here = dirname(fileURLToPath(import.meta.url))
+const shotDir = resolve(here, 'screenshots')
+
+const BASE_URL = (process.env.BASE_URL || 'http://localhost:4173').replace(/\/$/, '')
+const EXPECT = process.env.EXPECT || ''
+const VIEWPORT = { width: 1280, height: 800 }
+
+// A representative slice of the ~35 routes: home (Figma redesign),
+// a program page, a policy page, and a client-interactive page.
+const DEFAULT_ROUTES = ['/', '/about-us/', '/501c3/', '/privacy-policy/', '/search/']
+
+const routes = process.argv.slice(2)
+const targets = routes.length ? routes : DEFAULT_ROUTES
+
+const slug = (p) => (p.replace(/^\/|\/$/g, '') || 'home').replace(/[^a-z0-9]+/gi, '-')
+
+const PASS = '\x1b[32m✓\x1b[0m'
+const FAIL = '\x1b[31m✗\x1b[0m'
+
+async function main() {
+  await mkdir(shotDir, { recursive: true })
+  const browser = await chromium.launch({
+    args: ['--no-sandbox'],
+    ...(CHROME ? { executablePath: CHROME } : {}),
+  })
+  const context = await browser.newContext({ viewport: VIEWPORT })
+  let failures = 0
+
+  for (const path of targets) {
+    const url = path.startsWith('http') ? path : `${BASE_URL}${path}`
+    const page = await context.newPage()
+    const pageErrors = []
+    const localFails = [] // same-origin resource failures — real bugs
+    const extBlocks = [] // third-party hosts blocked by the sandbox — informational
+    page.on('pageerror', (e) => pageErrors.push(String(e)))
+    page.on('requestfailed', (r) => {
+      const err = r.failure()?.errorText || ''
+      if (err.includes('ERR_ABORTED')) return // aborted <Link> prefetches are normal
+      if (r.url().startsWith(BASE_URL)) localFails.push(`${r.url()} (${err})`)
+      else extBlocks.push(r.url())
+    })
+    page.on('response', (r) => {
+      if (r.url().startsWith(BASE_URL) && r.status() >= 400)
+        localFails.push(`${r.url()} (HTTP ${r.status()})`)
+    })
+
+    let ok = true
+    let detail = ''
+    try {
+      const res = await page.goto(url, { waitUntil: 'networkidle', timeout: 30000 })
+      const status = res?.status() ?? 0
+      if (status >= 400) {
+        ok = false
+        detail = `HTTP ${status}`
+      }
+      if (EXPECT && !(await page.content()).includes(EXPECT)) {
+        ok = false
+        detail = `${detail} missing text "${EXPECT}"`.trim()
+      }
+      const shot = resolve(shotDir, `${slug(path)}.png`)
+      await page.screenshot({ path: shot, fullPage: true })
+      if (pageErrors.length) {
+        ok = false
+        detail = `${detail} pageerror: ${pageErrors[0]}`.trim()
+      }
+      if (localFails.length) {
+        ok = false
+        detail = `${detail} same-origin fail: ${localFails[0]}`.trim()
+      }
+    } catch (e) {
+      ok = false
+      detail = String(e).split('\n')[0]
+    }
+
+    if (!ok) failures++
+    const note = extBlocks.length ? ` (${extBlocks.length} third-party blocked)` : ''
+    process.stdout.write(
+      `${ok ? PASS : FAIL} ${path}${detail ? ` — ${detail}` : ''}${note} -> screenshots/${slug(path)}.png\n`
+    )
+    await page.close()
+  }
+
+  await browser.close()
+  process.stdout.write(
+    `\n${failures ? FAIL : PASS} ${targets.length - failures}/${targets.length} routes clean\n`
+  )
+  process.exit(failures ? 1 : 0)
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/.claude/skills/run-ffc-site/driver.mjs
+++ b/.claude/skills/run-ffc-site/driver.mjs
@@ -31,9 +31,20 @@ import { fileURLToPath } from 'node:url'
 // The repo's Playwright pins a browser build that may not match the one
 // pre-installed in the container. Prefer the container's stable chromium
 // symlink so we never need `npx playwright install`. Override with
-// CHROME_PATH if needed.
-const CHROME =
-  process.env.CHROME_PATH || ['/opt/pw-browsers/chromium'].find((p) => existsSync(p)) || undefined
+// CHROME_PATH if needed — validated up front so a bad path fails loudly
+// here instead of as an opaque Playwright launch error later.
+function resolveChrome() {
+  const override = process.env.CHROME_PATH
+  if (override) {
+    if (!existsSync(override)) {
+      console.error(`CHROME_PATH="${override}" does not exist.`)
+      process.exit(1)
+    }
+    return override
+  }
+  return ['/opt/pw-browsers/chromium'].find((p) => existsSync(p)) || undefined
+}
+const CHROME = resolveChrome()
 
 const here = dirname(fileURLToPath(import.meta.url))
 const shotDir = resolve(here, 'screenshots')
@@ -64,7 +75,8 @@ async function main() {
   let failures = 0
 
   for (const path of targets) {
-    const url = path.startsWith('http') ? path : `${BASE_URL}${path}`
+    const rel = path.startsWith('/') ? path : `/${path}`
+    const url = path.startsWith('http') ? path : `${BASE_URL}${rel}`
     // Classify by the target's own origin, not BASE_URL — an absolute-URL
     // arg has its own origin, and BASE_URL wouldn't match it.
     const origin = new URL(url).origin

--- a/.claude/skills/run-ffc-site/driver.mjs
+++ b/.claude/skills/run-ffc-site/driver.mjs
@@ -5,9 +5,10 @@
  * `chromium-cli` isn't available in this container, so this drives
  * Playwright's bundled Chromium directly (the same `playwright` import
  * the repo's visual-regression script uses). It navigates one or more
- * routes against a running server, screenshots each, and reports any
- * console errors / failed requests / uncaught page errors. A page that
- * throws or 404s makes the run exit non-zero.
+ * routes against a running server, screenshots each, and reports
+ * same-origin request failures, bad HTTP responses (>=400), and uncaught
+ * page errors. A page that throws or 404s makes the run exit non-zero;
+ * blocked third-party requests are counted but never fail the run.
  *
  * Prereqs: `npm run build` then a server on BASE_URL (see SKILL.md).
  *


### PR DESCRIPTION
## What

Adds a Claude Code **run skill** at `.claude/skills/run-ffc-site/` so a future agent (or human) can build, serve, and actually *drive* the site from a clean machine — not just read about it.

The site ships as a Next.js 16 **static export** (`output: export` → `out/`), so "running it" means: build the export, serve `out/` over HTTP, and drive a headless Chromium against it.

## Files

- **`driver.mjs`** — a Playwright-Chromium harness. Navigates a route set, screenshots each full page, and exits non-zero on *real* problems only: bad HTTP status, uncaught page errors, or same-origin request failures. It:
  - launches the container's pre-installed browser at `/opt/pw-browsers/chromium` (override with `CHROME_PATH`) to sidestep the Playwright browser-build mismatch, so no `npx playwright install` is needed;
  - treats sandbox-blocked third-party embeds (Zeffy donation script, GuideStar seal) as informational ("N third-party blocked"), not failures;
  - ignores aborted Next.js `<Link>` prefetches;
  - supports `BASE_URL` (drive `npm run dev` or the export), `EXPECT` (assert text present), and explicit route args.
- **`SKILL.md`** — short, agent-facing man page: verified build/serve/drive steps, a driver usage table, an interaction example (typing into the `/search/` live filter), plus Gotchas and Troubleshooting captured while bringing it up headless.
- **`.gitignore`** — screenshots are generated proof, not committed.

## Verified in this container

- `npm install` → `npm run build` → serve `out/` on `:4173` → `node .claude/skills/run-ffc-site/driver.mjs` → **5/5 routes clean**, screenshots written.
- Negative check: a nonexistent route correctly fails with `HTTP 404` (exit 1).
- Interaction check: typing `domain` into `/search/` returns live client-side results (export hydrates).
- Driver also verified against `npm run dev` on `:3000`.
- Pre-commit hooks (Prettier + ESLint) pass.

The skill directory is auto-discovered by Claude Code and loads on requests like "run the FFC site" or "screenshot the homepage."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8MTPYKQ1FDQbuoXGKYjfW)_