### PR TITLE
feat(funnel): consent-free intake-funnel beacon endpoint + docs

### DIFF
--- a/docs/funnel-beacon.md
+++ b/docs/funnel-beacon.md
@@ -1,0 +1,34 @@
+# Intake-funnel beacon (form starts vs submissions)
+
+Tracks how many charities _open_ each WHMCS order form vs how many _complete_ an
+order — the "filter rate" of the deliberately hard intake forms (epic
+FreeForCharity/FFC-Cloudflare-Automation#676, issue #684).
+
+## How it works
+
+1. The WHMCS hub's `six_ffc` theme fires a `navigator.sendBeacon()` from
+   `cart.php` pages (no cookies, no identifiers, nothing personal):
+   - `?s=view&p=<pid>` when an order form is opened (`cart.php?a=add&pid=N`)
+   - `?s=complete` on the order-complete page (`cart.php?a=complete`)
+2. [`public/api/funnel-beacon.php`](../public/api/funnel-beacon.php) increments
+   a daily counter — `date → pid → step → count` — in
+   `~/ffc_funnel_counts.json`, **outside the web root** (sibling of
+   `public_html`, unreachable over HTTP).
+3. Because nothing user-identifying is stored, no consent banner is needed.
+
+## Reading the numbers
+
+- Open `~/ffc_funnel_counts.json` via cPanel File Manager (it sits next to
+  `public_html`, not inside it).
+- `view` counts per product id: 16 pre-501c3 / 33 501c3 onboarding, 40 website,
+  39 domain register, 41 domain transfer, 42/43 email.
+- For submissions, WHMCS order reports are authoritative — the beacon's
+  `complete` count is a same-day sanity check, not the source of truth.
+- Filter rate per product ≈ WHMCS submitted orders ÷ beacon `view` count.
+
+## Notes
+
+- Client-side beacons undercount (ad blockers, JS off) — treat trends, not
+  absolutes.
+- The theme-side snippet lives in `six_ffc/header.tpl` on the server (the theme
+  is managed over FTPS, not in this repo).

--- a/public/api/funnel-beacon.php
+++ b/public/api/funnel-beacon.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Free For Charity — consent-free intake-funnel counter (epic #676, issue #684).
+ * Runs as PHP on the cPanel/Apache server (same box as /hub), deployed via public/.
+ *
+ * The WHMCS hub's six_ffc theme fires navigator.sendBeacon() here from cart pages:
+ *   GET /api/funnel-beacon.php?s=view&p=<pid>   — an order form was opened
+ *   GET /api/funnel-beacon.php?s=complete       — an order was completed
+ *
+ * Privacy: stores ONLY daily counters (date → pid → step → count). No cookies,
+ * no IP, no user agent, no identifiers — so no consent banner is required.
+ * Counts live outside the web root; completions can be cross-checked against
+ * WHMCS order reports (the authoritative submission count).
+ */
+
+header('Cache-Control: no-store');
+
+$step = isset($_GET['s']) ? $_GET['s'] : '';
+$pid = isset($_GET['p']) ? $_GET['p'] : 'all';
+
+if (!in_array($step, ['view', 'complete'], true) || !preg_match('/^(all|[0-9]{1,4})$/', $pid)) {
+    http_response_code(204); // never make the storefront care about beacon errors
+    exit;
+}
+
+// Outside the web root: sibling of public_html, invisible to HTTP.
+$file = dirname($_SERVER['DOCUMENT_ROOT']) . '/ffc_funnel_counts.json';
+$date = gmdate('Y-m-d');
+
+$fh = fopen($file, 'c+');
+if ($fh !== false && flock($fh, LOCK_EX)) {
+    $raw = stream_get_contents($fh);
+    $data = json_decode($raw ?: '{}', true);
+    if (!is_array($data)) {
+        $data = [];
+    }
+    $data[$date][$pid][$step] = ($data[$date][$pid][$step] ?? 0) + 1;
+    ftruncate($fh, 0);
+    rewind($fh);
+    fwrite($fh, json_encode($data));
+    fflush($fh);
+    flock($fh, LOCK_UN);
+}
+if ($fh !== false) {
+    fclose($fh);
+}
+
+http_response_code(204);


### PR DESCRIPTION
## Summary

Implements option (b) from FreeForCharity/FFC-Cloudflare-Automation#684: measure the intake filter rate (form starts vs submissions) without putting GTM or a consent banner on the WHMCS hub.

- **public/api/funnel-beacon.php** — increments daily counters (date → pid → step) in `~/ffc_funnel_counts.json`, a sibling of public_html (unreachable over HTTP). No cookies, no IP, no identifiers → no consent required.
- **docs/funnel-beacon.md** — how it works, how to read the numbers, and that WHMCS order reports stay authoritative for submissions.
- Theme side already live: a `{literal}`-wrapped sendBeacon snippet in six_ffc/footer.tpl fires `s=view&p=<pid>` on cart.php?a=add and `s=complete` on order completion.

## Test plan
- [x] Endpoint logic mirrors the proven domain-check.php PHP deployment pattern (same public/ → cPanel path)
- [x] Hub page verified live with the snippet present and </body> intact
- [x] Beacon fires only on /cart.php paths, validates pid format, always returns 204

🤖 Generated with [Claude Code](https://claude.com/claude-code)