### PR TITLE
feat: two-template chooser section + banned old-order phrase CI guard

### DIFF
--- a/__tests__/components/free-charity-web-hosting/ChooseYourTemplate/index.test.tsx
+++ b/__tests__/components/free-charity-web-hosting/ChooseYourTemplate/index.test.tsx
@@ -1,0 +1,81 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import ChooseYourTemplate from '@/components/free-charity-web-hosting/ChooseYourTemplate'
+import { axe } from '../../../utils/axe'
+
+describe('ChooseYourTemplate Component', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<ChooseYourTemplate />)
+    expect(container).toBeInTheDocument()
+  })
+
+  it('renders the "Choose your starting point" section heading', () => {
+    render(<ChooseYourTemplate />)
+    const heading = screen.getByRole('heading', { name: /Choose your starting point/i })
+    expect(heading).toBeInTheDocument()
+  })
+
+  it('has the section id and scroll offset for anchor navigation', () => {
+    const { container } = render(<ChooseYourTemplate />)
+    const section = container.querySelector('section#choose-your-template')
+    expect(section).toBeInTheDocument()
+    expect(section?.className).toContain('scroll-mt-')
+  })
+
+  it('renders both template cards with their eyebrows', () => {
+    render(<ChooseYourTemplate />)
+    expect(screen.getByRole('heading', { name: /Single Page Site Template/i })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /Footer-Only Template/i })).toBeInTheDocument()
+    expect(screen.getByText(/Starting fresh\?/i)).toBeInTheDocument()
+    expect(screen.getByText(/Already love your website\?/i)).toBeInTheDocument()
+  })
+
+  it('describes the gated journey outcome on both cards (site validated, then domain)', () => {
+    render(<ChooseYourTemplate />)
+    const outcome = screen.getAllByText(
+      /your site validated live on its free GitHub Pages address, which unlocks your free \.org domain/i
+    )
+    expect(outcome).toHaveLength(2)
+  })
+
+  it('links each card to its GitHub template repository', () => {
+    render(<ChooseYourTemplate />)
+    const singlePageLink = screen.getByRole('link', {
+      name: /View the Single Page template on GitHub/i,
+    })
+    expect(singlePageLink).toHaveAttribute(
+      'href',
+      'https://github.com/FreeForCharity/FFC-IN-FFC_Single_Page_Template'
+    )
+    const footerOnlyLink = screen.getByRole('link', {
+      name: /View the Footer-Only template on GitHub/i,
+    })
+    expect(footerOnlyLink).toHaveAttribute(
+      'href',
+      'https://github.com/FreeForCharity/FFC-IN-Footer-Only-Template'
+    )
+    ;[singlePageLink, footerOnlyLink].forEach((link) => {
+      expect(link).toHaveAttribute('target', '_blank')
+      expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+    })
+  })
+
+  it('renders an apply CTA on each card pointing at the #apply anchor', () => {
+    render(<ChooseYourTemplate />)
+    const ctas = screen.getAllByRole('link', { name: /Apply to get started/i })
+    expect(ctas).toHaveLength(2)
+    ctas.forEach((cta) => expect(cta).toHaveAttribute('href', '#apply'))
+  })
+
+  it('shows the "not sure" guidance recommending the Single Page template', () => {
+    render(<ChooseYourTemplate />)
+    expect(screen.getByText(/Not sure which to pick\?/i)).toBeInTheDocument()
+    expect(screen.getByText(/fastest path to a validated site/i)).toBeInTheDocument()
+  })
+
+  it('has no basic accessibility violations', async () => {
+    const { container } = render(<ChooseYourTemplate />)
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+})

