### PR TITLE
fix(journey): purge remaining old-order copy; harden eligibility guide + tests

### DIFF
--- a/__tests__/components/ui/apply-options.test.tsx
+++ b/__tests__/components/ui/apply-options.test.tsx
@@ -4,17 +4,26 @@
  * the inline "Help me choose" panel behaviour, and component-level a11y.
  */
 import React from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, within } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { axe } from '../../utils/axe'
 import ApplyOptions from '@/components/ui/ApplyOptions'
+import { hubAddProduct, ONBOARDING_PID } from '@/lib/config'
+
+/** The revealed recommendation panel (aria-live region) — scoping queries here
+ *  keeps assertions from being satisfied by the page-level apply buttons. */
+function resultPanel(container: HTMLElement): HTMLElement {
+  const panel = container.querySelector('[aria-live="polite"]')
+  if (!panel) throw new Error('no recommendation panel revealed')
+  return panel as HTMLElement
+}
 
 describe('ApplyOptions', () => {
   it('renders both apply links to the stable WHMCS onboarding products', () => {
     render(<ApplyOptions />)
     const hrefs = screen.getAllByRole('link').map((a) => a.getAttribute('href') ?? '')
-    expect(hrefs.some((h) => h.includes('a=add&pid=33'))).toBe(true) // full 501(c)(3)
-    expect(hrefs.some((h) => h.includes('a=add&pid=16'))).toBe(true) // pre-501(c)3
+    expect(hrefs).toContain(hubAddProduct(ONBOARDING_PID.full501c3))
+    expect(hrefs).toContain(hubAddProduct(ONBOARDING_PID.pre501c3))
     for (const h of hrefs) expect(h).not.toContain('confproduct')
   })
 
@@ -34,25 +43,52 @@ describe('ApplyOptions', () => {
   })
 
   it('routes veterans / other 501(c) types to the 501(c)(3) application', () => {
-    render(<ApplyOptions />)
+    const { container } = render(<ApplyOptions />)
     fireEvent.click(screen.getByRole('radio', { name: /veterans post or another 501\(c\) type/i }))
-    expect(screen.getByText(/pick the organization type that matches/i)).toBeInTheDocument()
-    // The apply CTA in the revealed panel still deep-links to pid 33.
-    const links = screen
-      .getAllByRole('link', { name: /Apply as a 501\(c\)\(3\) charity/ })
-      .map((a) => a.getAttribute('href') ?? '')
-    expect(links.every((h) => h.includes('a=add&pid=33'))).toBe(true)
+    const panel = within(resultPanel(container))
+    expect(panel.getByText(/pick the organization type that matches/i)).toBeInTheDocument()
+    // The apply CTA inside the revealed panel itself deep-links to pid 33 —
+    // scoped to the panel so the page-level card button can't satisfy this.
+    expect(panel.getByRole('link', { name: /Apply as a 501\(c\)\(3\) charity/ })).toHaveAttribute(
+      'href',
+      hubAddProduct(ONBOARDING_PID.full501c3)
+    )
   })
 
   it('tells fiscally sponsored projects their sponsor must apply and approve them', () => {
-    render(<ApplyOptions />)
+    const { container } = render(<ApplyOptions />)
     fireEvent.click(screen.getByRole('radio', { name: /under a fiscal sponsor/i }))
-    expect(screen.getByText(/must apply and approve your project/i)).toBeInTheDocument()
+    const panel = within(resultPanel(container))
+    expect(panel.getByText(/must apply and approve your project/i)).toBeInTheDocument()
     // The email-grant rationale is stated — the reason the sponsor is required.
-    expect(screen.getByText(/email grants attach to the sponsor/i)).toBeInTheDocument()
+    expect(panel.getByText(/email grants attach to the sponsor/i)).toBeInTheDocument()
+    // Both affordances render: the sponsor's 501(c)(3) application AND the
+    // project's own pre-501(c)(3) path the copy recommends.
+    expect(panel.getByRole('link', { name: /Apply as a 501\(c\)\(3\) charity/ })).toHaveAttribute(
+      'href',
+      hubAddProduct(ONBOARDING_PID.full501c3)
+    )
     expect(
-      screen.getByRole('link', { name: /How we evaluate fiscal sponsorship/i })
+      panel.getByRole('link', { name: /Apply as a pre-501\(c\)\(3\) organization/ })
+    ).toHaveAttribute('href', hubAddProduct(ONBOARDING_PID.pre501c3))
+    // Corporate fiscal sponsors are steered to talk with FFC first.
+    expect(panel.getByText(/talk with us first/i)).toBeInTheDocument()
+    expect(
+      panel.getByRole('link', { name: /How we evaluate fiscal sponsorship/i })
     ).toHaveAttribute('href', 'https://ffcadmin.org/intake-help/fiscal-sponsorship/')
+  })
+
+  it('gives over-$1M organizations the graceful out-path, not an application', () => {
+    const { container } = render(<ApplyOptions />)
+    fireEvent.click(screen.getByRole('radio', { name: /annual revenue is \$1 million or more/i }))
+    const panel = within(resultPanel(container))
+    expect(panel.getByText(/reserved for charities with annual revenue under/i)).toBeInTheDocument()
+    expect(panel.getByRole('link', { name: 'TechSoup' })).toHaveAttribute(
+      'href',
+      'https://www.techsoup.org/'
+    )
+    // No apply button in this panel — it's a decline, not a routing.
+    expect(panel.queryByRole('link', { name: /Apply as a/ })).not.toBeInTheDocument()
   })
 
   it('routes non-US organizations to TechSoup as the graceful out-path', () => {

--- a/src/app/charity-faq/page.tsx
+++ b/src/app/charity-faq/page.tsx
@@ -57,9 +57,10 @@ const faqs: { question: string; answer: React.ReactNode }[] = [
     question: 'How long does onboarding take, and what happens when?',
     answer: (
       <>
-        Domain and email typically land within the first week or two; the website takes 2–6 weeks
-        depending mostly on how quickly content (logo, photos, text) is ready. The full picture is
-        in{' '}
+        Your website comes first: it takes 2–6 weeks depending mostly on how quickly content (logo,
+        photos, text) is ready, and goes live on its free GitHub Pages address. Once it&rsquo;s
+        validated, your domain lands the same week, and email a few days after that. The full
+        picture is in{' '}
         <Link href="/charity-onboarding-journey/" className="text-[#0567B1] underline">
           your onboarding journey
         </Link>

--- a/src/app/getting-started-checklist/page.tsx
+++ b/src/app/getting-started-checklist/page.tsx
@@ -39,8 +39,8 @@ export default function GettingStartedChecklist() {
         <div className="prose max-w-none font-[var(--font-lato)] text-[18px] leading-[28px] print:text-[13px] print:leading-[19px]">
           <p className="print:hidden">
             One page, three phases — everything a new charity gathers and does on the way to a free
-            domain, email, and website. Print it (this page is print-formatted) or work through it
-            on screen; each item links to the guide that explains it.
+            website, domain, and email (in that order). Print it (this page is print-formatted) or
+            work through it on screen; each item links to the guide that explains it.
           </p>
 
           <h2 className={h2}>Before you apply</h2>

--- a/src/app/m365-email-guide/page.tsx
+++ b/src/app/m365-email-guide/page.tsx
@@ -35,14 +35,16 @@ export default function M365EmailGuide() {
           <p>
             Microsoft&rsquo;s nonprofit grant covers 501(c)(3) organizations (and equivalents).
             You&rsquo;ll need your EIN and legal organization details. If you&rsquo;re pre-501c3,
-            start with our <Link href="/pre501c3/">Pre-501c3 onboarding</Link> — you can still get a
-            domain and prepare everything else while your determination is pending.
+            start with our <Link href="/pre501c3/">Pre-501c3 onboarding</Link> — you can get your
+            website built and prepare everything else while your determination is pending.
           </p>
 
           <h2 className={h2}>Step 2 — Have a domain ready</h2>
           <p>
-            Your email lives at your domain, so the domain comes first. FFC buys and manages .org
-            domains for supported charities at no cost — see{' '}
+            Your email lives at your domain, so you need the domain before email. In the FFC journey
+            the domain arrives right after your website is validated on its free GitHub Pages
+            address — so by the time you start this guide, it&rsquo;s usually already in place. FFC
+            buys and manages .org domains for supported charities at no cost — see{' '}
             <Link href="/domains/#check-your-domain">choosing your .org domain</Link> if you
             don&rsquo;t have one yet.
           </p>

--- a/src/components/domains/Check-Your-Org/index.tsx
+++ b/src/components/domains/Check-Your-Org/index.tsx
@@ -165,6 +165,15 @@ const CheckYourOrg = () => {
                 >
                   Get {result.name}.org free &raquo;
                 </a>
+                <p className="mt-3 text-[14px] text-[#555]">
+                  Heads up: the order form asks for the live GitHub Pages address of your validated
+                  website — we purchase domains only after your site is proven. No site yet? Note
+                  the name and start with{' '}
+                  <Link href="/help-for-charities/" className="text-[#0567B1] underline">
+                    onboarding
+                  </Link>
+                  .
+                </p>
               </>
             ) : result.org === 'registered' ? (
               <>
@@ -181,6 +190,10 @@ const CheckYourOrg = () => {
                 >
                   It’s mine — transfer it to FFC &raquo;
                 </a>
+                <p className="mt-3 text-[14px] text-[#555]">
+                  Transfers are processed once your FFC website is live and validated on its GitHub
+                  Pages address — the order form asks for that URL.
+                </p>
               </>
             ) : (
               <p className="text-[16px] text-[#555]">

--- a/src/components/domains/Curved-Black-Section/index.tsx
+++ b/src/components/domains/Curved-Black-Section/index.tsx
@@ -63,9 +63,10 @@ const Index = () => {
             data-font="aria-font"
           >
             DOMAIN NAME COUPON CODE Thank you for choosing us to help with your domain name and
-            email setup. To get the code please complete the onboarding form for either 501c3 or
-            pre-501c3 and you will see the code in the email confirmation that comes after you
-            finish. If you run into any questions, contact Clarke Moyer (520) 222-8104.
+            email setup. Complete the onboarding form for either 501c3 or pre-501c3 and the code
+            arrives in the email confirmation that comes after you finish — hold onto it. The domain
+            order itself unlocks later, once your website is live and validated on its free GitHub
+            Pages address. If you run into any questions, contact Clarke Moyer (520) 222-8104.
           </p>
         </div>
       </div>

--- a/src/components/domains/Get-New-Website/index.tsx
+++ b/src/components/domains/Get-New-Website/index.tsx
@@ -18,11 +18,11 @@ const index = () => {
               className="mb-[13px] w-[85%] mx-auto font-[500] text-[20px] leading-[30px] text-center"
               data-font="raleway-font"
             >
-              Your domain and email come with a website. Free For Charity builds each charity a
-              fast, secure static website on GitHub Pages from the FFC template, and a volunteer
-              sets it up and launches it on your Cloudflare-managed domain. New builds run on a
-              backlog — we aim to support 100 charities a year — and how quickly your site goes live
-              depends mainly on how ready your content is.
+              Your website comes first — the domain and email follow it. Free For Charity builds
+              each charity a fast, secure static website on GitHub Pages from the FFC template,
+              validates it live on its free GitHub Pages address, and then registers your .org and
+              points it there. New builds run on a backlog — we aim to support 100 charities a year
+              — and how quickly your site goes live depends mainly on how ready your content is.
             </p>
           </div>
         </div>

--- a/src/components/free-charity-web-hosting/FAQs/index.tsx
+++ b/src/components/free-charity-web-hosting/FAQs/index.tsx
@@ -184,15 +184,17 @@ const AccordionLayout = () => {
                 Ways to get in faster:
                 <ul className="list-disc list-inside mt-1">
                   <li>
-                    If you already have your 501(c)3 get your free domain from us{' '}
+                    Complete onboarding and pick your .org name early — check availability at{' '}
                     <a href="/domains/" className="text-[#0567B1]">
                       (https://freeforcharity.org/domains)
-                    </a>
+                    </a>{' '}
+                    — we purchase it once your site is validated
                   </li>
                   <li>
                     If you arrive with your content ready to go — logo, photos, mission text, and
-                    program descriptions — your GitHub Pages site can be built and launched much
-                    faster, which may move you up in the list.
+                    program descriptions — your GitHub Pages site can be built and validated much
+                    faster, which unlocks your domain and email sooner and may move you up in the
+                    list.
                   </li>
                 </ul>
               </AccordionItem>

--- a/src/components/free-charity-web-hosting/HowToApply/index.tsx
+++ b/src/components/free-charity-web-hosting/HowToApply/index.tsx
@@ -24,13 +24,13 @@ const steps: Step[] = [
     number: '3',
     title: 'We build your site',
     description:
-      'Send your logo, photos, and mission text. A volunteer registers your domain, sets up Microsoft 365, and builds your site, reviewing it with you along the way.',
+      'Send your logo, photos, and mission text. A volunteer builds your site from the FFC template, reviewing it with you along the way, and it goes live on its free GitHub Pages address.',
   },
   {
     number: '4',
-    title: 'Launch & stay supported',
+    title: 'Domain, email & ongoing support',
     description:
-      'Your site goes live on your .org domain. We keep it hosted and maintained so it stays fast, secure, and online — free, going forward.',
+      'Once your site is validated, we register your .org domain, point it at your site, and set up Microsoft 365. We keep it all hosted and maintained — free, going forward.',
   },
 ]
 

--- a/src/components/free-for-charity-ffc-web-developer-training-guide-components/Hero/index.tsx
+++ b/src/components/free-for-charity-ffc-web-developer-training-guide-components/Hero/index.tsx
@@ -210,11 +210,13 @@ const Index = () => {
 
             <li className="leading-[26px] pl-[0.5rem] mb-[0.75rem] text-[14px] font-[500] text-[#333d47]">
               <span className="font-[600] text-[#1c2a38]">Domain Purchase & Configuration:</span>{' '}
-              Guide the charity through purchasing a{' '}
+              After the charity&apos;s website is live and validated on its GitHub Pages address,
+              guide them through ordering their{' '}
               <code className="bg-[#f1f3f5] text-[#B82B5A] py-[0.3em] px-[0.5em] rounded-[6px] text-[0.9em]">
                 .org
               </code>{' '}
-              domain via WHMCS and confirm coupon codes from onboarding emails.
+              domain via WHMCS (the order form requires the live GitHub Pages URL) and confirm the
+              coupon code from their onboarding emails.
             </li>
           </ul>
 

--- a/src/components/home-page/FrequentlyAskedQuestions/index.tsx
+++ b/src/components/home-page/FrequentlyAskedQuestions/index.tsx
@@ -266,13 +266,15 @@ const index = () => {
             <p>
               <strong>Ways to get in faster:</strong>
               <br />
-              1. If you already have your 501(c)3 get your free domain from us{' '}
+              1. Complete onboarding and pick your .org name early — check availability at{' '}
               <a href="/domains/" className="text-[#1c6e92] underline">
                 freeforcharity.org/domains
-              </a>
+              </a>{' '}
+              (we purchase it once your site is validated).
               <br />
               2. If you arrive content-ready — with your logo, photos, mission statement, and
-              program text prepared — you may be moved up in the list.
+              program text prepared — your site gets built and validated sooner, which unlocks your
+              domain and email sooner.
             </p>
           </FrequentlyAskedQuestions>
 

--- a/src/components/online-impacts-onboarding-guide-components/Ready-To-Get-Started-Now/index.tsx
+++ b/src/components/online-impacts-onboarding-guide-components/Ready-To-Get-Started-Now/index.tsx
@@ -18,44 +18,14 @@ const index = () => {
           />
         </div>
 
-        <AccordionItem
-          number="3"
-          title=" Free For Charity Domain Name and Microsoft 365 Email Hosting Request"
-        >
-          <p className="text-[18px] font-[500] text-[#4a4a4a] mb-[1em]" data-font="lato-font">
-            Free For Charity Provides free .org domain names to US 501c3 organizations. Once your
-            onboarding forms are accepted you will receive an email from the system with the
-            discount code to request a new domain name or to transfer your current domain name to us
-            so we can start managing it and paying the annual fees.
-          </p>
-
-          <p className="text-[18px] font-[700] text-[#4a4a4a] mb-[1em]">
-            Visit{' '}
-            <a href="/domains/" className="text-[#0567B1]">
-              https://freeforcharity.org/domains
-            </a>{' '}
-            and follow all steps
-          </p>
-          <p className="text-[18px] font-[500] text-[#4a4a4a] mb-[1em]">
-            Once we have the domain name under management we can then set up your professional email
-            addresses e.g. board@yourcharityname.org
-          </p>
-          <p className="text-[18px] font-[700] text-[#4a4a4a]">
-            As always if you run into problems contact us at anytime{' '}
-            <a href="mailto:clarkemoyer@freeforcharity.org" className="text-[#0567B1]">
-              clarkemoyer@freeforcharity.org
-            </a>{' '}
-            520-222-8104
-          </p>
-        </AccordionItem>
-
-        <AccordionItem number="4" title=" Your Website (GitHub Pages)">
+        <AccordionItem number="3" title=" Your Website (GitHub Pages) — built and proven first">
           <div className="space-y-6 font-[500] text-[#666]">
             <p className="pb-4 leading-relaxed">
-              Free For Charity builds your website for you. We start from our tested FFC template
-              and publish a fast, secure GitHub Pages static site, then launch it on the
-              Cloudflare-managed domain we set up in the previous step. There is nothing for you to
-              install, host, or maintain — no servers, control panels, or plugins to manage.
+              Free For Charity builds your website for you. Once your onboarding application is
+              approved, we start from our tested FFC template and publish a fast, secure GitHub
+              Pages static site. Your site goes live on its free GitHub Pages address first — no
+              custom domain yet — and we validate it with you end to end. There is nothing for you
+              to install, host, or maintain — no servers, control panels, or plugins to manage.
             </p>
 
             <div>
@@ -65,7 +35,10 @@ const index = () => {
                 <li>
                   Publishing it as a GitHub Pages static site (fast, secure, and free to host)
                 </li>
-                <li>Connecting it to your Cloudflare-managed domain with HTTPS</li>
+                <li>
+                  Validating it live on its GitHub Pages address, then connecting it to your
+                  Cloudflare-managed domain with HTTPS once we register it
+                </li>
                 <li>Ongoing hosting, updates, and maintenance</li>
               </ul>
             </div>
@@ -90,6 +63,38 @@ const index = () => {
               520-222-8104
             </p>
           </div>
+        </AccordionItem>
+
+        <AccordionItem
+          number="4"
+          title=" Free For Charity Domain Name and Microsoft 365 Email Hosting Request"
+        >
+          <p className="text-[18px] font-[500] text-[#4a4a4a] mb-[1em]" data-font="lato-font">
+            Free For Charity provides free .org domain names to US 501c3 organizations. Once your
+            website is live and validated on its GitHub Pages address, request your domain — we
+            register a new .org (or transfer your current domain name to us), point it at your
+            validated site, and manage it while paying the annual fees. We only purchase domains for
+            websites that are already working and validated.
+          </p>
+
+          <p className="text-[18px] font-[700] text-[#4a4a4a] mb-[1em]">
+            Visit{' '}
+            <a href="/domains/" className="text-[#0567B1]">
+              https://freeforcharity.org/domains
+            </a>{' '}
+            and follow all steps
+          </p>
+          <p className="text-[18px] font-[500] text-[#4a4a4a] mb-[1em]">
+            Once we have the domain name under management we can then set up your professional email
+            addresses e.g. board@yourcharityname.org
+          </p>
+          <p className="text-[18px] font-[700] text-[#4a4a4a]">
+            As always if you run into problems contact us at anytime{' '}
+            <a href="mailto:clarkemoyer@freeforcharity.org" className="text-[#0567B1]">
+              clarkemoyer@freeforcharity.org
+            </a>{' '}
+            520-222-8104
+          </p>
         </AccordionItem>
       </div>
     </div>

--- a/src/components/pre501c3-components/charity/index.tsx
+++ b/src/components/pre501c3-components/charity/index.tsx
@@ -24,7 +24,7 @@ const index = () => {
           />
           <HelpForCharities
             title="–What Happens Next–"
-            description="Ready to get your website live? Once you’re accepted, you’ll order your free domain name and GitHub Pages website services. At checkout you’ll see a small $1 verification charge — it simply confirms that each request comes from a real charity — and a discount code that brings your total down to $0 arrives in your onboarding acceptance email (we never post the code publicly). Charity email through Microsoft 365 or Google Workspace becomes available once your 501(c)(3) status is approved."
+            description="Ready to get your website live? Once you’re accepted, you’ll order your GitHub Pages website service and we’ll build your site — it goes live and is validated on its free GitHub Pages address first. After your site is validated, you’ll order your free domain name and we’ll point it at your proven site. At checkout you’ll see a small $1 verification charge — it simply confirms that each request comes from a real charity — and a discount code that brings your total down to $0 arrives in your onboarding acceptance email (we never post the code publicly). Charity email through Microsoft 365 or Google Workspace becomes available once your 501(c)(3) status is approved."
             descriptionAlign="left"
           />
         </div>

--- a/src/components/ui/HelpMeChoose.tsx
+++ b/src/components/ui/HelpMeChoose.tsx
@@ -3,6 +3,7 @@
 import React, { useId, useState } from 'react'
 import Link from 'next/link'
 import { ApplyButton } from '@/components/ui/apply-buttons'
+import { ffcAdminUrl, adminLinks } from '@/data/admin-links'
 
 /**
  * Inline "Help me choose" guide — a native <details> disclosure with native
@@ -81,19 +82,46 @@ const choices: ChoiceOutcome[] = [
           sponsor&apos;s 501(c)(3) — without it we can&apos;t set up your charity email later.
         </p>
         <p className="mb-[16px]">
-          Send your sponsor to this application (and if you&apos;re also pursuing your own
-          501(c)(3), apply as a pre-501(c)(3) too):
+          <b>Your sponsor</b> uses this application (send them this link):
         </p>
         <ApplyButton kind="full501c3" />
+        <p className="mt-[16px] mb-[16px]">
+          Pursuing your own 501(c)(3) as well? Then <b>your project</b> also applies here:
+        </p>
+        <ApplyButton kind="pre501c3" />
         <p className="mt-[16px]">
+          Sponsored by a corporate fiscal sponsor (Tides, Open Collective, Players Philanthropy
+          Fund)? Talk with us first — those arrangements score differently.{' '}
           <a
-            href="https://ffcadmin.org/intake-help/fiscal-sponsorship/"
+            href={ffcAdminUrl(adminLinks['fiscal-sponsorship'].newModel)}
             className="text-[#0567B1] font-[600] underline"
           >
             How we evaluate fiscal sponsorship
           </a>
         </p>
       </div>
+    ),
+  },
+  {
+    label: 'Our annual revenue is $1 million or more',
+    result: (
+      <p>
+        Free For Charity&apos;s free program is reserved for charities with annual revenue under{' '}
+        <b>$1&nbsp;million</b> — it&apos;s a hard gate, so we focus our volunteers where the need is
+        greatest. Organizations your size typically fund commercial web services directly, and{' '}
+        <a href="https://www.techsoup.org/" className="text-[#0567B1] font-[600] underline">
+          TechSoup
+        </a>{' '}
+        offers deeply discounted software. If you&apos;d like to help smaller charities, you can{' '}
+        <Link href="/volunteer/" className="text-[#0567B1] font-[600] underline">
+          volunteer
+        </Link>{' '}
+        or{' '}
+        <Link href="/donate/" className="text-[#0567B1] font-[600] underline">
+          support the mission
+        </Link>
+        .
+      </p>
     ),
   },
   {

--- a/src/data/admin-links.ts
+++ b/src/data/admin-links.ts
@@ -65,6 +65,9 @@ export const adminLinks = {
   'contributor-ladder': {
     newModel: '/contributor-ladder/',
   },
+  'fiscal-sponsorship': {
+    newModel: '/intake-help/fiscal-sponsorship/',
+  },
   'workforce-development': {
     newModel: '/training/',
   },

--- a/tests/onboarding-journey.spec.ts
+++ b/tests/onboarding-journey.spec.ts
@@ -41,8 +41,8 @@ test.describe('Domains page — Cloudflare model, dual email (#447/#448/#449)', 
 })
 
 test.describe('Onboarding journey page — Website before Email (#450)', () => {
-  // The strict numbered stage ordering (3. Website before 4. Email) is
-  // asserted in the unit test __tests__/app/charity-onboarding-journey.test.tsx,
+  // The strict numbered stage ordering (2. Website before 3. Domain before
+  // 4. Email) is asserted in the unit test __tests__/app/charity-onboarding-journey.test.tsx,
   // which parses the headings directly. Here we assert the customer-visible
   // outcome: the email stage states the live-website prerequisite and both
   // providers are offered.

--- a/tests/wizards.spec.ts
+++ b/tests/wizards.spec.ts
@@ -32,7 +32,7 @@ test.describe('On-page "Help me choose" apply guide', () => {
 
     const guide = page.locator('details').filter({ hasText: 'Help me choose' }).first()
     await guide.locator('summary').click()
-    await guide.getByText('We’re based outside the United States').click()
+    await guide.getByText(/based outside the United States/).click()
 
     const result = guide.locator('[aria-live="polite"]')
     await expect(result.getByRole('link', { name: 'TechSoup' })).toHaveAttribute(
@@ -46,7 +46,7 @@ test.describe('On-page "Help me choose" apply guide', () => {
 
     const guide = page.locator('details').filter({ hasText: 'Help me choose' }).first()
     await guide.locator('summary').click()
-    await guide.getByText('We’re a project under a fiscal sponsor').click()
+    await guide.getByText(/a project under a fiscal sponsor/).click()
 
     const result = guide.locator('[aria-live="polite"]')
     await expect(result.getByText(/must apply and approve your project/i)).toBeVisible()


### PR DESCRIPTION
## Summary

Fixes all freeforcharity.org findings from the max-effort review of the gated-journey rollout (refs FreeForCharity/FFC-Cloudflare-Automation#669):

**Stale old-order copy purged (9 surfaces)** — every remaining place that still told charities the domain comes before the website:
- Online Impacts guide accordions (reordered: website built + validated first, then domain + email)
- /domains **Curved-Black-Section** (coupon arrives at onboarding, but the domain order *unlocks after site validation*) and **Get-New-Website** ('website comes first' framing)
- /free-charity-web-hosting **HowToApply** step cards (step 3 = build on GitHub Pages, step 4 = domain + M365 after validation)
- **charity-faq** timeline answer (website 2–6 weeks first, then domain same week, then email)
- Home-page + web-hosting **'ways to get in faster' FAQs** (old tip was impossible under the gate)
- **M365 email guide** steps 1–2 (domain arrives after site validation)
- **/pre501c3 What-Happens-Next** (website service first, domain after validation; $1/coupon mechanics kept)
- **Web-developer training guide** domain chapter (order domain only after validated GH Pages site)

**Eligibility guide hardened:**
- Fiscal-sponsorship panel: sponsor's 501(c)(3) button AND the project's pre-501(c)(3) button, audience-labeled; corporate-sponsor (Tides/Open Collective/PPF) talk-to-us-first caveat; ffcadmin link now via the admin-links registry
- New **over-$1M revenue out-path** (the founder-approved hard gate the wizard never screened)
- Check-your-org verdict cards state the purchase gate next to the CTAs

**Test hardening:** panel-scoped assertions (kills the vacuous pid-33 check), pid literals → `hubAddProduct(ONBOARDING_PID…)`, glyph-safe e2e locators, stale comment fixed, new $1M test.

## Test plan
- [x] lint clean · build passes · **596/596 unit** · **374 passed / 19 skipped e2e**

🤖 Generated with [Claude Code](https://claude.com/claude-code)