### PR TITLE
fix: align hosting HowToApply step 1 with on-page apply flow

### DIFF
--- a/src/components/free-charity-web-hosting/HowToApply/index.tsx
+++ b/src/components/free-charity-web-hosting/HowToApply/index.tsx
@@ -10,9 +10,9 @@ interface Step {
 const steps: Step[] = [
   {
     number: '1',
-    title: 'Check your eligibility',
+    title: 'Confirm you qualify',
     description:
-      'Answer five quick questions to confirm your nonprofit qualifies and see which free programs fit — domain, email, website, or a migration.',
+      'Free For Charity is one all-in program for 501(c)(3) and pre-501(c)(3) nonprofits — a managed .org domain, Microsoft 365 email, and a built-and-hosted website. Not sure you’re a fit? Use “Help me choose” when you apply below.',
   },
   {
     number: '2',


### PR DESCRIPTION
## Summary

Follow-up from a code review of the eligibility-check retirement (#476). On `/free-charity-web-hosting/`, **Step 1 of "How to apply" was still describing the retired 5-question eligibility-check wizard** and the à-la-carte "menu of programs" framing — both of which were removed when the standalone eligibility page was retired in favor of the on-page apply flow.

Old Step 1:
> **Check your eligibility** — Answer five quick questions to confirm your nonprofit qualifies and see which free programs fit — domain, email, website, or a migration.

This promised a "five quick questions" checker that no longer exists (the page's only CTA is "Start your application" → `#apply`), and framed FFC as a pick-your-programs menu, contradicting the single all-in program positioning. Steps 3 and 4 had already been updated to the all-in flow; Step 1 was missed.

## Change

Rewrote Step 1 to match FFC's single all-in program positioning and point unsure visitors at the on-page "Help me choose" guide:

> **Confirm you qualify** — Free For Charity is one all-in program for 501(c)(3) and pre-501(c)(3) nonprofits — a managed .org domain, Microsoft 365 email, and a built-and-hosted website. Not sure you're a fit? Use "Help me choose" when you apply below.

Copy-only change to one step object; no structural or behavioral changes.

## Verification

- `npm run lint` — clean
- `npm run build` — static export succeeds
- `npm run test` — 613 jest tests pass
- Verified against built output: `/free-charity-web-hosting/index.html` now renders "Confirm you qualify" and no longer contains "five quick questions".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JrqnLULSB1GYoiKYDQVA8T)_