--- a/__tests__/content/banned-phrases.test.ts
+++ b/__tests__/content/banned-phrases.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Banned old-journey-order phrases guard.
+ *
+ * FFC's charity onboarding journey is gated: the website is built and
+ * validated FIRST (on its free GitHub Pages address), and only then is the
+ * free .org domain registered, followed by Microsoft 365 email. A past
+ * content review found nine stale-copy stragglers that still asserted the
+ * OLD order (domain registered before the website exists), which contradicts
+ * the copy on /free-charity-web-hosting/, /charity-onboarding-journey/, and
+ * /domains/.
+ *
+ * This test permanently guards against that copy creeping back in. It scans
+ * all source files under src/ (ts/tsx/json — source, not build output, for
+ * speed and stable line numbers) and fails with file:line locations if any
+ * banned phrase reappears.
+ *
+ * NOTE: "you need the domain before email" (src/app/m365-email-guide/page.tsx)
+ * is legitimate and intentionally NOT banned — email genuinely requires the
+ * domain. The banned patterns below are scoped so that phrasing never matches.
+ */
+import fs from 'fs'
+import path from 'path'
+
+const SRC_DIR = path.join(__dirname, '..', '..', 'src')
+const SCANNED_EXTENSIONS = new Set(['.ts', '.tsx', '.json'])
+
+interface BannedPhrase {
+  pattern: RegExp
+  reason: string
+}
+
+const bannedPhrases: BannedPhrase[] = [
+  {
+    // The gated journey is website-first. "Your website comes first" is fine
+    // and appears throughout src; "domain comes first" is the old order.
+    pattern: /domain comes first/i,
+    reason: 'Old journey order — the website comes first; the domain follows validation.',
+  },
+  {
+    pattern: /launches it on your Cloudflare-managed domain/i,
+    reason: 'Old journey order — sites launch on their free GitHub Pages address first.',
+  },
+  {
+    pattern: /discount code to request a new domain/i,
+    reason: 'Stale process — domains are registered by FFC after site validation, no codes.',
+  },
+  {
+    pattern: /the domain we set up in the previous step/i,
+    reason: 'Old journey order — the domain is not set up before the website.',
+  },
+  {
+    pattern: /get your free domain from us/i,
+    reason: 'Old queue-jump tip — the domain is purchased once your site is validated.',
+  },
+  {
+    pattern: /registers your domain, sets up Microsoft 365, and builds your site/i,
+    reason: 'Old journey order — build & validate the site first, then domain, then email.',
+  },
+]
+
+function collectSourceFiles(dir: string): string[] {
+  const files: string[] = []
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      files.push(...collectSourceFiles(fullPath))
+    } else if (entry.isFile() && SCANNED_EXTENSIONS.has(path.extname(entry.name))) {
+      files.push(fullPath)
+    }
+  }
+  return files
+}
+
+describe('banned old-journey-order phrases', () => {
+  const sourceFiles = collectSourceFiles(SRC_DIR)
+
+  it('finds source files to scan', () => {
+    expect(sourceFiles.length).toBeGreaterThan(0)
+  })
+
+  it.each(bannedPhrases.map((phrase) => [phrase.pattern.source, phrase]))(
+    'no source file contains banned phrase: %s',
+    (_source, phrase) => {
+      const violations: string[] = []
+      for (const file of sourceFiles) {
+        const lines = fs.readFileSync(file, 'utf8').split(/\r?\n/)
+        lines.forEach((line, index) => {
+          if ((phrase as BannedPhrase).pattern.test(line)) {
+            violations.push(`${path.relative(SRC_DIR, file)}:${index + 1}: ${line.trim()}`)
+          }
+        })
+      }
+      if (violations.length > 0) {
+        throw new Error(
+          `Banned phrase /${(phrase as BannedPhrase).pattern.source}/ found.\n` +
+            `Why banned: ${(phrase as BannedPhrase).reason}\n` +
+            `Locations (relative to src/):\n  ${violations.join('\n  ')}`
+        )
+      }
+      expect(violations).toEqual([])
+    }
+  )
+})

--- a/src/app/free-charity-web-hosting/page.tsx
+++ b/src/app/free-charity-web-hosting/page.tsx
@@ -4,6 +4,7 @@ import Hero from '@/components/free-charity-web-hosting/Hero'
 import WhatsIncluded from '@/components/free-charity-web-hosting/WhatsIncluded'
 import AboutFFCHosting from '@/components/free-charity-web-hosting/About-FFC-Hosting'
 import HowToApply from '@/components/free-charity-web-hosting/HowToApply'
+import ChooseYourTemplate from '@/components/free-charity-web-hosting/ChooseYourTemplate'
 import ReadyToGetStarted from '@/components/free-charity-web-hosting/ReadyToGetStarted'
 import ClientTestimonials from '@/components/free-charity-web-hosting/ClientTestimonials'
 import SupportThisCampaign from '@/components/free-charity-web-hosting/SupportThisCampaign'
