### PR TITLE
feat(funnel): beacon live-contract test + operator FTPS report script

### DIFF
--- a/__tests__/scripts/funnel-report.test.ts
+++ b/__tests__/scripts/funnel-report.test.ts
@@ -1,0 +1,64 @@
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+/**
+ * Offline contract for scripts/funnel-report.mjs (--file mode): the operator
+ * report script must render the beacon counts JSON written by
+ * public/api/funnel-beacon.php as a per-pid markdown funnel table, and must
+ * handle the not-yet-created / empty cases gracefully.
+ */
+const root = join(__dirname, '..', '..')
+const script = join(root, 'scripts', 'funnel-report.mjs')
+
+function runWithCounts(counts: unknown): string {
+  const dir = mkdtempSync(join(tmpdir(), 'funnel-report-'))
+  const file = join(dir, 'ffc_funnel_counts.json')
+  writeFileSync(file, JSON.stringify(counts))
+  try {
+    return execFileSync(process.execPath, [script, '--file', file], { encoding: 'utf8' })
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+describe('funnel-report script (offline --file mode)', () => {
+  it('renders a per-pid markdown table with views and completes', () => {
+    const out = runWithCounts({
+      '2026-07-10': { '40': { view: 12, complete: 2 }, '16': { view: 5 } },
+      '2026-07-11': { '40': { view: 8, complete: 1 }, all: { complete: 3 } },
+    })
+    expect(out).toContain('| PID | Product | Views | Completes |')
+    expect(out).toContain('| 40 | Website | 20 | 3 |')
+    expect(out).toContain('| 16 | Pre-501c3 onboarding | 5 | 0 |')
+    expect(out).toContain('**2026-07-10** to **2026-07-11**')
+  })
+
+  it('states the WHMCS-orders-are-authoritative caveat', () => {
+    const out = runWithCounts({ '2026-07-10': { '40': { view: 1 } } })
+    expect(out).toMatch(/WHMCS order reports are authoritative/i)
+  })
+
+  it('handles an empty counts file gracefully', () => {
+    const out = runWithCounts({})
+    expect(out).toMatch(/no beacon counts recorded yet/i)
+  })
+
+  it('exits with a clear message when credentials are missing (no --file)', () => {
+    let failed = false
+    try {
+      execFileSync(process.execPath, [script], {
+        encoding: 'utf8',
+        env: { ...process.env, FTP_HOST: '', FTP_USER: '', FTP_PASS: '' },
+      })
+    } catch (error) {
+      failed = true
+      const e = error as { status: number; stderr: string }
+      expect(e.status).toBe(2)
+      expect(e.stderr).toMatch(/FTP_HOST, FTP_USER and FTP_PASS/)
+      expect(e.stderr).toMatch(/Never hardcode credentials/i)
+    }
+    expect(failed).toBe(true)
+  })
+})

--- a/docs/funnel-beacon.md
+++ b/docs/funnel-beacon.md
@@ -26,6 +26,37 @@ FreeForCharity/FFC-Cloudflare-Automation#676, issue #684).
   `complete` count is a same-day sanity check, not the source of truth.
 - Filter rate per product ≈ WHMCS submitted orders ÷ beacon `view` count.
 
+## Pulling a report locally (operator)
+
+[`scripts/funnel-report.mjs`](../scripts/funnel-report.mjs) fetches
+`ffc_funnel_counts.json` over FTPS and renders a markdown funnel table (per
+product id: views, completes) with the WHMCS caveat above. Node stdlib only —
+no dependencies to install.
+
+```bash
+FTP_HOST=<host> FTP_USER=<user> FTP_PASS=<pass> node scripts/funnel-report.mjs
+```
+
+- Credentials come from the environment (`FTP_HOST`, `FTP_USER`, `FTP_PASS`,
+  optional `FTP_PORT`, default 21 / explicit AUTH TLS). **Never hardcode or
+  commit them** — pull them from your password manager per the security rules.
+- The counts file lives in the FTP home directory itself (a sibling of
+  `public_html`, outside the web root), so the script fetches the path
+  `ffc_funnel_counts.json` relative to the FTP home.
+- If the file does not exist yet (no beacon hits recorded), the script says so
+  and exits cleanly.
+- Offline mode for a previously downloaded file:
+  `node scripts/funnel-report.mjs --file <path>`.
+
+## Live contract test
+
+[`tests/funnel-beacon.spec.ts`](../tests/funnel-beacon.spec.ts) verifies the
+production endpoint's contract (204 on valid **and** invalid params — the
+storefront must never see an error — and no `Set-Cookie`, the consent-free
+guarantee). Like the Zeffy link check it is gated off normal CI; run it with
+`FUNNEL_LIVE=1 npx playwright test tests/funnel-beacon.spec.ts`. It uses the
+unused test pid `999` so real counters are not polluted.
+
 ## Notes
 
 - Client-side beacons undercount (ad blockers, JS off) — treat trends, not

--- a/scripts/funnel-report.mjs
+++ b/scripts/funnel-report.mjs
@@ -1,0 +1,304 @@
+#!/usr/bin/env node
+/**
+ * Intake-funnel report (operator-run, local).
+ *
+ * Fetches `ffc_funnel_counts.json` — the daily counters written by
+ * public/api/funnel-beacon.php — from the production host over FTPS and
+ * renders a markdown funnel table (per product id: views, completes).
+ *
+ * The counts file lives OUTSIDE the web root, in the FTP home directory
+ * itself (a sibling of `public_html`), so the path relative to the FTP home
+ * is simply `ffc_funnel_counts.json`.
+ *
+ * Usage (credentials come from the environment — never hardcode them):
+ *   FTP_HOST=... FTP_USER=... FTP_PASS=... node scripts/funnel-report.mjs
+ *
+ * Environment variables:
+ *   FTP_HOST  FTPS server hostname (required)
+ *   FTP_USER  FTPS username        (required)
+ *   FTP_PASS  FTPS password        (required)
+ *   FTP_PORT  control port         (optional, default 21 — explicit AUTH TLS)
+ *
+ * Offline mode (render a previously downloaded counts file, no FTP):
+ *   node scripts/funnel-report.mjs --file /path/to/ffc_funnel_counts.json
+ *
+ * Node stdlib only — no dependencies. See docs/funnel-beacon.md.
+ */
+
+import net from 'node:net'
+import tls from 'node:tls'
+import { readFileSync } from 'node:fs'
+import process from 'node:process'
+import { pathToFileURL } from 'node:url'
+
+const COUNTS_PATH = 'ffc_funnel_counts.json' // relative to the FTP home
+
+// Product-id labels from docs/funnel-beacon.md (WHMCS order forms).
+const PID_LABELS = {
+  16: 'Pre-501c3 onboarding',
+  33: '501c3 onboarding',
+  40: 'Website',
+  39: 'Domain register',
+  41: 'Domain transfer',
+  42: 'Email',
+  43: 'Email',
+  999: 'Contract-test pid (ignore)',
+  all: '(no pid — legacy/complete)',
+}
+
+/* ------------------------------------------------------------------ */
+/* Minimal explicit-FTPS (AUTH TLS) client — control + one RETR.       */
+/* ------------------------------------------------------------------ */
+
+/** Reads complete FTP replies (handles multi-line replies). */
+function makeReplyReader(socket) {
+  let buffer = ''
+  const pending = []
+  const waiters = []
+  const onData = (chunk) => {
+    buffer += chunk.toString('latin1')
+    // A reply is complete at its first "NNN " (3 digits + space) final line;
+    // any lines before it (e.g. "230-...") belong to the same reply.
+    let match
+    while ((match = buffer.match(/^[\s\S]*?^(\d{3}) [^\r\n]*\r?\n/m))) {
+      buffer = buffer.slice(match[0].length)
+      const reply = { code: Number(match[1]), text: match[0].trimEnd() }
+      const waiter = waiters.shift()
+      if (waiter) waiter.resolve(reply)
+      else pending.push(reply)
+    }
+  }
+  socket.on('data', onData)
+  return {
+    next() {
+      if (pending.length > 0) return Promise.resolve(pending.shift())
+      return new Promise((resolve, reject) => {
+        waiters.push({ resolve, reject })
+        socket.once('error', reject)
+      })
+    },
+    detach() {
+      socket.removeListener('data', onData)
+    },
+  }
+}
+
+async function expectReply(reader, okCodes, context) {
+  const reply = await reader.next()
+  if (!okCodes.includes(reply.code)) {
+    const err = new Error(`FTPS ${context}: unexpected reply ${reply.text}`)
+    err.ftpCode = reply.code
+    throw err
+  }
+  return reply
+}
+
+function connectPlain(host, port) {
+  return new Promise((resolve, reject) => {
+    const socket = net.createConnection({ host, port }, () => resolve(socket))
+    socket.once('error', reject)
+    socket.setTimeout(30_000, () => {
+      socket.destroy(new Error('FTPS control connection timed out'))
+    })
+  })
+}
+
+function upgradeToTls(socket, host, session) {
+  return new Promise((resolve, reject) => {
+    const secure = tls.connect(
+      { socket, servername: host, session, rejectUnauthorized: true },
+      () => resolve(secure)
+    )
+    secure.once('error', reject)
+  })
+}
+
+/** Parses "227 Entering Passive Mode (h1,h2,h3,h4,p1,p2)." */
+function parsePasv(text) {
+  const m = text.match(/\((\d+),(\d+),(\d+),(\d+),(\d+),(\d+)\)/)
+  if (!m) throw new Error(`FTPS: cannot parse PASV reply: ${text}`)
+  return { host: `${m[1]}.${m[2]}.${m[3]}.${m[4]}`, port: Number(m[5]) * 256 + Number(m[6]) }
+}
+
+/** Parses "229 Extended Passive Mode (|||port|)" */
+function parseEpsv(text) {
+  const m = text.match(/\(\|\|\|(\d+)\|\)/)
+  if (!m) throw new Error(`FTPS: cannot parse EPSV reply: ${text}`)
+  return Number(m[1])
+}
+
+/**
+ * Downloads `filePath` over explicit FTPS. Returns the file contents as a
+ * string, or null if the server says the file does not exist (550).
+ */
+async function ftpsDownload({ host, port, user, pass }, filePath) {
+  const raw = await connectPlain(host, port)
+  let reader = makeReplyReader(raw)
+  await expectReply(reader, [220], 'greeting')
+
+  raw.write('AUTH TLS\r\n')
+  await expectReply(reader, [234], 'AUTH TLS')
+  reader.detach()
+
+  const control = await upgradeToTls(raw, host)
+  reader = makeReplyReader(control)
+
+  control.write(`USER ${user}\r\n`)
+  await expectReply(reader, [331, 230], 'USER')
+  control.write(`PASS ${pass}\r\n`)
+  await expectReply(reader, [230], 'PASS (check FTP_USER/FTP_PASS)')
+
+  control.write('PBSZ 0\r\n')
+  await expectReply(reader, [200], 'PBSZ')
+  control.write('PROT P\r\n')
+  await expectReply(reader, [200], 'PROT P')
+  control.write('TYPE I\r\n')
+  await expectReply(reader, [200], 'TYPE I')
+
+  // Prefer EPSV (NAT-safe); fall back to PASV.
+  let dataHost = host
+  let dataPort
+  control.write('EPSV\r\n')
+  const epsv = await reader.next()
+  if (epsv.code === 229) {
+    dataPort = parseEpsv(epsv.text)
+  } else {
+    control.write('PASV\r\n')
+    const pasv = await expectReply(reader, [227], 'PASV')
+    const parsed = parsePasv(pasv.text)
+    dataHost = parsed.host
+    dataPort = parsed.port
+  }
+
+  const dataRaw = await connectPlain(dataHost, dataPort)
+  control.write(`RETR ${filePath}\r\n`)
+  const retr = await reader.next()
+  if (retr.code === 550) {
+    dataRaw.destroy()
+    control.write('QUIT\r\n')
+    control.end()
+    return null // file not yet created — no beacon hits recorded yet
+  }
+  if (![125, 150].includes(retr.code)) {
+    dataRaw.destroy()
+    throw new Error(`FTPS RETR: unexpected reply ${retr.text}`)
+  }
+
+  // Data connection is TLS too (PROT P); most servers require reusing the
+  // control connection's TLS session.
+  const data = await upgradeToTls(dataRaw, host, control.getSession())
+  const chunks = []
+  await new Promise((resolve, reject) => {
+    data.on('data', (c) => chunks.push(c))
+    data.on('end', resolve)
+    data.on('error', reject)
+  })
+  await expectReply(reader, [226, 250], 'transfer complete')
+  control.write('QUIT\r\n')
+  control.end()
+  return Buffer.concat(chunks).toString('utf8')
+}
+
+/* ------------------------------------------------------------------ */
+/* Markdown rendering                                                  */
+/* ------------------------------------------------------------------ */
+
+/**
+ * counts shape (from funnel-beacon.php): { "YYYY-MM-DD": { "<pid>": { "view": n, "complete": n } } }
+ * Renders a per-pid totals table plus a per-day breakdown.
+ */
+export function renderMarkdown(counts) {
+  const perPid = new Map()
+  const dates = Object.keys(counts).sort()
+  for (const date of dates) {
+    for (const [pid, steps] of Object.entries(counts[date])) {
+      const agg = perPid.get(pid) ?? { view: 0, complete: 0 }
+      agg.view += Number(steps.view ?? 0)
+      agg.complete += Number(steps.complete ?? 0)
+      perPid.set(pid, agg)
+    }
+  }
+
+  const lines = []
+  lines.push('# Intake-funnel report')
+  lines.push('')
+  if (dates.length === 0) {
+    lines.push('_No beacon counts recorded yet._')
+    return lines.join('\n')
+  }
+  lines.push(
+    `Data from **${dates[0]}** to **${dates[dates.length - 1]}** (${dates.length} day(s)).`
+  )
+  lines.push('')
+  lines.push('| PID | Product | Views | Completes |')
+  lines.push('| --- | ------- | ----: | --------: |')
+  const pids = [...perPid.keys()].sort((a, b) => {
+    const na = Number(a)
+    const nb = Number(b)
+    if (Number.isNaN(na)) return 1
+    if (Number.isNaN(nb)) return -1
+    return na - nb
+  })
+  for (const pid of pids) {
+    const { view, complete } = perPid.get(pid)
+    lines.push(`| ${pid} | ${PID_LABELS[pid] ?? '—'} | ${view} | ${complete} |`)
+  }
+  lines.push('')
+  lines.push('> **Caveat:** WHMCS order reports are authoritative for submissions — the')
+  lines.push("> beacon's `complete` count is a same-day sanity check, not the source of")
+  lines.push('> truth. Client-side beacons undercount (ad blockers, JS off) — treat')
+  lines.push('> trends, not absolutes. Filter rate ≈ WHMCS orders ÷ beacon views.')
+  return lines.join('\n')
+}
+
+/* ------------------------------------------------------------------ */
+/* Main                                                                */
+/* ------------------------------------------------------------------ */
+
+async function main() {
+  const fileFlag = process.argv.indexOf('--file')
+  let raw
+  if (fileFlag !== -1) {
+    const path = process.argv[fileFlag + 1]
+    if (!path) {
+      console.error('Usage: node scripts/funnel-report.mjs --file <counts.json>')
+      process.exit(2)
+    }
+    raw = readFileSync(path, 'utf8')
+  } else {
+    const { FTP_HOST, FTP_USER, FTP_PASS, FTP_PORT } = process.env
+    if (!FTP_HOST || !FTP_USER || !FTP_PASS) {
+      console.error(
+        'Missing credentials. Set FTP_HOST, FTP_USER and FTP_PASS in the environment\n' +
+          '(FTP_PORT optional, default 21), or use --file <counts.json> for offline mode.\n' +
+          'Never hardcode credentials — see docs/funnel-beacon.md.'
+      )
+      process.exit(2)
+    }
+    raw = await ftpsDownload(
+      { host: FTP_HOST, port: Number(FTP_PORT ?? 21), user: FTP_USER, pass: FTP_PASS },
+      COUNTS_PATH
+    )
+    if (raw === null) {
+      console.log(
+        `\`${COUNTS_PATH}\` does not exist on the server yet — the beacon has not ` +
+          'recorded any hits. Nothing to report.'
+      )
+      return
+    }
+  }
+
+  let counts
+  try {
+    counts = JSON.parse(raw || '{}')
+  } catch {
+    console.error('Counts file is not valid JSON — is the beacon writing correctly?')
+    process.exit(1)
+  }
+  console.log(renderMarkdown(counts))
+}
+
+// Only run when executed directly (allows importing renderMarkdown in tests).
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main()
+}

