### PR TITLE
feat(marketing): why-website-first explainer, journey diagram, social + case-study drafts

### DIFF
--- a/__tests__/app/why-website-first.test.tsx
+++ b/__tests__/app/why-website-first.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { axe } from '../utils/axe'
+import WhyWebsiteFirst from '@/app/why-website-first/page'
+
+describe('Why Website First page', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<WhyWebsiteFirst />)
+    expect(container).not.toBeEmptyDOMElement()
+  })
+
+  it('tells the website-first story: donor trust, no sunk costs, competence filter', () => {
+    const { container } = render(<WhyWebsiteFirst />)
+    const text = container.textContent || ''
+
+    expect(text).toMatch(/donor trust/i)
+    expect(text).toMatch(/no sunk costs/i)
+    expect(text).toMatch(/competence filter/i)
+  })
+
+  it('lists all four gates in order: validation, website, funding, email', () => {
+    const { container } = render(<WhyWebsiteFirst />)
+    const text = container.textContent || ''
+
+    const validation = text.indexOf('Gate 1 — Validation')
+    const website = text.indexOf('Gate 2 — Website')
+    const funding = text.indexOf('Gate 3 — Funding')
+    const email = text.indexOf('Gate 4 — Email')
+
+    expect(validation).toBeGreaterThan(-1)
+    expect(website).toBeGreaterThan(validation)
+    expect(funding).toBeGreaterThan(website)
+    expect(email).toBeGreaterThan(funding)
+  })
+
+  it('introduces both templates', () => {
+    const { container } = render(<WhyWebsiteFirst />)
+    const text = container.textContent || ''
+
+    expect(text).toContain('Single Page Site Template')
+    expect(text).toContain('Footer-Only Template')
+  })
+
+  it('renders the journey diagram', () => {
+    const { getByRole } = render(<WhyWebsiteFirst />)
+    const diagram = getByRole('img', {
+      name: /five-stage Free For Charity onboarding journey/i,
+    })
+    expect(diagram).toBeInTheDocument()
+  })
+
+  it('links the CTA to /help-for-charities/ and cross-links the journey page', () => {
+    const { container } = render(<WhyWebsiteFirst />)
+    const hrefs = Array.from(container.querySelectorAll('a')).map(
+      (a) => a.getAttribute('href') ?? ''
+    )
+
+    expect(hrefs.some((h) => h.includes('/help-for-charities'))).toBe(true)
+    expect(hrefs.some((h) => h.includes('/charity-onboarding-journey'))).toBe(true)
+    expect(hrefs.some((h) => h.includes('/free-charity-web-hosting'))).toBe(true)
+  })
+
+  it('has no axe violations', async () => {
+    const { container } = render(<WhyWebsiteFirst />)
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  }, 30000)
+})

--- a/__tests__/components/journey/JourneyDiagram.test.tsx
+++ b/__tests__/components/journey/JourneyDiagram.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { axe } from '../../utils/axe'
+import JourneyDiagram from '@/components/journey/JourneyDiagram'
+
+describe('JourneyDiagram', () => {
+  it('renders an accessible image with title and description', () => {
+    const { getByRole } = render(<JourneyDiagram />)
+    const diagram = getByRole('img', {
+      name: /five-stage Free For Charity onboarding journey/i,
+    })
+    expect(diagram).toBeInTheDocument()
+    expect(diagram).toHaveAttribute('aria-describedby', 'journey-diagram-desc')
+  })
+
+  it('shows all five stages in the gated order', () => {
+    const { container } = render(<JourneyDiagram />)
+    const text = container.textContent || ''
+
+    const apply = text.indexOf('Apply')
+    const website = text.indexOf('Website')
+    const domain = text.indexOf('Domain')
+    const email = text.indexOf('Email')
+    const ongoing = text.indexOf('Ongoing')
+
+    expect(apply).toBeGreaterThan(-1)
+    expect(website).toBeGreaterThan(apply)
+    expect(domain).toBeGreaterThan(website)
+    expect(email).toBeGreaterThan(domain)
+    expect(ongoing).toBeGreaterThan(email)
+  })
+
+  it('highlights the funding gate between website and domain', () => {
+    const { container } = render(<JourneyDiagram />)
+    const text = container.textContent || ''
+
+    expect(text).toContain('FUNDING GATE')
+    expect(text).toMatch(/money is spent only after your site is proven/i)
+    // The website stage sits on GitHub Pages before the gate
+    expect(text).toContain('GitHub Pages')
+  })
+
+  it('is responsive: scales via viewBox with fluid width', () => {
+    const { container } = render(<JourneyDiagram />)
+    const svg = container.querySelector('svg')
+    expect(svg).toHaveAttribute('viewBox')
+    expect(svg?.getAttribute('class')).toContain('w-full')
+    expect(svg?.getAttribute('class')).toContain('max-w-full')
+  })
+
+  it('uses the FFC brand colors', () => {
+    const { container } = render(<JourneyDiagram />)
+    const html = container.innerHTML
+    expect(html).toContain('#0567B1')
+    expect(html).toContain('#F58C23')
+  })
+
+  it('has no axe violations', async () => {
+    const { container } = render(<JourneyDiagram />)
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  }, 30000)
+})

