### PR TITLE
fix(test): align ChooseYourTemplate test with corrected repo URL; harden phrase guard

### DIFF
--- a/__tests__/components/free-charity-web-hosting/ChooseYourTemplate/index.test.tsx
+++ b/__tests__/components/free-charity-web-hosting/ChooseYourTemplate/index.test.tsx
@@ -52,7 +52,7 @@ describe('ChooseYourTemplate Component', () => {
     })
     expect(footerOnlyLink).toHaveAttribute(
       'href',
-      'https://github.com/FreeForCharity/FFC-IN-Footer-Only-Template'
+      'https://github.com/FreeForCharity/FFC-IN-Footer_Only_Template'
     )
     ;[singlePageLink, footerOnlyLink].forEach((link) => {
       expect(link).toHaveAttribute('target', '_blank')

--- a/__tests__/content/banned-phrases.test.ts
+++ b/__tests__/content/banned-phrases.test.ts
@@ -56,6 +56,10 @@ const bannedPhrases: BannedPhrase[] = [
     pattern: /registers your domain, sets up Microsoft 365, and builds your site/i,
     reason: 'Old journey order — build & validate the site first, then domain, then email.',
   },
+  {
+    pattern: /once your domain (name )?is set up/i,
+    reason: 'Old journey order — nothing waits on the domain except email; the site comes first.',
+  },
 ]
 
 function collectSourceFiles(dir: string): string[] {
@@ -83,18 +87,23 @@ describe('banned old-journey-order phrases', () => {
     (_source, phrase) => {
       const violations: string[] = []
       for (const file of sourceFiles) {
-        const lines = fs.readFileSync(file, 'utf8').split(/\r?\n/)
-        lines.forEach((line, index) => {
-          if ((phrase as BannedPhrase).pattern.test(line)) {
-            violations.push(`${path.relative(SRC_DIR, file)}:${index + 1}: ${line.trim()}`)
-          }
-        })
+        // Prettier wraps long JSX prose across lines (with {' '} joiners), so a
+        // per-line scan misses multi-word phrases. Match against a
+        // whitespace-normalized view of the whole file instead.
+        const normalized = fs
+          .readFileSync(file, 'utf8')
+          .replace(/\{['"]\s['"]\}/g, ' ') // JSX explicit-space joiners
+          .replace(/\s+/g, ' ')
+        const match = normalized.match((phrase as BannedPhrase).pattern)
+        if (match) {
+          violations.push(`${path.relative(SRC_DIR, file)}: “…${match[0]}…”`)
+        }
       }
       if (violations.length > 0) {
         throw new Error(
           `Banned phrase /${(phrase as BannedPhrase).pattern.source}/ found.\n` +
             `Why banned: ${(phrase as BannedPhrase).reason}\n` +
-            `Locations (relative to src/):\n  ${violations.join('\n  ')}`
+            `Files (relative to src/):\n  ${violations.join('\n  ')}`
         )
       }
       expect(violations).toEqual([])

--- a/src/components/free-charity-web-hosting/FAQs/index.tsx
+++ b/src/components/free-charity-web-hosting/FAQs/index.tsx
@@ -186,7 +186,7 @@ const AccordionLayout = () => {
                   <li>
                     Complete onboarding and pick your .org name early — check availability at{' '}
                     <a href="/domains/" className="text-[#0567B1]">
-                      (https://freeforcharity.org/domains)
+                      freeforcharity.org/domains
                     </a>{' '}
                     — we purchase it once your site is validated
                   </li>


### PR DESCRIPTION
## Summary

**Urgent: main's unit suite is red** — #482 fixed the Footer-Only repo URL in the component but not the test asserting it. This aligns the test, and folds in two round-2 review findings:

- Banned-phrase guard now scans whitespace-normalized content (Prettier-wrapped JSX prose could smuggle a banned phrase past the per-line scan) and bans 'once your domain (name) is set up'
- FAQ anchor text '(https://freeforcharity.org/domains)' → 'freeforcharity.org/domains'

## Test plan
- [x] 613/613 unit tests green locally (was 612 passed / 1 failed on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)