--- a/tests/funnel-beacon.spec.ts
+++ b/tests/funnel-beacon.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Live contract test for the intake-funnel beacon endpoint
+ * (`public/api/funnel-beacon.php`, deployed to the production cPanel host —
+ * see docs/funnel-beacon.md and epic FreeForCharity/FFC-Cloudflare-Automation#676).
+ *
+ * The beacon's contract with the WHMCS storefront theme:
+ *   1. A valid hit  (`?s=view&p=<pid>`) returns HTTP 204 with no body.
+ *   2. Invalid params (`?s=bogus`, `?p=abc`) STILL return HTTP 204 — the
+ *      storefront must never care about beacon errors.
+ *   3. No `Set-Cookie` header, ever — the consent-free guarantee (nothing
+ *      user-identifying is stored, so no consent banner is needed).
+ *
+ * Like tests/zeffy-links.spec.ts this hits the LIVE endpoint rather than the
+ * local static build, so it only runs when `FUNNEL_LIVE=1` in an environment
+ * with egress to freeforcharity.org:
+ *   FUNNEL_LIVE=1 npx playwright test tests/funnel-beacon.spec.ts
+ *
+ * NOTE: the valid-hit test uses pid 999 — an intentionally unused product id —
+ * so real funnel counters (pids 16/33/39/40/41/42/43) are never polluted.
+ */
+const LIVE = process.env.FUNNEL_LIVE === '1'
+const t = LIVE ? test : test.skip
+const BEACON = 'https://freeforcharity.org/api/funnel-beacon.php'
+
+test.describe('funnel beacon live contract', () => {
+  test.describe.configure({ timeout: 30_000 })
+
+  t('valid view beacon (test pid 999) returns 204', async ({ request }) => {
+    const res = await request.get(`${BEACON}?s=view&p=999`)
+    expect(res.status(), 'valid beacon hit must return 204').toBe(204)
+    expect((await res.body()).length, '204 must carry no body').toBe(0)
+  })
+
+  t('invalid step (?s=bogus) still returns 204 — the beacon never errors', async ({ request }) => {
+    const res = await request.get(`${BEACON}?s=bogus&p=999`)
+    expect(res.status(), 'invalid step must not surface an error').toBe(204)
+  })
+
+  t('invalid pid (?p=abc) still returns 204 — the beacon never errors', async ({ request }) => {
+    const res = await request.get(`${BEACON}?s=view&p=abc`)
+    expect(res.status(), 'invalid pid must not surface an error').toBe(204)
+  })
+
+  t('missing params still return 204 — the beacon never errors', async ({ request }) => {
+    const res = await request.get(BEACON)
+    expect(res.status(), 'missing params must not surface an error').toBe(204)
+  })
+
+  t('never sets a cookie (consent-free guarantee)', async ({ request }) => {
+    // `p=999` keeps even the `complete` sanity counter on the unused test pid.
+    for (const qs of ['?s=view&p=999', '?s=complete&p=999', '?s=bogus&p=abc']) {
+      const res = await request.get(`${BEACON}${qs}`)
+      const cookies = res
+        .headersArray()
+        .filter((h) => h.name.toLowerCase() === 'set-cookie')
+        .map((h) => h.value)
+      expect(cookies, `${qs} must not set any cookie`).toEqual([])
+    }
+  })
+})


### PR DESCRIPTION
## Summary

**Block 16 — intake-funnel observability** (epic FreeForCharity/FFC-Cloudflare-Automation#676).

- **`tests/funnel-beacon.spec.ts`** — live contract test for the production beacon endpoint, following the `tests/zeffy-links.spec.ts` live-contract pattern (env-gated, `FUNNEL_LIVE=1`):
  - `GET /api/funnel-beacon.php?s=view&p=999` → **204**
  - invalid params (`?s=bogus`, `?p=abc`, missing params) → still **204** — the storefront must never see an error
  - **no `Set-Cookie` header**, ever — the consent-free guarantee
  - uses the unused test pid **999** so real funnel counters (16/33/39/40/41/42/43) are never polluted
- **`scripts/funnel-report.mjs`** — operator-run local report: fetches `ffc_funnel_counts.json` over explicit FTPS (AUTH TLS, TLS-session-reused data channel) using `FTP_HOST`/`FTP_USER`/`FTP_PASS`/`FTP_PORT` env creds (documented, never hardcoded); the file lives in the FTP home itself, a sibling of `public_html` outside the web root. Renders a per-pid markdown funnel table (views, completes) with the WHMCS-orders-are-authoritative caveat. Node stdlib only; graceful 'file not yet created' handling; `--file` offline mode.
- **`__tests__/scripts/funnel-report.test.ts`** — jest coverage of the offline mode: table rendering, WHMCS caveat, empty-file handling, missing-credentials guidance.
- **`docs/funnel-beacon.md`** — new report-script usage and live-contract sections.

## Test plan

- [x] `FUNNEL_LIVE=1 npx playwright test tests/funnel-beacon.spec.ts` — **5/5 passed against production**
- [x] `npm run lint` clean, `npm run format:check` clean
- [x] `npm run build` clean
- [x] `npm run test` — 633 passed (incl. 4 new funnel-report tests)
- [x] `npx playwright test` — 378 passed, 24 skipped (live-gated)

Refs FreeForCharity/FFC-Cloudflare-Automation#697 (overnight block 16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)