@@ -23,6 +24,7 @@ const index = () => {
       <WhatsIncluded />
       <AboutFFCHosting />
       <HowToApply />
+      <ChooseYourTemplate />
       <ClientTestimonials />
       <SupportThisCampaign />
       <FAQs />

--- a/src/components/free-charity-web-hosting/ChooseYourTemplate/index.tsx
+++ b/src/components/free-charity-web-hosting/ChooseYourTemplate/index.tsx
@@ -1,0 +1,146 @@
+import React from 'react'
+import { FileText, PanelBottom, ExternalLink } from 'lucide-react'
+
+interface TemplateOption {
+  icon: React.ReactNode
+  eyebrow: string
+  title: string
+  description: string
+  features: string[]
+  repoUrl: string
+  repoLabel: string
+}
+
+const templates: TemplateOption[] = [
+  {
+    icon: <FileText className="w-9 h-9" aria-hidden="true" />,
+    eyebrow: 'Starting fresh?',
+    title: 'Single Page Site Template',
+    description:
+      'For charities without a website — most pre-501(c)(3)s start here. A complete, professionally structured single-page site built from our tested template. We design and build it from your content.',
+    features: [
+      'Every section a charity needs: mission, programs, team, donate, contact',
+      'Fast static hosting on GitHub Pages',
+      'Full FFC footer with legal pages, cookie consent, and analytics built in',
+    ],
+    repoUrl: 'https://github.com/FreeForCharity/FFC-IN-FFC_Single_Page_Template',
+    repoLabel: 'View the Single Page template on GitHub',
+  },
+  {
+    icon: <PanelBottom className="w-9 h-9" aria-hidden="true" />,
+    eyebrow: 'Already love your website?',
+    title: 'Footer-Only Template',
+    description:
+      'For charities that already have a designed site and need the validation and formality of the FFC standard — added to your existing design instead of replacing it.',
+    features: [
+      'The FFC footer and seven legal/policy pages',
+      'GDPR cookie consent and analytics',
+      'Team section and SEO infrastructure',
+    ],
+    repoUrl: 'https://github.com/FreeForCharity/FFC-IN-Footer-Only-Template',
+    repoLabel: 'View the Footer-Only template on GitHub',
+  },
+]
+
+const ChooseYourTemplate = () => {
+  return (
+    <section id="choose-your-template" className="py-[60px] scroll-mt-[120px]">
+      <div className="w-[90%] lg:w-[80%] max-w-[1200px] mx-auto">
+        <div className="text-center max-w-[720px] mx-auto mb-[48px]">
+          <h2
+            className="mb-[14px] text-[31px] font-[700] leading-[38px] text-[#0567B1]"
+            data-font="cantata-font"
+          >
+            Choose your starting point
+          </h2>
+          <p className="text-[18px] font-[500] leading-[29px] text-[#333]" data-font="raleway-font">
+            Every FFC website starts from one of two open-source templates. Pick the one that
+            matches where your charity is today.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-[28px] mb-[28px]">
+          {templates.map((template) => (
+            <div
+              key={template.title}
+              className="flex flex-col bg-white rounded-[10px] p-[28px] shadow-[0px_2px_18px_0px_rgba(0,0,0,0.12)] border border-[#eef2f6]"
+            >
+              <div className="mb-[18px] inline-flex items-center justify-center w-[56px] h-[56px] rounded-[12px] bg-[#0567B1]/10 text-[#0567B1]">
+                {template.icon}
+              </div>
+              <p
+                className="mb-[6px] text-[15px] font-[700] uppercase tracking-[0.08em] text-[#0567B1]"
+                data-font="raleway-font"
+              >
+                {template.eyebrow}
+              </p>
+              <h3
+                className="mb-[10px] text-[22px] font-[700] leading-[28px] text-[#1a2e35]"
+                data-font="cantata-font"
+              >
+                {template.title}
+              </h3>
+              <p
+                className="mb-[14px] text-[16px] font-[500] leading-[26px] text-[#555]"
+                data-font="raleway-font"
+              >
+                {template.description}
+              </p>
+              <ul className="mb-[18px] space-y-[8px]">
+                {template.features.map((feature) => (
+                  <li
+                    key={feature}
+                    className="flex items-start gap-[10px] text-[16px] font-[500] leading-[25px] text-[#555]"
+                    data-font="raleway-font"
+                  >
+                    <span
+                      className="mt-[9px] w-[7px] h-[7px] shrink-0 rounded-full bg-[#0567B1]"
+                      aria-hidden="true"
+                    />
+                    {feature}
+                  </li>
+                ))}
+              </ul>
+              <p
+                className="mb-[20px] text-[15px] font-[500] leading-[24px] text-[#555] italic"
+                data-font="raleway-font"
+              >
+                Both paths end the same way — your site validated live on its free GitHub Pages
+                address, which unlocks your free .org domain.
+              </p>
+              <div className="mt-auto flex flex-col gap-[12px]">
+                <a
+                  href="#apply"
+                  className="inline-flex items-center justify-center rounded-[10px] bg-[#0567B1] px-[28px] py-[13px] text-[16px] font-[700] text-white transition-transform duration-200 hover:scale-[1.03] hover:bg-[#045a9b]"
+                  data-font="raleway-font"
+                >
+                  Apply to get started
+                </a>
+                <a
+                  href={template.repoUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center justify-center gap-[8px] text-[15px] font-[700] text-[#0567B1] hover:underline"
+                  data-font="raleway-font"
+                >
+                  {template.repoLabel}
+                  <ExternalLink className="w-4 h-4" aria-hidden="true" />
+                </a>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <p
+          className="text-center text-[16px] font-[500] leading-[26px] text-[#555]"
+          data-font="raleway-font"
+        >
+          Not sure which to pick? Choose the Single Page Site Template — it&rsquo;s the fastest path
+          to a validated site.
+        </p>
+      </div>
+    </section>
+  )
+}
+
+export default ChooseYourTemplate

--- a/src/data/faqs.ts
+++ b/src/data/faqs.ts
@@ -84,7 +84,7 @@ We also provide many physical services like nonprofit websites and hosting that 
     answer: `We have a large backlog for new sites and support. We try to process at least 1 new charity into the full hosting system per week.
 
 Ways to get in faster
-If you already have your 501(c)3 get your free domain from us (https://freeforcharity.org/domains/)
+Complete onboarding and pick your .org name early — check availability at https://freeforcharity.org/domains/ — we purchase it once your site is validated.
 If you arrive content-ready — with your logo, photos, mission statement, and program text prepared — you may be moved up in the list.`,
   },
   {


### PR DESCRIPTION
## Summary

Implements three FFC-Cloudflare-Automation sub-issues in one PR:

**Two-template positioning + chooser section** (Refs https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/686, https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/687)
- New `ChooseYourTemplate` section (`src/components/free-charity-web-hosting/ChooseYourTemplate/`) rendered on `/free-charity-web-hosting/` directly after How-to-apply (before testimonials and FAQs), so the template decision follows naturally from the application steps.
- Two side-by-side cards: **Single Page Site Template** ("Starting fresh?") for charities without a website, and **Footer-Only Template** ("Already love your website?") for charities that already have a designed site and need the FFC standard added.
- Both cards end with the shared gated-journey outcome (site validated live on its free GitHub Pages address unlocks the free .org domain), matching the WhatsIncluded/HowToApply copy.
- Each card links its GitHub template repo as a secondary link and the on-page `#apply` anchor as the CTA, plus a "Not sure? Pick Single Page" guidance note.
- Follows the page's existing section conventions: section id + `scroll-mt`, `data-font` attributes, card styling mirroring WhatsIncluded.

**Banned old-order phrases guard** (Refs https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/685)
- New Jest test `__tests__/content/banned-phrases.test.ts` recursively scans `src/` (ts/tsx/json — source, not build output) for six banned old-journey-order phrase regexes and fails listing file:line + reason on any match.
- The legitimate "you need the domain before email" phrasing in the M365 email guide is intentionally out of scope of the patterns; "your website comes first" copy never matches `/domain comes first/i`.
- Pattern verification against current code found one live straggler: the old queue-jump tip "get your free domain from us" in `src/data/faqs.ts`. That copy is rewritten to the validated-site-first wording the FAQ components already use, so the guard passes on the current codebase.

**Unit tests**
- `__tests__/components/free-charity-web-hosting/ChooseYourTemplate/index.test.tsx`: render, heading, section id/scroll-mt, both cards + eyebrows, gated-journey outcome on both cards, repo links (href/target/rel), #apply CTAs, guidance note, and axe accessibility check via the shared fragment-axe util.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run build` — static export succeeds
- [x] `npm run test` — 46 suites / 612 tests pass (including the 2 new suites)
- [x] `npx playwright test` — 374 passed, 19 skipped
- [x] Visual check of the built export: section renders after How-to-apply with both cards, outcome line, and guidance note

Refs FreeForCharity/FFC-Cloudflare-Automation#686, FreeForCharity/FFC-Cloudflare-Automation#687, FreeForCharity/FFC-Cloudflare-Automation#685

🤖 Generated with [Claude Code](https://claude.com/claude-code)