--- a/docs/marketing/case-study-catnipandcattitude-draft.md
+++ b/docs/marketing/case-study-catnipandcattitude-draft.md
@@ -1,0 +1,68 @@
+# Case study (DRAFT): Catnip & Cattitude — the first gated-journey pilot
+
+> **DRAFT — do not publish.** This skeleton is for internal drafting only.
+> Publication waits for (1) the charity's production cutover to complete and
+> (2) written consent from Catnip & Cattitude per the
+> [publicity consent policy](https://www.freeforcharity.org/publicity-consent-policy/).
+> All `[PLACEHOLDER]` markers must be replaced with verified facts and
+> approved quotes before this leaves the repo.
+
+## Working title
+
+From GoDaddy to a validated GitHub Pages site — how the gated journey worked
+for its first pilot charity.
+
+## The organization
+
+Catnip & Cattitude is a cat-welfare nonprofit. `[PLACEHOLDER: mission
+statement, location, founding year, EIN-verified legal name — confirm with the
+charity]`
+
+## Starting point
+
+- Existing website live on GoDaddy hosting.
+- `[PLACEHOLDER: monthly/annual hosting + domain costs the charity was paying]`
+- `[PLACEHOLDER: pain points in the charity's own words — maintenance burden,
+cost, update turnaround]`
+
+## What FFC did (the gated journey in practice)
+
+1. **Application & validation** — the organization applied and was validated
+   through FFC's standard onboarding. `[PLACEHOLDER: dates]`
+2. **Website first** — volunteers rebuilt the existing GoDaddy site as a
+   static GitHub Pages site in the FreeForCharity GitHub organization,
+   localizing all external dependencies and adding the standard FFC footer
+   (legal pages, cookie consent, analytics). The rebuild went live on its free
+   GitHub Pages address for side-by-side validation against the original.
+3. **Validation** — `[PLACEHOLDER: what the charity reviewed and signed off
+on; CI checks passing — build, accessibility, smoke tests]`
+4. **Cutover** — pending. The domain will point at the validated GitHub Pages
+   site once the charity confirms. `[PLACEHOLDER: cutover date once complete]`
+5. **Email & ongoing** — `[PLACEHOLDER: nonprofit email setup details if/when
+applicable]`
+
+## Why this proves the model
+
+- No money was spent until the rebuilt site was live and validated —
+  the funding gate working exactly as designed.
+- The charity kept its existing site online the whole time; the rebuild
+  carried zero downtime risk during the build phase.
+- `[PLACEHOLDER: metric — page-speed / Lighthouse / accessibility score
+comparison, old site vs. rebuild]`
+- `[PLACEHOLDER: metric — annual cost to the charity before vs. after ($0)]`
+
+## Quotes
+
+- `[PLACEHOLDER: quote from the Catnip & Cattitude point of contact —
+requires their review and written approval]`
+- `[PLACEHOLDER: quote from the FFC volunteer who led the rebuild]`
+
+## Publication checklist (all must be true before publishing)
+
+- [ ] Production cutover complete and stable
+- [ ] Written consent from the charity on file (publicity consent policy)
+- [ ] All placeholders replaced with verified facts
+- [ ] Quotes approved by their speakers
+- [ ] Reviewed against the banned-phrase guard (website-first ordering) and
+      the no-coupon-code hard rule
+- [ ] Operator sign-off

--- a/docs/marketing/journey-launch-social-drafts.md
+++ b/docs/marketing/journey-launch-social-drafts.md
@@ -1,0 +1,113 @@
+# DRAFTS — operator review before posting
+
+> **These are unpublished drafts.** Nothing in this file has been posted anywhere.
+> An FFC operator must review, edit, and approve each post before it goes to any
+> social channel. Do not copy-paste without review. Never add promo or coupon
+> codes to public posts.
+
+Announcing: the gated onboarding journey — the website is built and validated
+free on GitHub Pages **first**, and the free .org domain is only purchased once
+the site is proven.
+
+Suggested visuals: the journey diagram from
+`https://www.freeforcharity.org/why-website-first/` (screenshot or re-export),
+or a before/after of a charity site.
+
+---
+
+## LinkedIn drafts
+
+### LinkedIn 1 — Charity-recruiting angle
+
+**Suggested link target:** `https://www.freeforcharity.org/help-for-charities/`
+
+Is your 501(c)(3) still paying for hosting — or worse, running without a
+website at all?
+
+Free For Charity builds verified nonprofits a complete website at no cost, and
+we do it in an order most providers won't: the website comes first. Your site
+is built by volunteers from our open-source template, goes live on free GitHub
+Pages hosting, and is validated end to end with your team — before a single
+dollar is spent. Only then do we register your free .org domain and set up
+free Microsoft 365 or Google Workspace email.
+
+No setup fees. No hosting bills. No sunk costs if you're not ready yet.
+
+Apply here: [link]
+
+### LinkedIn 2 — Volunteer-recruiting angle
+
+**Suggested link target:** `https://www.freeforcharity.org/volunteer/`
+
+Want a portfolio project that actually ships — and stays online serving a real
+nonprofit?
+
+Free For Charity volunteers build real websites for verified 501(c)(3)
+organizations using a modern static stack: GitHub, CI checks, accessibility
+testing, and GitHub Pages hosting. Our new gated onboarding journey means every
+build has a clear finish line: the charity's site validated live, which
+unlocks their free domain and email.
+
+You bring a few hours a week; we bring the template, the process, and a
+charity that genuinely needs you. Every merged PR is public proof of your
+work.
+
+See open roles: [link]
+
+### LinkedIn 3 — Donor-trust angle
+
+**Suggested link target:** `https://www.freeforcharity.org/why-website-first/`
+
+How do you make sure a donated dollar is never wasted? You spend it last.
+
+Free For Charity's onboarding journey is gated: volunteers build and validate
+each charity's website on free GitHub Pages hosting before we spend anything
+on their domain. If an organization isn't ready, nothing has been lost — no
+parked domains, no renewal fees for sites that never launched. When we do
+spend, it's on a charity whose site is already live and proven.
+
+We wrote up the full reasoning — donor trust, zero sunk costs, and the four
+gates every charity passes through: [link]
+
+---
+
+## Facebook drafts
+
+### Facebook 1 — Charity-recruiting angle
+
+**Suggested link target:** `https://www.freeforcharity.org/help-for-charities/`
+
+Does your nonprofit need a website but not the bills that come with one?
+
+Free For Charity builds websites for verified 501(c)(3) charities completely
+free — designed by volunteers, hosted for free, with a free .org domain and
+free nonprofit email (Microsoft 365 or Google Workspace) once your site is
+live and validated.
+
+The best part? Everything before the domain purchase costs nothing, so there's
+zero risk in applying. Start here: [link]
+
+### Facebook 2 — Volunteer-recruiting angle
+
+**Suggested link target:** `https://www.freeforcharity.org/volunteer/`
+
+Know your way around websites (or want to learn)? A charity near you needs
+that.
+
+Our volunteers build free websites for real nonprofits — from first template
+to validated launch on GitHub Pages. You'll follow a clear five-stage journey,
+get support from experienced builders, and end with public, shippable work you
+can point to.
+
+A few hours a week changes a charity's whole online presence. Join us: [link]
+
+### Facebook 3 — Donor-trust angle
+
+**Suggested link target:** `https://www.freeforcharity.org/why-website-first/`
+
+Here's a promise most organizations can't make: we never spend money on a
+charity's website until the website already works.
+
+Free For Charity builds and validates every charity site on free hosting
+first. Only when the site is live and proven do we buy the domain — so every
+donated dollar buys something real. Read how the gated journey works: [link]

--- a/src/app/charity-onboarding-journey/page.tsx
+++ b/src/app/charity-onboarding-journey/page.tsx
@@ -1,5 +1,6 @@
 import { pageMetadata } from '@/lib/page-metadata'
 import Link from 'next/link'
+import JourneyDiagram from '@/components/journey/JourneyDiagram'
 
 export const metadata = pageMetadata({
   title: 'Your Onboarding Journey',
@@ -79,8 +80,16 @@ export default function CharityOnboardingJourney() {
             validated on free GitHub Pages hosting <em>first</em>, and we only spend money on your
             domain once your site is proven. Volunteers do this work, so timelines are typical
             rather than guaranteed; content readiness on your side is the biggest factor in how fast
-            a site launches.
+            a site launches. Curious about the reasoning behind this order?{' '}
+            <Link href="/why-website-first/">
+              Read why we build your website before buying your domain
+            </Link>
+            .
           </p>
+        </div>
+
+        <div className="mt-8">
+          <JourneyDiagram />
         </div>
 
         <ol className="mt-8 space-y-6">

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -86,6 +86,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { path: '/publicity-consent-policy', priority: 0.3, changeFrequency: 'yearly' as const },
     { path: '/guides', priority: 0.8, changeFrequency: 'weekly' as const },
     { path: '/charity-onboarding-journey', priority: 0.7, changeFrequency: 'monthly' as const },
+    { path: '/why-website-first', priority: 0.7, changeFrequency: 'monthly' as const },
     { path: '/getting-started-checklist', priority: 0.7, changeFrequency: 'monthly' as const },
     { path: '/m365-email-guide', priority: 0.7, changeFrequency: 'monthly' as const },
     { path: '/google-for-nonprofits-guide', priority: 0.7, changeFrequency: 'monthly' as const },

--- a/src/app/why-website-first/page.tsx
+++ b/src/app/why-website-first/page.tsx
@@ -1,0 +1,140 @@
+import { pageMetadata } from '@/lib/page-metadata'
+import Link from 'next/link'
+import JourneyDiagram from '@/components/journey/JourneyDiagram'
+
+export const metadata = pageMetadata({
+  title: 'Why We Build Your Website Before Buying Your Domain',
+  description:
+    'The gated FFC onboarding journey explained: donor trust, no sunk costs, and the four gates that make sure money is only spent on charities whose sites are already proven live.',
+  canonical: '/why-website-first/',
+})
+
+const h2 = 'font-[var(--font-faustina)] text-[32px] leading-[40px] mt-8 mb-4'
+
+interface Gate {
+  name: string
+  plain: string
+}
+
+const gates: Gate[] = [
+  {
+    name: 'Gate 1 — Validation',
+    plain:
+      'Before anything is built, we verify your organization: IRS status, Candid profile, and program fit. Every later stage requires this approval, so nobody invests effort in an organization that cannot qualify.',
+  },
+  {
+    name: 'Gate 2 — Website',
+    plain:
+      'The website application only opens after validation. A volunteer builds your site from an FFC template and you prove the partnership works by getting us your content. The site goes live on its free GitHub Pages address — which costs nothing.',
+  },
+  {
+    name: 'Gate 3 — Funding',
+    plain:
+      'This is the money gate. We only spend funds on your free .org domain once your website is validated live. The domain order form literally asks for your live GitHub Pages address — that is what unlocks the purchase.',
+  },
+  {
+    name: 'Gate 4 — Email',
+    plain:
+      'Microsoft and Google both require a live website before they approve a nonprofit for free email. Because your site is already proven and your domain is live, your free Microsoft 365 or Google Workspace mailboxes sail through.',
+  },
+]
+
+export default function WhyWebsiteFirst() {
+  return (
+    <div className="ffc-container py-16">
+      <div className="max-w-4xl mx-auto">
+        <h1 className="font-[var(--font-faustina)] text-[48px] leading-[60px] mb-8">
+          Why we build your website before buying your domain
+        </h1>
+
+        <div className="prose max-w-none font-[var(--font-lato)] text-[18px] leading-[28px]">
+          <p>
+            Most web programs start by selling you a domain. Free For Charity deliberately does the
+            opposite: your website is built and validated <em>first</em>, live on its free GitHub
+            Pages address, and only then do we spend a single donated dollar on your .org domain.
+            That order is not an accident — it is how we protect donors, charities, and volunteers
+            at the same time.
+          </p>
+        </div>
+
+        <div className="mt-8" data-testid="journey-diagram-wrapper">
+          <JourneyDiagram />
+        </div>
+
+        <div className="prose max-w-none font-[var(--font-lato)] text-[18px] leading-[28px]">
+          <h2 className={h2}>Donor trust: every dollar buys something proven</h2>
+          <p>
+            FFC runs on donations and volunteer time. When we register a domain, that is real money
+            leaving a charity&rsquo;s ecosystem — so we only spend it on organizations whose site is
+            already live, validated, and ready to point a domain at. Donors can see exactly what
+            their support bought: a working website, not a parked name.
+          </p>
+
+          <h2 className={h2}>No sunk costs: free until it works</h2>
+          <p>
+            Everything before the funding gate is free. GitHub Pages hosting costs nothing, the
+            templates are open source, and volunteer time is donated. If an organization stalls,
+            changes direction, or never sends content, nothing has been wasted — there is no annual
+            domain renewal quietly billing for a site that never launched. The build phase has zero
+            sunk cost by design.
+          </p>
+
+          <h2 className={h2}>A competence filter that protects everyone</h2>
+          <p>
+            Getting a site validated takes a small amount of real engagement from your charity:
+            sending your logo, mission text, and photos, and reviewing the result. That engagement
+            is the best predictor we have that a partnership will last. Organizations that clear the
+            website stage almost always thrive with their domain and email; asking for that proof{' '}
+            <em>before</em> money moves filters kindly but firmly, with no penalty for anyone who is
+            not ready yet.
+          </p>
+
+          <h2 className={h2}>The four gates, in plain language</h2>
+        </div>
+
+        <ol className="mt-4 space-y-6">
+          {gates.map((gate) => (
+            <li key={gate.name} className="border border-gray-200 rounded-lg p-6">
+              <h3 className="font-[var(--font-faustina)] text-[26px] leading-[34px] mb-3">
+                {gate.name}
+              </h3>
+              <p className="font-[var(--font-lato)] text-[17px] leading-[27px]">{gate.plain}</p>
+            </li>
+          ))}
+        </ol>
+
+        <div className="prose max-w-none font-[var(--font-lato)] text-[18px] leading-[28px] mt-10">
+          <h2 className={h2}>Two templates, one destination</h2>
+          <p>
+            Every FFC build starts from one of two open-source templates. The{' '}
+            <strong>Single Page Site Template</strong> is for charities starting fresh: a complete,
+            professionally structured one-page site with every section a charity needs — mission,
+            programs, team, donate, contact — plus the full FFC footer. The{' '}
+            <strong>Footer-Only Template</strong> is for charities that already love their website:
+            it adds the FFC footer, legal pages, cookie consent, and analytics to your existing
+            design instead of replacing it. Both paths end the same way — your site validated live
+            on GitHub Pages, which unlocks your free .org domain. Compare them on the{' '}
+            <Link href="/free-charity-web-hosting/">free charity web hosting page</Link>.
+          </p>
+
+          <h2 className={h2}>Ready to start?</h2>
+          <p>
+            The whole journey — application, website, domain, email, and ongoing support — is free
+            for verified 501(c)(3) organizations. See the full stage-by-stage walkthrough on the{' '}
+            <Link href="/charity-onboarding-journey/">charity onboarding journey page</Link>, or
+            jump straight in:
+          </p>
+        </div>
+
+        <p className="mt-6">
+          <Link
+            href="/help-for-charities/"
+            className="inline-block rounded bg-[#0567B1] px-8 py-3 font-[var(--font-lato)] text-[18px] font-[700] text-white transition-colors hover:bg-[#045a9b]"
+          >
+            Apply for your free website
+          </Link>
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/components/journey/JourneyDiagram.tsx
+++ b/src/components/journey/JourneyDiagram.tsx
@@ -1,0 +1,169 @@
+/**
+ * Journey diagram (overnight block 7): the five gated onboarding stages as an
+ * inline, responsive SVG. The funding gate — money is only spent after the
+ * website is validated live on GitHub Pages — sits between stages 2 and 3 and
+ * is highlighted in FFC orange. Rendered on /why-website-first/ and
+ * /charity-onboarding-journey/.
+ *
+ * Accessibility: role="img" with <title>/<desc> wired via aria-labelledby /
+ * aria-describedby; every visual detail is decorative relative to that
+ * summary, and the full journey is described in the surrounding page text.
+ */
+
+const BLUE = '#0567B1'
+const ORANGE = '#F58C23'
+const INK = '#1a2e35'
+
+interface DiagramStage {
+  number: string
+  title: string
+  detail: [string, string]
+}
+
+const diagramStages: DiagramStage[] = [
+  { number: '1', title: 'Apply', detail: ['Validation &', 'approval'] },
+  { number: '2', title: 'Website', detail: ['Built & validated on', 'GitHub Pages'] },
+  { number: '3', title: 'Domain', detail: ['Free .org bought &', 'pointed at your site'] },
+  { number: '4', title: 'Email', detail: ['Microsoft 365 or', 'Google Workspace'] },
+  { number: '5', title: 'Ongoing', detail: ['Renewals, DNS &', 'support forever'] },
+]
+
+const BOX_WIDTH = 168
+const BOX_HEIGHT = 96
+const BOX_Y = 92
+const GAP = 30
+const LEFT = 6
+const stageX = (index: number) => LEFT + index * (BOX_WIDTH + GAP)
+
+// The funding gate sits in the connector between stage 2 (website) and
+// stage 3 (domain): the site must be proven before money is spent.
+const GATE_X = stageX(1) + BOX_WIDTH + GAP / 2
+
+const JourneyDiagram = () => {
+  return (
+    <svg
+      viewBox="0 0 1002 232"
+      xmlns="http://www.w3.org/2000/svg"
+      role="img"
+      aria-labelledby="journey-diagram-title"
+      aria-describedby="journey-diagram-desc"
+      className="w-full max-w-full h-auto"
+      style={{ fontFamily: 'var(--font-lato), Lato, sans-serif' }}
+    >
+      <title id="journey-diagram-title">The five-stage Free For Charity onboarding journey</title>
+      <desc id="journey-diagram-desc">
+        Flow diagram of five stages: 1 Apply (validation and approval), 2 Website (built and
+        validated on GitHub Pages), 3 Domain (free .org bought and pointed at your site), 4 Email
+        (Microsoft 365 or Google Workspace), 5 Ongoing (renewals, DNS and support). An orange
+        funding gate sits between the Website and Domain stages: no money is spent until your
+        website is validated live.
+      </desc>
+
+      {/* Connector arrows between consecutive stages */}
+      <defs>
+        <marker
+          id="journey-arrowhead"
+          markerWidth="8"
+          markerHeight="8"
+          refX="6"
+          refY="4"
+          orient="auto"
+        >
+          <path d="M0 0 L8 4 L0 8 Z" fill={BLUE} />
+        </marker>
+      </defs>
+      {diagramStages.slice(0, -1).map((stage, index) => (
+        <line
+          key={`connector-${stage.number}`}
+          x1={stageX(index) + BOX_WIDTH}
+          y1={BOX_Y + BOX_HEIGHT / 2}
+          x2={stageX(index + 1) - 2}
+          y2={BOX_Y + BOX_HEIGHT / 2}
+          stroke={BLUE}
+          strokeWidth="2.5"
+          markerEnd="url(#journey-arrowhead)"
+          aria-hidden="true"
+        />
+      ))}
+
+      {/* Funding gate highlight between Website and Domain */}
+      <g aria-hidden="true">
+        <line
+          x1={GATE_X}
+          y1="58"
+          x2={GATE_X}
+          y2={BOX_Y + BOX_HEIGHT + 14}
+          stroke={ORANGE}
+          strokeWidth="4"
+          strokeDasharray="7 5"
+          strokeLinecap="round"
+        />
+        <text
+          x={GATE_X}
+          y="26"
+          textAnchor="middle"
+          fontSize="17"
+          fontWeight="700"
+          fill={ORANGE}
+          letterSpacing="0.06em"
+        >
+          FUNDING GATE
+        </text>
+        <text x={GATE_X} y="48" textAnchor="middle" fontSize="13.5" fill={INK}>
+          Money is spent only after your site is proven
+        </text>
+        <text x={GATE_X} y={BOX_Y + BOX_HEIGHT + 34} textAnchor="middle" fontSize="13.5" fill={INK}>
+          Validated live site unlocks the domain purchase
+        </text>
+      </g>
+
+      {/* Stage boxes */}
+      {diagramStages.map((stage, index) => {
+        const x = stageX(index)
+        const isBeforeGate = index <= 1
+        return (
+          <g key={stage.number} aria-hidden="true">
+            <rect
+              x={x}
+              y={BOX_Y}
+              width={BOX_WIDTH}
+              height={BOX_HEIGHT}
+              rx="10"
+              fill={isBeforeGate ? BLUE : '#ffffff'}
+              stroke={isBeforeGate ? BLUE : ORANGE}
+              strokeWidth={isBeforeGate ? 0 : 3}
+            />
+            <circle cx={x + 24} cy={BOX_Y + 26} r="13" fill={isBeforeGate ? '#ffffff' : ORANGE} />
+            <text
+              x={x + 24}
+              y={BOX_Y + 31}
+              textAnchor="middle"
+              fontSize="15"
+              fontWeight="700"
+              fill={isBeforeGate ? BLUE : '#ffffff'}
+            >
+              {stage.number}
+            </text>
+            <text
+              x={x + 46}
+              y={BOX_Y + 31}
+              fontSize="18"
+              fontWeight="700"
+              fill={isBeforeGate ? '#ffffff' : INK}
+            >
+              {stage.title}
+            </text>
+            <text x={x + 14} y={BOX_Y + 58} fontSize="13.5" fill={isBeforeGate ? '#ffffff' : INK}>
+              {stage.detail[0]}
+            </text>
+            <text x={x + 14} y={BOX_Y + 76} fontSize="13.5" fill={isBeforeGate ? '#ffffff' : INK}>
+              {stage.detail[1]}
+            </text>
+          </g>
+        )
+      })}
+    </svg>
+  )
+}
+
+export default JourneyDiagram

--- a/src/data/guides.json
+++ b/src/data/guides.json
@@ -17,6 +17,13 @@
       "minutes": 5
     },
     {
+      "href": "/why-website-first/",
+      "title": "Why your website comes before your domain",
+      "promise": "Donor trust, zero sunk costs, and the four gates that make sure money is only spent on proven sites.",
+      "group": "Getting started",
+      "minutes": 4
+    },
+    {
       "href": "/getting-started-checklist/",
       "title": "Getting started checklist (printable)",
       "promise": "One page covering everything to gather before, during, and after onboarding.",

--- a/src/data/search-index.json
+++ b/src/data/search-index.json
@@ -338,6 +338,12 @@
       "type": "post"
     },
     {
+      "title": "Why We Build Your Website Before Buying Your Domain",
+      "description": "The gated FFC onboarding journey explained: donor trust, no sunk costs, and the four gates that make sure money is only spent on charities whose sites are already proven live.",
+      "href": "/why-website-first/",
+      "type": "page"
+    },
+    {
       "title": "Workforce Development",
       "description": "Free workforce development and training in modern web development—building GitHub Pages static sites with AI development agents (Claude and GitHub Copilot)—and programming. Build your skills while helping charities.",
       "href": "/workforce-development/",

--- a/tests/routes.ts
+++ b/tests/routes.ts
@@ -66,6 +66,7 @@ export const siteRoutes = [
   { route: '/publicity-consent-policy', name: 'Publicity & Story Consent Policy' },
   { route: '/guides', name: 'Guides Hub' },
   { route: '/charity-onboarding-journey', name: 'Charity Onboarding Journey' },
+  { route: '/why-website-first', name: 'Why Website First' },
   { route: '/getting-started-checklist', name: 'Getting Started Checklist' },
   { route: '/m365-email-guide', name: 'M365 Email Guide' },
   { route: '/google-for-nonprofits-guide', name: 'Google for Nonprofits Guide' },


### PR DESCRIPTION
## Summary

Overnight block 7 (log: FreeForCharity/FFC-Cloudflare-Automation#697) — recovered from the block agent's completed worktree and verified end-to-end:

- **/why-website-first/** — public explainer for the gated journey: why the website is built and validated before FFC spends money on the domain, in charity-facing language, with both templates introduced and an apply CTA
- **JourneyDiagram** — accessible inline SVG (FFC brand colors) of the five stages with the funding gate highlighted; rendered on the new page and /charity-onboarding-journey/
- **docs/marketing/** — six social post drafts (LinkedIn + Facebook; charity-recruiting, volunteer-recruiting, donor-trust angles) and the Catnip case-study skeleton, all clearly marked DRAFTS for operator review; nothing is posted anywhere
- Registered in sitemap, route tests, and search data; passes the banned-phrase guard; no coupon references

## Test plan
- [x] lint clean · build (static export) clean
- [x] 628/628 unit (15 new: page render/content/links + diagram + axe)
- [x] 378 passed / 19 skipped e2e

🤖 Generated with [Claude Code](https://claude.com/claude-code)