### PR TITLE
refactor(content): single-source journey stages and shared FAQ copy

### DIFF
--- a/__tests__/data/data-files.test.ts
+++ b/__tests__/data/data-files.test.ts
@@ -7,7 +7,7 @@
 
 import { team } from '@/data/team'
 import { testimonials } from '@/data/testimonials'
-import { faqs } from '@/data/faqs'
+import { domainDonationTaxFaq, hostingBacklogFaq } from '@/data/faqs'
 
 describe('Team Data', () => {
   it('exports an array of team members', () => {
@@ -51,16 +51,32 @@ describe('Testimonials Data', () => {
   })
 })
 
-describe('FAQs Data', () => {
-  it('exports an array of FAQs', () => {
-    expect(Array.isArray(faqs)).toBe(true)
-    expect(faqs.length).toBeGreaterThan(0)
+describe('Shared FAQ Data (single-sourced copy)', () => {
+  it('hosting backlog FAQ has question, backlog answer, and ways to get in faster', () => {
+    expect(hostingBacklogFaq.question).toBeTruthy()
+    expect(hostingBacklogFaq.backlog).toBeTruthy()
+    expect(hostingBacklogFaq.waysHeading).toBeTruthy()
+    expect(hostingBacklogFaq.ways.length).toBeGreaterThan(0)
+    for (const way of hostingBacklogFaq.ways) {
+      expect(way.before).toBeTruthy()
+      if (way.link) {
+        expect(way.link.href).toBeTruthy()
+        expect(way.link.label).toBeTruthy()
+      }
+    }
   })
 
-  it('each FAQ has question and answer', () => {
-    for (const faq of faqs) {
-      expect(faq.question).toBeTruthy()
-      expect(faq.answer).toBeTruthy()
-    }
+  it('reflects the gated journey (domain purchased after site validation)', () => {
+    const allText = [
+      hostingBacklogFaq.backlog,
+      ...hostingBacklogFaq.ways.flatMap((w) => [w.before, w.after ?? '']),
+    ].join(' ')
+    expect(allText).toMatch(/once your site is validated/i)
+    expect(allText).not.toMatch(/eNom/i)
+  })
+
+  it('tax-deduction FAQ has question and answer with the EIN', () => {
+    expect(domainDonationTaxFaq.question).toBeTruthy()
+    expect(domainDonationTaxFaq.answer).toContain('46-2471893')
   })
 })

--- a/docs/METRICS-PLAYBOOK.md
+++ b/docs/METRICS-PLAYBOOK.md
@@ -34,7 +34,7 @@ two gaps that keep the real numbers from being knowable today.
 | 7   | "**100** new charities annually"        | 100           | `…/Empowering-Charities/index.tsx:40`                | aspirational target |
 | 8   | Progress bars (95% / 85% / 75%)         | 95/85/75      | `…/Empowering-Charities/index.tsx:44-46`             | decorative          |
 | 9   | "$**1,000,000** endowment goal"         | $1M           | endowment components (3 files)                       | goal, not progress  |
-| 10  | "~$**16.50** per charity per year"      | $16.50        | `src/data/faqs.ts:12` + home FAQ                     | verify vs. actual   |
+| 10  | "~$**16.50** per charity per year"      | $16.50        | home FAQ + `/charity-faq/` copy                      | verify vs. actual   |
 | 11  | "IRS designation **since 2014**"        | 2014          | `src/data/faqs/are-you-really-a-charity.json`        | static fact (OK)    |
 
 ### 1.2 Out of scope (policy/legal constants)

--- a/src/app/charity-onboarding-journey/page.tsx
+++ b/src/app/charity-onboarding-journey/page.tsx
@@ -1,6 +1,7 @@
 import { pageMetadata } from '@/lib/page-metadata'
 import Link from 'next/link'
 import JourneyDiagram from '@/components/journey/JourneyDiagram'
+import { GATE_SENTENCE, journeyStages } from '@/data/journey'
 
 export const metadata = pageMetadata({
   title: 'Your Onboarding Journey',
@@ -10,60 +11,6 @@ export const metadata = pageMetadata({
 })
 
 const h2 = 'font-[var(--font-faustina)] text-[32px] leading-[40px] mt-8 mb-4'
-
-interface Stage {
-  name: string
-  you: string
-  ffc: string
-  duration: string
-  links?: { href: string; label: string }[]
-}
-
-const stages: Stage[] = [
-  {
-    name: '1. Application & validation',
-    you: 'Submit the onboarding form with your EIN, legal name, charity Facebook and LinkedIn pages, and what you need. Have your IRS determination letter handy (pre-501c3 orgs: your formation documents).',
-    ffc: 'We validate your organization (IRS status, Candid profile) and confirm program fit. Every later stage requires this approval first.',
-    duration: 'A few days',
-    links: [{ href: '/help-for-charities/', label: 'Start here: Help for Charities' }],
-  },
-  {
-    name: '2. Website — built and proven first',
-    you: 'Submit the website application (it requires your approved onboarding), then send your logo, photos, mission text, and program descriptions. A one-page outline is enough — we help with the rest.',
-    ffc: 'A volunteer builds your site from the FFC template (fast, secure static hosting), with the full FFC footer generated from your validated application data. Your site goes live on its free GitHub Pages address — no custom domain yet — and we validate it end to end with you.',
-    duration: '2–6 weeks, mostly depending on content readiness',
-    links: [
-      {
-        href: 'https://ffcadmin.org/sites-list/',
-        label: 'How FFC delivers services',
-      },
-    ],
-  },
-  {
-    name: '3. Domain — only after your site is proven',
-    you: 'Send us your top three .org name choices — or the details of a domain you already own — along with your live GitHub Pages address. You can check name availability any time; we buy once your site is validated.',
-    ffc: 'Once your website is validated, we spend the funds: we register (and pay for) the best available name, or take over management of your existing domain, set up DNS and security, and point it at your live site.',
-    duration: 'Same week (after website validation)',
-    links: [{ href: '/domains/#check-your-domain', label: 'Guide: choosing your .org domain' }],
-  },
-  {
-    name: '4. Email',
-    you: 'Choose Microsoft 365 or Google Workspace, then register with Microsoft for Nonprofits or Google for Nonprofits and tell us when the DNS verification codes appear. Both nonprofit email programs require a live website before they approve your 501(c)(3) — which is exactly why your website comes first.',
-    ffc: 'We add the DNS records so your free Microsoft 365 or Google Workspace mailboxes go live, and confirm MFA is on.',
-    duration: '2–5 business days (Microsoft or Google validation)',
-    links: [
-      { href: '/m365-email-guide/', label: 'Guide: free Microsoft 365 email' },
-      { href: '/google-for-nonprofits-guide/', label: 'Guide: free Google Workspace email' },
-    ],
-  },
-  {
-    name: '5. Handoff & ongoing support',
-    you: 'Learn where to send changes and questions; add the trust-builders (Candid seal, donation form) when ready.',
-    ffc: 'We keep the domain renewed, DNS secure, and hosting healthy — and stay reachable for changes and fixes.',
-    duration: 'Ongoing',
-    links: [{ href: '/guides/', label: 'All guides' }],
-  },
-]
 
 export default function CharityOnboardingJourney() {
   return (
@@ -76,11 +23,10 @@ export default function CharityOnboardingJourney() {
         <div className="prose max-w-none font-[var(--font-lato)] text-[18px] leading-[28px]">
           <p>
             Here&rsquo;s exactly what happens after your charity applies — the five stages, who does
-            what at each one, and honest durations. The order matters: your website is built and
-            validated on free GitHub Pages hosting <em>first</em>, and we only spend money on your
-            domain once your site is proven. Volunteers do this work, so timelines are typical
-            rather than guaranteed; content readiness on your side is the biggest factor in how fast
-            a site launches. Curious about the reasoning behind this order?{' '}
+            what at each one, and honest durations. The order matters: {GATE_SENTENCE} Volunteers do
+            this work, so timelines are typical rather than guaranteed; content readiness on your
+            side is the biggest factor in how fast a site launches. Curious about the reasoning
+            behind this order?{' '}
             <Link href="/why-website-first/">
               Read why we build your website before buying your domain
             </Link>
@@ -93,19 +39,19 @@ export default function CharityOnboardingJourney() {
         </div>
 
         <ol className="mt-8 space-y-6">
-          {stages.map((stage) => (
-            <li key={stage.name} className="border border-gray-200 rounded-lg p-6">
+          {journeyStages.map((stage) => (
+            <li key={stage.id} className="border border-gray-200 rounded-lg p-6">
               <h2 className="font-[var(--font-faustina)] text-[26px] leading-[34px] mb-3">
                 {stage.name}
               </h2>
               <dl className="font-[var(--font-lato)] text-[17px] leading-[27px] space-y-2">
                 <div>
                   <dt className="font-[700] inline">You: </dt>
-                  <dd className="inline">{stage.you}</dd>
+                  <dd className="inline">{stage.youDo}</dd>
                 </div>
                 <div>
                   <dt className="font-[700] inline">FFC: </dt>
-                  <dd className="inline">{stage.ffc}</dd>
+                  <dd className="inline">{stage.ffcDoes}</dd>
                 </div>
                 <div>
                   <dt className="font-[700] inline">Typical duration: </dt>

--- a/src/app/getting-started-checklist/page.tsx
+++ b/src/app/getting-started-checklist/page.tsx
@@ -1,5 +1,6 @@
 import { pageMetadata } from '@/lib/page-metadata'
 import Link from 'next/link'
+import { GATE_SENTENCE } from '@/data/journey'
 
 export const metadata = pageMetadata({
   title: 'Getting Started Checklist',
@@ -59,10 +60,8 @@ export default function GettingStartedChecklist() {
 
           <h2 className={h2}>During onboarding</h2>
           <p className="print:text-[11px]">
-            FFC builds your website first, live and validated on its free GitHub Pages address —
-            your domain is purchased only after your site is proven, and charity email comes after
-            that, because the nonprofit email programs (Microsoft 365 / Google Workspace) expect
-            your organization to have an established web presence.
+            {GATE_SENTENCE} That order exists because the nonprofit email programs (Microsoft 365 /
+            Google Workspace) expect your organization to have an established web presence.
           </p>
           <ul className="space-y-2 list-none pl-0">
             <Item>

--- a/src/components/free-charity-web-hosting/FAQs/index.tsx
+++ b/src/components/free-charity-web-hosting/FAQs/index.tsx
@@ -1,6 +1,7 @@
 'use client'
 import React, { useState, useRef } from 'react'
 import { FaPlus, FaMinus } from 'react-icons/fa'
+import { domainDonationTaxFaq, hostingBacklogFaq } from '@/data/faqs'
 
 /* ---------------------------------------------------
    Reusable AccordionItem Component (Styled)
@@ -174,28 +175,25 @@ const AccordionLayout = () => {
               </AccordionItem>
 
               <AccordionItem
-                title="Why do I not see hosting as an option?"
+                title={hostingBacklogFaq.question}
                 isOpen={openRight === 'right2'}
                 onToggle={() => toggleRight('right2')}
               >
-                We have a large backlog for new sites and support. We try to process at least 1 new
-                charity into the full hosting system per week.
+                {hostingBacklogFaq.backlog}
                 <br />
-                Ways to get in faster:
+                {hostingBacklogFaq.waysHeading}
                 <ul className="list-disc list-inside mt-1">
-                  <li>
-                    Complete onboarding and pick your .org name early — check availability at{' '}
-                    <a href="/domains/" className="text-[#0567B1]">
-                      freeforcharity.org/domains
-                    </a>{' '}
-                    — we purchase it once your site is validated
-                  </li>
-                  <li>
-                    If you arrive with your content ready to go — logo, photos, mission text, and
-                    program descriptions — your GitHub Pages site can be built and validated much
-                    faster, which unlocks your domain and email sooner and may move you up in the
-                    list.
-                  </li>
+                  {hostingBacklogFaq.ways.map((way) => (
+                    <li key={way.before}>
+                      {way.before}
+                      {way.link && (
+                        <a href={way.link.href} className="text-[#0567B1]">
+                          {way.link.label}
+                        </a>
+                      )}
+                      {way.after}
+                    </li>
+                  ))}
                 </ul>
               </AccordionItem>
             </div>
@@ -204,17 +202,12 @@ const AccordionLayout = () => {
           {/* Bottom Independent Accordion */}
           <div className="w-full max-w-md mx-auto">
             <AccordionItem
-              title="If I am an individual or business and donate money for a domain package to Free For Charity is this tax-deductible?"
+              title={domainDonationTaxFaq.question}
               isOpen={bottomOpen}
               onToggle={() => setBottomOpen(!bottomOpen)}
               small
             >
-              While any official tax guidance should come from your accountant or other tax advisor
-              Free For Charity is a registered 501(c)(3) organization and donations are
-              tax-deductible. Our IRS designation number (EIN) is 46-2471893. Upon checkout you will
-              receive a receipt to provide to your accountant. Specifically, if you represent a
-              business you can elect to deduct this as an expense versus as a donation depending on
-              the guidance of your tax advisor.
+              {domainDonationTaxFaq.answer}
             </AccordionItem>
           </div>
         </div>

--- a/src/components/home-page/FrequentlyAskedQuestions/index.tsx
+++ b/src/components/home-page/FrequentlyAskedQuestions/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import FrequentlyAskedQuestions from '@/components/ui/Frequently-Asked-Questions'
+import { domainDonationTaxFaq, hostingBacklogFaq } from '@/data/faqs'
 
 const index = () => {
   return (
@@ -258,35 +259,27 @@ const index = () => {
             </p>
           </FrequentlyAskedQuestions>
 
-          <FrequentlyAskedQuestions title="Why do I not see hosting as an option?">
-            <p className="mb-[20px]">
-              We have a large backlog for new sites and support. We try to process at least 1 new
-              charity into the full hosting system per week.
-            </p>
+          <FrequentlyAskedQuestions title={hostingBacklogFaq.question}>
+            <p className="mb-[20px]">{hostingBacklogFaq.backlog}</p>
             <p>
-              <strong>Ways to get in faster:</strong>
-              <br />
-              1. Complete onboarding and pick your .org name early — check availability at{' '}
-              <a href="/domains/" className="text-[#1c6e92] underline">
-                freeforcharity.org/domains
-              </a>{' '}
-              (we purchase it once your site is validated).
-              <br />
-              2. If you arrive content-ready — with your logo, photos, mission statement, and
-              program text prepared — your site gets built and validated sooner, which unlocks your
-              domain and email sooner.
+              <strong>{hostingBacklogFaq.waysHeading}</strong>
+              {hostingBacklogFaq.ways.map((way, index) => (
+                <React.Fragment key={way.before}>
+                  <br />
+                  {index + 1}. {way.before}
+                  {way.link && (
+                    <a href={way.link.href} className="text-[#1c6e92] underline">
+                      {way.link.label}
+                    </a>
+                  )}
+                  {way.after}
+                </React.Fragment>
+              ))}
             </p>
           </FrequentlyAskedQuestions>
 
-          <FrequentlyAskedQuestions title="If I am an individual or business and donate money for a domain package to Free For Charity, is this tax-deductible?">
-            <p>
-              While any official tax guidance should come from your accountant or other tax advisor
-              Free For Charity is a registered 501(c)(3) organization and donations are
-              tax-deductible. Our IRS designation number (EIN) is 46-2471893.  Upon checkout you
-              will receive a receipt to provide to your accountant. Specifically, if you represent a
-              business you can elect to deduct this as an expense versus as a donation depending on
-              the guidance of your tax advisor.
-            </p>
+          <FrequentlyAskedQuestions title={domainDonationTaxFaq.question}>
+            <p>{domainDonationTaxFaq.answer}</p>
           </FrequentlyAskedQuestions>
         </div>
       </div>

--- a/src/data/faqs.ts
+++ b/src/data/faqs.ts
@@ -1,95 +1,56 @@
-export type Faq = { question: string; answer: string }
+/**
+ * Single source of truth for FAQ copy that is rendered in more than one
+ * place, so the answers cannot drift apart.
+ *
+ * Renderers:
+ *  - src/components/home-page/FrequentlyAskedQuestions/index.tsx
+ *  - src/components/free-charity-web-hosting/FAQs/index.tsx
+ *
+ * Both components keep their own markup (accordion styles differ) but pull
+ * the question and answer strings for the overlapping entries from here.
+ *
+ * History: this module previously exported a large `faqs` array that no
+ * component imported (dead data that had already drifted from the rendered
+ * copy). Those unused entries were removed; see git history if you need the
+ * old text. The CMS-managed JSON files in src/data/faqs/ hold the two
+ * long-form program FAQs still referenced by docs/METRICS-PLAYBOOK.md.
+ */
 
-// Import CMS-managed FAQs
-import faq1 from './faqs/what-is-the-organization-aiming-to-accomplish.json'
-import faq2 from './faqs/are-you-really-a-charity.json'
+export interface FaqLink {
+  href: string
+  label: string
+}
 
-export const faqs: Faq[] = [
-  faq1,
-  faq2,
-  {
-    question: "What are the organization's key strategies for making this happen?",
-    answer: `FFC assists by paying the full cost of the .org domain name if available. This reduces a charity direct hard cost instantly and increases adoption of many other formal IT systems as a very low cost per charity (~$16.50 per year)
+/** A bullet in the "ways to get in faster" list: before + optional link + after. */
+export interface FaqWay {
+  before: string
+  link?: FaqLink
+  after?: string
+}
 
-FFC is also employing a premium subscription to volunteer match to source additional IT project managers, IT Webmasters, and Graphic designers to expand how many charities we can support at one time. as well as working on partnerships with other charities and technology vendors for additional services not offered by Free For Charity.`,
-  },
-  {
-    question: "What are the organization's capabilities for doing this?",
-    answer: `We already have accounts set up at Cloudflare Registrar to provide enterprise level domain procurement, and by using WHMCS specifically for our 501c3 and pre 501c3 organizations we can register domain names and stand up GitHub Pages static sites automatically without staff input.
+/** 'Why do I not see hosting as an option?' — the hosting backlog answer. */
+export const hostingBacklogFaq = {
+  question: 'Why do I not see hosting as an option?',
+  backlog:
+    'We have a large backlog for new sites and support. We try to process at least 1 new charity into the full hosting system per week.',
+  waysHeading: 'Ways to get in faster:',
+  ways: [
+    {
+      before: 'Complete onboarding and pick your .org name early — check availability at ',
+      link: { href: '/domains/', label: 'freeforcharity.org/domains' },
+      after: ' — we purchase it once your site is validated.',
+    },
+    {
+      before:
+        'If you arrive content-ready — with your logo, photos, mission text, and program descriptions prepared — your GitHub Pages site is built and validated sooner, which unlocks your domain and email sooner and may move you up in the list.',
+    },
+  ] as FaqWay[],
+}
 
-For our training programs we help charities navigate through the AB-900 (Microsoft 365 Copilot and Agent Administration Fundamentals) certification program while pursuing their "Microsoft 365 Grants". We further build each charity a GitHub Pages static website from the Free For Charity template, assembled and refined by our AI agents, so your organization gets a fast, secure site without hosting overhead.`,
-  },
-  {
-    question: "What have and haven't they accomplished so far?",
-    answer: `While a lot has been accomplished on the IT hosting side and to a certain degree the IT project management and consulting side, one element of FFC has not even been started. The Free For Charity directory showing services by category that are actually entirely free to non-profits has not been developed yet. There are on the market a number of regional consulting directories traditionally where the consultant is a for-profit entity and pays money to be marketed to other nonprofits. We seek to produce an entirely free directory with unbiased empirical metrics showing what resources are available to nonprofits. By reducing the high cost often several hundred dollars a year to be listed in these directories a broader suite of available high-quality professionals can be made available to the nonprofit community at a national level. However to accomplish this will require additional code and hosting resources that have a hard cost not currently budgeted within the freeforcharity budget. We are seeking grant opportunities to overcome these issues.`,
-  },
-  {
-    question: 'Is there a need for a charity to provide help for charities?',
-    answer: `Yes there is a need to provide help for charities in many ways! Free For Charity is not the only ‘charity for charities’ helping to lower your costs. Another great charity showing all the big name things you can get for free or at heavy discounts is TechSoup.org. Even with these other sites many charities and non profits still pay for profit companies to do work every day or buy products at full cost. Some do so without knowing that as a charity they qualify for lower rates or even free services from major companies. Others because it is hard to find the free products needed though the massive amount of paid marketing by well-funded for profit companies.
-
-The Free For Charity services, consultant, and technology products directories seek to fix this problem with our motto “Decisions should be made by metrics not marketing.”`,
-  },
-  {
-    question: 'Where did the idea come from?',
-    answer: `Free For Charity was started when the founder first started as a board member on the local children’s museum’s board of directors. In just a few short weeks he uncovered many items the museum was paying for that were free to charities but the museum was paying for anyways.
-
-In addition, for big projects the museum was not following any procurement management procedures at all. Items such as quoting from multiple vendors before a bid or cross leveling the bids for price and quality were not being done.
-
-Other issues found were the reliance on outdated technology because better alternatives were not known to the non IT trained staff.`,
-  },
-  {
-    question: 'Why do charities pay for items they can get for free?',
-    answer: `The first reaction to uncovering these issues with the board was anger. The museum was losing or wasting thousands each year; money that could be used to keep admission prices lower and serve more children! After a deeper look it all came back to training and experience. Most charity founders and directors of small and medium charities are trained in the specialty of the charities mission, in this case child education and development. It is unreasonable to expect every charity director to be up to date on all procurement management methods and the technology that supports business and still run the day-to-day mission. This is where Free For Charity will come in to help your charities projects to thrive.`,
-  },
-  {
-    question: 'Where does Free For Charity come in to help our charity or nonprofit?',
-    answer: `Free For Charity will fill these vital roles for non profits and charities saving money for real program expenses. Most small to medium charities do not have the budget for full-time IT staff or business analysts like for profit companies and large charities. This is because grant managers and large donors want to see the lowest cost to “overhead” and don’t always look closely at the results that fall under program expenses.
-
-Because of this common practice by large donors and grant institutions it is actually better for a small charity to waste money due to mismanagement such as by paying for something they could get for free because the item is put on the books as a ‘program expense’ and not questioned. Program expenses do not count against the charity like “overhead” does.
-
-Paying someone on the non program admin staff or the director of the charity to research and call companies for discounts is a labor cost that counts as “overhead” because it helps more than one program. With Free For Charity doing the work the target charity does not have to claim costs for overhead. Your nonprofit or charity group will gain access to professionals that have more expertise with the common business tasks like researching products to meet the charities needs. Free For Charity will also show you recommended technology and business practices that can save thousands each year.`,
-  },
-  {
-    question: 'How can I tell if we have high overhead? / My charity does not have high overhead!',
-    answer: `Free For Charity is all about efficiency. Many charities ‘fix’ this overhead problem by treating all staff as working on / in the programs or pro-rating between them all and hoping they will not get audited. While on paper you show very low overhead the functional effect is still the same. You have high paid staff like a director doing work that should be done by skilled volunteers or technology. Items such as your nonprofit or charity group bookkeeping data entry, or a full-time employee who updates the charity website or nonprofit Facebook page every now and then between front desk tasks.
-
-If you have ever seen a charity with lower than 5% over head this is mostly what is going on. If you have low recorded overhead then your charity is most likely not using experts for tasks and all staff are wearing many hats; most of which they were never trained in.`,
-  },
-  {
-    question: 'How do you provide your program services?',
-    answer: `We provide help for charities with efficiency. One element of efficiency is getting the best product at the lowest price. For charities and non profits much more labor can be provided for free by volunteers. Free For Charity does not make your full-time staff take on more and more roles we can fully take over many of these tasks with expert volunteer labor. Business and IT professionals are always seeking to advance their skills while helping out charities. We capture this labor pool (or create it with training programs) and then manage the volunteers for your charities tasks and projects. We can do this at extremely low if not zero cost because of economies of scale, and because most of this work is process or research based and does not have ‘hard’ costs like equipment.`,
-  },
-  {
-    question: 'Are you like volunteermatch.org or other matching agencies?',
-    answer: `Not exactly. That type of charity matches workers with charities but then leaves the management of the work to the individual nonprofit or charity group. Many small and medium charities do not have the time to manage a volunteer or group of volunteers. Even charities with a volunteer coordinator who works with entry level volunteers may not have the skills to manage highly technical or high level business volunteers such as those with MBA’s or decades in high level information technology. This can result in your best volunteers leaving before a project is completed.
-
-Free For Charity will manage both the work and the results of the projects in-house. All you have to do as a charity is to work with your project manager to set expectations and define results at each stage of the project.
-
-We also provide many physical services like nonprofit websites and hosting that are functionally like a product to your charity. We manage all the functions in the background with volunteers. With these other sites you get one person assigned to work your web project and you have no management support once it is done unless that one person stays on as a volunteer permanently. With Free For Charity if your initial volunteer leaves another from the web team still works on your project and keeps your websites running and maintained. This is just one example.`,
-  },
-  {
-    question: 'What do I need to get started?',
-    answer: `All you need to do to get Free For Charity to provide help for your charities mission today is to contact us with some basic information about your charity. We need to know what type of projects that you would like us to look at or undertake. Please fill out the form below and we will be in touch shortly.`,
-  },
-  {
-    question: 'How can you afford to give away free domain names?',
-    answer: `As a 501(c)3 charity ourselves we seek individual, business, and grant sources of funding. At current, Free For Charity has not received a grant specifically for domain names or hosting but uses individual and business contributions to fund this program.`,
-  },
-  {
-    question: 'Where do you get your domain name packages?',
-    answer: `Our supported charity domains are registered and managed directly at Cloudflare Registrar, which offers domains at cost so we can provide the lowest cost domain names for a charity of our size. As we get more and more charities into the domain system we expect the costs to freeforcharity.org to drop even further.`,
-  },
-  {
-    question: 'Why do I not see hosting as an option?',
-    answer: `We have a large backlog for new sites and support. We try to process at least 1 new charity into the full hosting system per week.
-
-Ways to get in faster
-Complete onboarding and pick your .org name early — check availability at https://freeforcharity.org/domains/ — we purchase it once your site is validated.
-If you arrive content-ready — with your logo, photos, mission statement, and program text prepared — you may be moved up in the list.`,
-  },
-  {
-    question:
-      'If I am an individual or business and donate money for a domain package to Free For Charity is this tax-deductible?',
-    answer: `While any official tax guidance should come from your accountant or other tax advisor Free For Charity is a registered 501(c)(3) organization and donations are tax-deductible. Our IRS designation number (EIN) is 46-2471893. Upon checkout you will receive a receipt to provide to your accountant. Specifically, if you represent a business you can elect to deduct this as an expense versus as a donation depending on the guidance of your tax advisor.`,
-  },
-]
+/** The domain-package donation tax-deduction answer. */
+export const domainDonationTaxFaq = {
+  question:
+    'If I am an individual or business and donate money for a domain package to Free For Charity, is this tax-deductible?',
+  answer:
+    'While any official tax guidance should come from your accountant or other tax advisor Free For Charity is a registered 501(c)(3) organization and donations are tax-deductible. Our IRS designation number (EIN) is 46-2471893. Upon checkout you will receive a receipt to provide to your accountant. Specifically, if you represent a business you can elect to deduct this as an expense versus as a donation depending on the guidance of your tax advisor.',
+}

--- a/src/data/journey.ts
+++ b/src/data/journey.ts
@@ -1,0 +1,105 @@
+/**
+ * Single source of truth for the five-stage gated charity onboarding journey.
+ *
+ * Rendered by src/app/charity-onboarding-journey/page.tsx (the full stage
+ * cards) and referenced by src/app/getting-started-checklist/page.tsx (the
+ * "During onboarding" order statement via GATE_SENTENCE), so the journey
+ * order and copy cannot drift between pages.
+ *
+ * The order is load-bearing: the website is built and validated FIRST on its
+ * free GitHub Pages address, and money is only spent on the domain once the
+ * site is proven (the funding gate), with email after that. See also
+ * src/components/journey/JourneyDiagram.tsx and /why-website-first/.
+ */
+
+export interface JourneyStageLink {
+  href: string
+  label: string
+}
+
+export interface JourneyStage {
+  id: string
+  name: string
+  /** How this stage relates to the journey's gates (approval / funding). */
+  gateNote: string
+  youDo: string
+  ffcDoes: string
+  duration: string
+  links?: JourneyStageLink[]
+}
+
+/**
+ * The one-sentence order statement shared verbatim by the journey page and
+ * the getting-started checklist so the gated order is stated identically
+ * everywhere.
+ */
+export const GATE_SENTENCE =
+  'Your website is built and validated first, live on its free GitHub Pages address — your domain is purchased only after your site is proven, and charity email comes after that.'
+
+export const journeyStages: JourneyStage[] = [
+  {
+    id: 'application',
+    name: '1. Application & validation',
+    gateNote: 'Approval here is the gate for every later stage.',
+    youDo:
+      'Submit the onboarding form with your EIN, legal name, charity Facebook and LinkedIn pages, and what you need. Have your IRS determination letter handy (pre-501c3 orgs: your formation documents).',
+    ffcDoes:
+      'We validate your organization (IRS status, Candid profile) and confirm program fit. Every later stage requires this approval first.',
+    duration: 'A few days',
+    links: [{ href: '/help-for-charities/', label: 'Start here: Help for Charities' }],
+  },
+  {
+    id: 'website',
+    name: '2. Website — built and proven first',
+    gateNote:
+      'Your validated live site is the funding gate: it unlocks the domain purchase in stage 3.',
+    youDo:
+      'Submit the website application (it requires your approved onboarding), then send your logo, photos, mission text, and program descriptions. A one-page outline is enough — we help with the rest.',
+    ffcDoes:
+      'A volunteer builds your site from the FFC template (fast, secure static hosting), with the full FFC footer generated from your validated application data. Your site goes live on its free GitHub Pages address — no custom domain yet — and we validate it end to end with you.',
+    duration: '2–6 weeks, mostly depending on content readiness',
+    links: [
+      {
+        href: 'https://ffcadmin.org/sites-list/',
+        label: 'How FFC delivers services',
+      },
+    ],
+  },
+  {
+    id: 'domain',
+    name: '3. Domain — only after your site is proven',
+    gateNote: 'Unlocked only after your website is validated live on GitHub Pages.',
+    youDo:
+      'Send us your top three .org name choices — or the details of a domain you already own — along with your live GitHub Pages address. You can check name availability any time; we buy once your site is validated.',
+    ffcDoes:
+      'Once your website is validated, we spend the funds: we register (and pay for) the best available name, or take over management of your existing domain, set up DNS and security, and point it at your live site.',
+    duration: 'Same week (after website validation)',
+    links: [{ href: '/domains/#check-your-domain', label: 'Guide: choosing your .org domain' }],
+  },
+  {
+    id: 'email',
+    name: '4. Email',
+    gateNote:
+      'Comes after the domain — the nonprofit email programs require a live website before they approve your 501(c)(3).',
+    youDo:
+      'Choose Microsoft 365 or Google Workspace, then register with Microsoft for Nonprofits or Google for Nonprofits and tell us when the DNS verification codes appear. Both nonprofit email programs require a live website before they approve your 501(c)(3) — which is exactly why your website comes first.',
+    ffcDoes:
+      'We add the DNS records so your free Microsoft 365 or Google Workspace mailboxes go live, and confirm MFA is on.',
+    duration: '2–5 business days (Microsoft or Google validation)',
+    links: [
+      { href: '/m365-email-guide/', label: 'Guide: free Microsoft 365 email' },
+      { href: '/google-for-nonprofits-guide/', label: 'Guide: free Google Workspace email' },
+    ],
+  },
+  {
+    id: 'handoff',
+    name: '5. Handoff & ongoing support',
+    gateNote: 'No gate — ongoing once you are live.',
+    youDo:
+      'Learn where to send changes and questions; add the trust-builders (Candid seal, donation form) when ready.',
+    ffcDoes:
+      'We keep the domain renewed, DNS secure, and hosting healthy — and stay reachable for changes and fixes.',
+    duration: 'Ongoing',
+    links: [{ href: '/guides/', label: 'All guides' }],
+  },
+]


### PR DESCRIPTION
## Summary

**Block 9 — journey SSOT + FAQ single-source.**

- **Journey SSOT**: new `src/data/journey.ts` exports the five-stage gated journey as typed data (`id`, `name`, `gateNote`, `youDo`, `ffcDoes`, `duration`, `links`), content lifted verbatim from `/charity-onboarding-journey/`. The journey page now renders its stage cards from the module, and `/getting-started-checklist/` derives its 'During onboarding' order statement from the shared `GATE_SENTENCE` constant — the gated order (website → domain → email) is now stated identically everywhere and cannot drift.
- **FAQ single-source**: `src/data/faqs.ts` was dead data (no component imported it) while two components hardcoded near-duplicate FAQs. It is now the single source for the two overlapping answers — the hosting-backlog answer ('Why do I not see hosting as an option?') and the domain-donation tax-deduction answer — rendered by both `home-page/FrequentlyAskedQuestions` and `free-charity-web-hosting/FAQs` from structured `{question, paragraphs, links}`-style data (each keeps its own accordion markup). All dead entries removed with a header comment naming the two renderers.
- Data-files test updated for the new shape; `docs/METRICS-PLAYBOOK.md` pointer updated.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [x] `npm run build` (static export) clean
- [x] `npm run test` — 629 passed (journey unit tests assert '2. Website — built and proven first' etc.; faqs-onboarding-sync tests green)
- [x] `npx playwright test` — 378 passed, 19 skipped

Refs FreeForCharity/FFC-Cloudflare-Automation#697 (overnight block 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)