### PR TITLE
feat(content): two-templates explainer + training-guide gated-journey alignment

### DIFF
--- a/__tests__/app/why-website-first.test.tsx
+++ b/__tests__/app/why-website-first.test.tsx
@@ -41,6 +41,31 @@ describe('Why Website First page', () => {
     expect(text).toContain('Footer-Only Template')
   })
 
+  it('explains the two-templates-one-standard model converging at Gate 3', () => {
+    const { container } = render(<WhyWebsiteFirst />)
+    const text = container.textContent || ''
+
+    expect(text).toContain('Two templates, one standard')
+    expect(text).toMatch(/converge at Gate 3/i)
+  })
+
+  it('links the template chooser and both template repositories', () => {
+    const { container } = render(<WhyWebsiteFirst />)
+    const hrefs = Array.from(container.querySelectorAll('a')).map(
+      (a) => a.getAttribute('href') ?? ''
+    )
+
+    // Next.js <Link> normalizes away the pre-hash trailing slash when rendering.
+    expect(
+      hrefs.some(
+        (h) => h.includes('/free-charity-web-hosting') && h.includes('#choose-your-template')
+      )
+    ).toBe(true)
+    expect(hrefs).toContain('https://github.com/FreeForCharity/FFC-IN-FFC_Single_Page_Template')
+    // Footer repo name uses underscores — a hyphenated URL would 404.
+    expect(hrefs).toContain('https://github.com/FreeForCharity/FFC-IN-Footer_Only_Template')
+  })
+
   it('renders the journey diagram', () => {
     const { getByRole } = render(<WhyWebsiteFirst />)
     const diagram = getByRole('img', {

--- a/__tests__/components/web-developer-training-guide/hero-github-pages.test.tsx
+++ b/__tests__/components/web-developer-training-guide/hero-github-pages.test.tsx
@@ -19,4 +19,50 @@ describe('Web Developer Training Guide Hero (GitHub Pages current model + legacy
     const text = container.textContent ?? ''
     expect(text).toMatch(/legacy/i)
   })
+
+  it('teaches the gated journey in order: approve → application → build → validate → domain → email', () => {
+    const { container } = render(<Hero />)
+    const text = container.textContent ?? ''
+
+    const approved = text.indexOf('Charity approved')
+    const application = text.indexOf('Website application')
+    const build = text.indexOf('Build from one of two templates')
+    const validate = text.indexOf('Validate on GitHub Pages')
+    const domain = text.indexOf('Domain via WHMCS')
+    const email = text.indexOf('Email last')
+
+    expect(approved).toBeGreaterThan(-1)
+    expect(application).toBeGreaterThan(approved)
+    expect(build).toBeGreaterThan(application)
+    expect(validate).toBeGreaterThan(build)
+    expect(domain).toBeGreaterThan(validate)
+    expect(email).toBeGreaterThan(domain)
+  })
+
+  it('links both template repositories (footer repo uses underscores)', () => {
+    const { container } = render(<Hero />)
+    const hrefs = Array.from(container.querySelectorAll('a')).map(
+      (a) => a.getAttribute('href') ?? ''
+    )
+    expect(hrefs).toContain('https://github.com/FreeForCharity/FFC-IN-FFC_Single_Page_Template')
+    expect(hrefs).toContain('https://github.com/FreeForCharity/FFC-IN-Footer_Only_Template')
+  })
+
+  it('cites the validation standard: FFC footer + Lighthouse accessibility + adoption checklist', () => {
+    const { container } = render(<Hero />)
+    const text = container.textContent ?? ''
+    expect(text).toMatch(/FFC footer standard/i)
+    expect(text).toMatch(/Lighthouse accessibility/i)
+
+    const hrefs = Array.from(container.querySelectorAll('a')).map(
+      (a) => a.getAttribute('href') ?? ''
+    )
+    expect(hrefs).toContain('https://ffcadmin.org/guides/adopt-ffc-footer-on-existing-site/')
+  })
+
+  it('teaches the live-URL funding gate for the WHMCS domain order', () => {
+    const { container } = render(<Hero />)
+    const text = container.textContent ?? ''
+    expect(text).toMatch(/order form requires the live GitHub Pages URL/i)
+  })
 })

--- a/src/app/why-website-first/page.tsx
+++ b/src/app/why-website-first/page.tsx
@@ -104,17 +104,41 @@ export default function WhyWebsiteFirst() {
         </ol>
 
         <div className="prose max-w-none font-[var(--font-lato)] text-[18px] leading-[28px] mt-10">
-          <h2 className={h2}>Two templates, one destination</h2>
+          <h2 className={h2}>Two templates, one standard</h2>
           <p>
             Every FFC build starts from one of two open-source templates. The{' '}
-            <strong>Single Page Site Template</strong> is for charities starting fresh: a complete,
-            professionally structured one-page site with every section a charity needs — mission,
-            programs, team, donate, contact — plus the full FFC footer. The{' '}
-            <strong>Footer-Only Template</strong> is for charities that already love their website:
-            it adds the FFC footer, legal pages, cookie consent, and analytics to your existing
-            design instead of replacing it. Both paths end the same way — your site validated live
-            on GitHub Pages, which unlocks your free .org domain. Compare them on the{' '}
-            <Link href="/free-charity-web-hosting/">free charity web hosting page</Link>.
+            <strong>Single Page Site Template</strong> is the starting point for charities without a
+            site: a complete, professionally structured one-page site with every section a charity
+            needs — mission, programs, team, donate, contact — plus the full FFC footer. The{' '}
+            <strong>Footer-Only Template</strong> is the FFC footer and compliance layer for
+            charities whose site is already designed: it adds the FFC footer, legal pages, cookie
+            consent, and analytics to your existing design instead of replacing it.
+          </p>
+          <p>
+            Whichever template a site starts from, it must meet the same standard — the FFC footer
+            with your validated organization details, the legal pages, and an accessible build — and
+            both paths converge at Gate 3: your site validated live on GitHub Pages, which unlocks
+            your free .org domain. Compare the two side by side in the{' '}
+            <Link href="/free-charity-web-hosting/#choose-your-template">
+              template chooser on the free charity web hosting page
+            </Link>
+            , or inspect the templates themselves on GitHub:{' '}
+            <a
+              href="https://github.com/FreeForCharity/FFC-IN-FFC_Single_Page_Template"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Single Page Site Template
+            </a>{' '}
+            and{' '}
+            <a
+              href="https://github.com/FreeForCharity/FFC-IN-Footer_Only_Template"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Footer-Only Template
+            </a>
+            .
           </p>
 
           <h2 className={h2}>Ready to start?</h2>

--- a/src/components/free-for-charity-ffc-web-developer-training-guide-components/Hero/index.tsx
+++ b/src/components/free-for-charity-ffc-web-developer-training-guide-components/Hero/index.tsx
@@ -64,11 +64,84 @@ const Index = () => {
             FFC now builds every new charity website as a fast, secure{' '}
             <span className="font-[600] text-[#1c2a38]">static site hosted on GitHub Pages</span>.
             Sites are developed with AI development agents (Claude and GitHub Copilot), built as a
-            Next.js static export, and deployed automatically through GitHub Actions, with domains
-            managed in Cloudflare. This is the workflow you should follow for all new charity sites.
-            The InterServer / DirectAdmin / WordPress workflow in the later sections is retained
-            only as a legacy reference for sites that have not yet migrated.
+            Next.js static export from one of two FFC templates, and deployed automatically through
+            GitHub Actions, with domains managed in Cloudflare. This is the workflow you should
+            follow for all new charity sites. The InterServer / DirectAdmin / WordPress workflow in
+            the later sections is retained only as a legacy reference for sites that have not yet
+            migrated.
           </p>
+
+          <h3 className="text-[24px] leading-[31px] font-[700] text-[#0066B8] mt-10 mb-4">
+            The gated journey you are building inside
+          </h3>
+
+          <p className="text-[14px] font-[500] leading-[25px] text-[#333d47]">
+            Every charity site you build sits inside FFC&rsquo;s gated onboarding journey. The
+            website comes <span className="font-[600] text-[#1c2a38]">before</span> the domain and
+            email — money is only spent once the site is proven. As the volunteer developer, your
+            work follows this order:
+          </p>
+
+          <ol className="list-decimal pl-[2rem] pt-[0.75rem] pb-[23px] space-y-[0.75rem]">
+            <li className="leading-[26px] pl-[0.5rem] text-[14px] font-[500] text-[#333d47]">
+              <span className="font-[600] text-[#1c2a38]">Charity approved:</span> the charity
+              completes onboarding and FFC validates the organization (IRS status, Candid profile).
+              Nothing is built before this approval.
+            </li>
+            <li className="leading-[26px] pl-[0.5rem] text-[14px] font-[500] text-[#333d47]">
+              <span className="font-[600] text-[#1c2a38]">Website application:</span> the charity
+              submits the website application (it requires the approved onboarding) and sends
+              content — logo, photos, mission text, program descriptions.
+            </li>
+            <li className="leading-[26px] pl-[0.5rem] text-[14px] font-[500] text-[#333d47]">
+              <span className="font-[600] text-[#1c2a38]">Build from one of two templates:</span>{' '}
+              start from the{' '}
+              <a
+                href="https://github.com/FreeForCharity/FFC-IN-FFC_Single_Page_Template"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-[#0066B8] underline"
+              >
+                Single Page Site Template
+              </a>{' '}
+              for a charity without a site, or the{' '}
+              <a
+                href="https://github.com/FreeForCharity/FFC-IN-Footer_Only_Template"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-[#0066B8] underline"
+              >
+                Footer-Only Template
+              </a>{' '}
+              to add the FFC footer and compliance layer to a site the charity already has. Both
+              must meet the same standard.
+            </li>
+            <li className="leading-[26px] pl-[0.5rem] text-[14px] font-[500] text-[#333d47]">
+              <span className="font-[600] text-[#1c2a38]">Validate on GitHub Pages:</span> the site
+              goes live on its free GitHub Pages address and is validated end to end — including the
+              FFC footer standard (generated from the charity&rsquo;s validated application data)
+              and a Lighthouse accessibility pass. Work through the{' '}
+              <a
+                href="https://ffcadmin.org/guides/adopt-ffc-footer-on-existing-site/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-[#0066B8] underline"
+              >
+                adoption checklist on FFC Admin
+              </a>{' '}
+              before calling a site done.
+            </li>
+            <li className="leading-[26px] pl-[0.5rem] text-[14px] font-[500] text-[#333d47]">
+              <span className="font-[600] text-[#1c2a38]">Domain via WHMCS:</span> only after the
+              site is validated live does the charity order their free .org domain through the FFC
+              Hub — the order form requires the live GitHub Pages URL (that is the funding gate).
+            </li>
+            <li className="leading-[26px] pl-[0.5rem] text-[14px] font-[500] text-[#333d47]">
+              <span className="font-[600] text-[#1c2a38]">Email last:</span> Microsoft 365 or Google
+              Workspace nonprofit email is set up after the domain — both programs require a live
+              website before approving a nonprofit.
+            </li>
+          </ol>
 
           <h3 className="text-[24px] leading-[31px] font-[700] text-[#0066B8] mt-10 mb-4">
             How each charity site is structured
@@ -86,6 +159,19 @@ const Index = () => {
                 FFC-EX-examplecharity.org
               </code>
               ). All content and configuration are version-controlled in that repo.
+            </li>
+            <li className="leading-[26px] pl-[0.5rem] mb-[0.75rem] text-[14px] font-[500] text-[#333d47]">
+              <span className="font-[600] text-[#1c2a38]">One of two templates:</span> New sites
+              start from the{' '}
+              <code className="bg-[#f1f3f5] text-[#B82B5A] py-[0.3em] px-[0.5em] rounded-[6px] text-[0.9em]">
+                FFC-IN-FFC_Single_Page_Template
+              </code>{' '}
+              repository; charities that already have a designed site get the FFC footer and
+              compliance layer from{' '}
+              <code className="bg-[#f1f3f5] text-[#B82B5A] py-[0.3em] px-[0.5em] rounded-[6px] text-[0.9em]">
+                FFC-IN-Footer_Only_Template
+              </code>
+              . Both converge at the same validation standard.
             </li>
             <li className="leading-[26px] pl-[0.5rem] mb-[0.75rem] text-[14px] font-[500] text-[#333d47]">
               <span className="font-[600] text-[#1c2a38]">Framework:</span> Sites are built with{' '}
@@ -117,6 +203,24 @@ const Index = () => {
           </h3>
 
           <ul className="p-[0_0_23px_1.5rem] list-disc">
+            <li className="underline pl-[0.5rem] mb-[0.75rem] text-[14px] text-[#0066B8] leading-[26px]">
+              <a
+                href="https://ffcadmin.org/guides/build-charity-site-from-template/"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                FFC Admin Guide: Build a Charity Site from the Template
+              </a>
+            </li>
+            <li className="underline pl-[0.5rem] mb-[0.75rem] text-[14px] text-[#0066B8] leading-[26px]">
+              <a
+                href="https://ffcadmin.org/guides/adopt-ffc-footer-on-existing-site/"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                FFC Admin Guide: Adopt the FFC Footer on an Existing Site (adoption checklist)
+              </a>
+            </li>
             <li className="underline pl-[0.5rem] mb-[0.75rem] text-[14px] text-[#0066B8] leading-[26px]">
               <a href="https://docs.github.com/en/pages" target="_blank" rel="noopener noreferrer">
                 GitHub Pages Documentation
@@ -591,7 +695,10 @@ const Index = () => {
 
           <p className="text-[14px] font-[500] leading-[25px] text-[#333d47]">
             Microsoft 365 provides the email hosting solution for charity accounts, ensuring
-            seamless communication and collaboration.
+            seamless communication and collaboration. Email is the final stage of the gated journey:
+            both Microsoft and Google require a live website before approving a nonprofit for free
+            email, which is why the site is built and validated first and the domain connected
+            before you start this section.
           </p>
 
           <h3 className="text-[24px] leading-[31px] font-[700] text-[#0066B8] mt-10 mb-4">
@@ -1268,8 +1375,9 @@ const Index = () => {
 
           <ul className="mt-[20px] pl-[1.5rem] p-[0_0_23px_1em] list-disc">
             <li className="pl-[0.5rem] mb-[0.75rem] text-[14px] font-[500] text-[#333d47]">
-              You will be able to efficiently set up new charity accounts, configure domain
-              management, secure email hosting, and create a robust web presence using the tools FFC
+              You will be able to efficiently support a charity through the gated journey: build and
+              validate their website from one of the two FFC templates, then configure domain
+              management, and finally secure email hosting — in that order, using the tools FFC
               supports.
             </li>
             <li className="pl-[0.5rem] mb-[0.75rem] text-[14px] font-[500] text-[#333d47]">


### PR DESCRIPTION
## Summary

**Block 17 — two-templates explainer + training-guide alignment.**

Chose the **extend `/why-website-first/`** option (the page merged via #486 already seeded a templates section; the site's guide pattern favors deepening it over a new route — no sitemap/search-index churn).

- **/why-website-first/** — the seed section becomes **'Two templates, one standard'**: Single Page Site Template = the starting point for charities without a site; Footer-Only Template = the FFC footer/compliance layer for already-designed sites; both converge at **Gate 3** validation. Links the chooser section on `/free-charity-web-hosting/#choose-your-template` and both template repos (`FFC-IN-FFC_Single_Page_Template`, `FFC-IN-Footer_Only_Template` — underscores).
- **Training guide Hero** (`free-for-charity-ffc-web-developer-training-guide-components/Hero`) — surgical alignment with the gated journey, not a redesign:
  - new **'The gated journey you are building inside'** subsection: approve → website application → build from **one of two templates** → **validate on GitHub Pages** (FFC footer standard + Lighthouse accessibility, citing the [adoption checklist on FFC Admin](https://ffcadmin.org/guides/adopt-ffc-footer-on-existing-site/)) → **domain via WHMCS** (order form requires the live GitHub Pages URL — the funding gate) → **email last**
  - two-templates bullet in the site-structure list; FFC Admin build-from-template + adoption-checklist links in Learning Resources
  - M365 section now states email is the final gated stage (live website required); Final Notes reordered to the gated order
- **Tests extended**: why-website-first (Gate-3 convergence, chooser anchor + both repo links) and training-guide hero (journey order assertions, repo links, validation standard, live-URL gate). Banned-phrase guard passes.

## Test plan

- [x] `npm run lint` clean, `npm run format:check` clean
- [x] `npm run build` (static export) clean
- [x] `npm run test` — 639 passed (incl. banned-phrase guard + 7 new assertions)
- [x] `npx playwright test` — 378 passed, 24 skipped (live-gated)

Refs FreeForCharity/FFC-Cloudflare-Automation#697 (overnight block 17)

🤖 Generated with [Claude Code](https://claude.com/claude-code)