### PR TITLE
fix(hosting): correct Footer-Only template repo URL (underscores, not hyphens)

### DIFF
--- a/src/components/free-charity-web-hosting/ChooseYourTemplate/index.tsx
+++ b/src/components/free-charity-web-hosting/ChooseYourTemplate/index.tsx
@@ -37,7 +37,7 @@ const templates: TemplateOption[] = [
       'GDPR cookie consent and analytics',
       'Team section and SEO infrastructure',
     ],
-    repoUrl: 'https://github.com/FreeForCharity/FFC-IN-Footer-Only-Template',
+    repoUrl: 'https://github.com/FreeForCharity/FFC-IN-Footer_Only_Template',
     repoLabel: 'View the Footer-Only template on GitHub',
   },
 ]


### PR DESCRIPTION
One-line fix: the ChooseYourTemplate section linked https://github.com/FreeForCharity/FFC-IN-Footer-Only-Template (hyphens, 404) — the real repo is FFC-IN-Footer_Only_Template (underscores, 200). This is what failed the Lychee link check on main after #481.

Refs FreeForCharity/FFC-Cloudflare-Automation#687

🤖 Generated with [Claude Code](https://claude.com/claude-code)