### PR TITLE
fix: funnel-report FTPS hardening + accessible responsive journey diagram (block 8 r3)

### DIFF
--- a/__tests__/app/charity-onboarding-journey.test.tsx
+++ b/__tests__/app/charity-onboarding-journey.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { render } from '@testing-library/react'
 import CharityOnboardingJourney from '@/app/charity-onboarding-journey/page'
+import { journeyStages } from '@/data/journey'
 
 describe('Charity Onboarding Journey page', () => {
   it('renders without crashing', () => {
@@ -33,6 +34,17 @@ describe('Charity Onboarding Journey page', () => {
     expect(text).toContain('3. Domain — only after your site is proven')
     expect(text).toContain('4. Email')
     expect(text).toContain('5. Handoff & ongoing support')
+  })
+
+  it('renders every stage gateNote from the shared journey module', () => {
+    const { container } = render(<CharityOnboardingJourney />)
+    const text = container.textContent || ''
+
+    // The gate relationship of each stage (src/data/journey.ts gateNote) is
+    // shown as an emphasized line in the stage cards — it must not be dead data.
+    for (const stage of journeyStages) {
+      expect(text).toContain(stage.gateNote)
+    }
   })
 
   it('offers both Microsoft 365 and Google Workspace as email options', () => {

--- a/__tests__/app/why-website-first.test.tsx
+++ b/__tests__/app/why-website-first.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { render } from '@testing-library/react'
 import { axe } from '../utils/axe'
 import WhyWebsiteFirst from '@/app/why-website-first/page'
+import { journeyStages } from '@/data/journey'
 
 describe('Why Website First page', () => {
   it('renders without crashing', () => {
@@ -66,12 +67,24 @@ describe('Why Website First page', () => {
     expect(hrefs).toContain('https://github.com/FreeForCharity/FFC-IN-Footer_Only_Template')
   })
 
-  it('renders the journey diagram', () => {
-    const { getByRole } = render(<WhyWebsiteFirst />)
-    const diagram = getByRole('img', {
+  it('renders the journey diagram (responsive horizontal + vertical variants)', () => {
+    const { getAllByRole } = render(<WhyWebsiteFirst />)
+    const diagrams = getAllByRole('img', {
       name: /five-stage Free For Charity onboarding journey/i,
     })
-    expect(diagram).toBeInTheDocument()
+    expect(diagrams).toHaveLength(2)
+  })
+
+  it('derives each gate card from the shared journey module (stage name + gateNote)', () => {
+    const { container } = render(<WhyWebsiteFirst />)
+    const text = container.textContent || ''
+
+    // Stage names and gate facts come from src/data/journey.ts, so the gate
+    // cards cannot drift from the journey page.
+    for (const stage of journeyStages.filter((s) => s.id !== 'handoff')) {
+      expect(text).toContain(stage.name)
+      expect(text).toContain(stage.gateNote)
+    }
   })
 
   it('links the CTA to /help-for-charities/ and cross-links the journey page', () => {

--- a/__tests__/components/journey/JourneyDiagram.test.tsx
+++ b/__tests__/components/journey/JourneyDiagram.test.tsx
@@ -4,55 +4,116 @@ import { axe } from '../../utils/axe'
 import JourneyDiagram from '@/components/journey/JourneyDiagram'
 
 describe('JourneyDiagram', () => {
-  it('renders an accessible image with title and description', () => {
-    const { getByRole } = render(<JourneyDiagram />)
-    const diagram = getByRole('img', {
+  it('renders both variants as accessible images with title and description', () => {
+    const { getAllByRole } = render(<JourneyDiagram />)
+    const diagrams = getAllByRole('img', {
       name: /five-stage Free For Charity onboarding journey/i,
     })
-    expect(diagram).toBeInTheDocument()
-    expect(diagram).toHaveAttribute('aria-describedby', 'journey-diagram-desc')
+    // Horizontal (>= sm) and vertical (< sm) variants; CSS shows one at a time.
+    expect(diagrams).toHaveLength(2)
+    for (const diagram of diagrams) {
+      const descId = diagram.getAttribute('aria-describedby')
+      expect(descId).toBeTruthy()
+      const desc = document.getElementById(descId as string)
+      expect(desc?.textContent).toMatch(/funding gate/i)
+    }
   })
 
-  it('shows all five stages in the gated order', () => {
+  it('generates unique ids via useId so two instances never collide', () => {
+    const { container } = render(
+      <>
+        <JourneyDiagram />
+        <JourneyDiagram />
+      </>
+    )
+    const ids = Array.from(container.querySelectorAll('[id]')).map((el) => el.id)
+    expect(ids.length).toBeGreaterThanOrEqual(8) // 2 instances x 2 variants x (title + desc)
+    expect(new Set(ids).size).toBe(ids.length)
+    // No hardcoded static id left behind.
+    expect(ids).not.toContain('journey-diagram-title')
+    // Marker references must point at ids that exist (url(#...) wiring).
+    for (const line of Array.from(container.querySelectorAll('[marker-end]'))) {
+      const ref = (line.getAttribute('marker-end') || '').match(/url\(#(.+)\)/)?.[1]
+      expect(ref).toBeTruthy()
+      expect(container.querySelector(`marker[id="${ref}"]`)).not.toBeNull()
+    }
+  })
+
+  it('shows all five stages in the gated order (both variants)', () => {
     const { container } = render(<JourneyDiagram />)
-    const text = container.textContent || ''
+    for (const variant of ['horizontal', 'vertical']) {
+      const text = container.querySelector(`[data-journey-variant="${variant}"]`)?.textContent || ''
+      const apply = text.indexOf('Apply')
+      const website = text.indexOf('Website')
+      const domain = text.indexOf('Domain')
+      const email = text.indexOf('Email')
+      const ongoing = text.indexOf('Ongoing')
 
-    const apply = text.indexOf('Apply')
-    const website = text.indexOf('Website')
-    const domain = text.indexOf('Domain')
-    const email = text.indexOf('Email')
-    const ongoing = text.indexOf('Ongoing')
-
-    expect(apply).toBeGreaterThan(-1)
-    expect(website).toBeGreaterThan(apply)
-    expect(domain).toBeGreaterThan(website)
-    expect(email).toBeGreaterThan(domain)
-    expect(ongoing).toBeGreaterThan(email)
+      expect(apply).toBeGreaterThan(-1)
+      expect(website).toBeGreaterThan(apply)
+      expect(domain).toBeGreaterThan(website)
+      expect(email).toBeGreaterThan(domain)
+      expect(ongoing).toBeGreaterThan(email)
+    }
   })
 
-  it('highlights the funding gate between website and domain', () => {
+  it('highlights the funding gate between website and domain (both variants)', () => {
     const { container } = render(<JourneyDiagram />)
-    const text = container.textContent || ''
-
-    expect(text).toContain('FUNDING GATE')
-    expect(text).toMatch(/money is spent only after your site is proven/i)
-    // The website stage sits on GitHub Pages before the gate
-    expect(text).toContain('GitHub Pages')
+    for (const variant of ['horizontal', 'vertical']) {
+      const text = container.querySelector(`[data-journey-variant="${variant}"]`)?.textContent || ''
+      expect(text).toContain('FUNDING GATE')
+      expect(text).toMatch(/money is spent only after your site is proven/i)
+      // The website stage sits on GitHub Pages before the gate
+      expect(text).toContain('GitHub Pages')
+    }
   })
 
-  it('is responsive: scales via viewBox with fluid width', () => {
+  it('is responsive: a horizontal variant for >= sm and a stacked vertical variant below sm', () => {
     const { container } = render(<JourneyDiagram />)
-    const svg = container.querySelector('svg')
-    expect(svg).toHaveAttribute('viewBox')
-    expect(svg?.getAttribute('class')).toContain('w-full')
-    expect(svg?.getAttribute('class')).toContain('max-w-full')
+    const horizontal = container.querySelector('[data-journey-variant="horizontal"]')
+    const vertical = container.querySelector('[data-journey-variant="vertical"]')
+    // Tailwind responsive classes on the wrappers toggle the variants —
+    // media queries cannot toggle classes inside the svg itself.
+    expect(horizontal?.getAttribute('class')).toContain('hidden')
+    expect(horizontal?.getAttribute('class')).toContain('sm:block')
+    expect(vertical?.getAttribute('class')).toContain('sm:hidden')
+    for (const wrapper of [horizontal, vertical]) {
+      const svg = wrapper?.querySelector('svg')
+      expect(svg).toHaveAttribute('viewBox')
+      expect(svg?.getAttribute('class')).toContain('w-full')
+      expect(svg?.getAttribute('class')).toContain('max-w-full')
+    }
   })
 
-  it('uses the FFC brand colors', () => {
+  it('keeps mobile text legible: every vertical-variant font renders >= 10px on a 320px viewport', () => {
+    const { container } = render(<JourneyDiagram />)
+    const svg = container.querySelector('[data-journey-variant="vertical"] svg') as SVGSVGElement
+    const viewBoxWidth = Number((svg.getAttribute('viewBox') || '').split(/\s+/)[2])
+    expect(viewBoxWidth).toBeGreaterThan(0)
+    // The old single horizontal diagram scaled a 1002-unit viewBox down to a
+    // phone width, rendering 13.5-unit text at ~4.6px. The stacked variant's
+    // narrow viewBox must keep every label at a readable rendered size even
+    // on the smallest common viewport (320px).
+    const scale = 320 / viewBoxWidth
+    const fontSizes = Array.from(svg.querySelectorAll('text')).map((t) =>
+      Number(t.getAttribute('font-size'))
+    )
+    expect(fontSizes.length).toBeGreaterThan(0)
+    for (const size of fontSizes) {
+      expect(size * scale).toBeGreaterThanOrEqual(10)
+    }
+  })
+
+  it('uses accessible brand colors (WCAG AA contrast)', () => {
     const { container } = render(<JourneyDiagram />)
     const html = container.innerHTML
+    // FFC blue: #0567B1 on/under white = 5.86:1.
     expect(html).toContain('#0567B1')
-    expect(html).toContain('#F58C23')
+    // Deep accessible orange: #A85400 on/under white = 5.34:1. The original
+    // brand orange #F58C23 is only 2.43:1 on white — it must not be used for
+    // any text or meaning-bearing element in the diagram.
+    expect(html).toContain('#A85400')
+    expect(html).not.toContain('#F58C23')
   })
 
   it('has no axe violations', async () => {

--- a/__tests__/scripts/funnel-report.test.ts
+++ b/__tests__/scripts/funnel-report.test.ts
@@ -2,12 +2,18 @@ import { execFileSync } from 'node:child_process'
 import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
 
 /**
  * Offline contract for scripts/funnel-report.mjs (--file mode): the operator
  * report script must render the beacon counts JSON written by
  * public/api/funnel-beacon.php as a per-pid markdown funnel table, and must
  * handle the not-yet-created / empty cases gracefully.
+ *
+ * The FTPS helpers that can be tested without a server (PASV host fix-up,
+ * TLS data-session selection, ignored-pid handling) are exercised by
+ * importing the module in a child node process — same spawn pattern as the
+ * --file tests, and it keeps the ESM script out of the jest/ts transform.
  */
 const root = join(__dirname, '..', '..')
 const script = join(root, 'scripts', 'funnel-report.mjs')
@@ -21,6 +27,21 @@ function runWithCounts(counts: unknown): string {
   } finally {
     rmSync(dir, { recursive: true, force: true })
   }
+}
+
+/** Evaluates `expr` in a child node process with the script imported as `m`. */
+function evalWithModule(expr: string): unknown {
+  const href = pathToFileURL(script).href
+  const out = execFileSync(
+    process.execPath,
+    [
+      '--input-type=module',
+      '-e',
+      `const m = await import(${JSON.stringify(href)}); process.stdout.write(JSON.stringify(${expr}))`,
+    ],
+    { encoding: 'utf8' }
+  )
+  return JSON.parse(out)
 }
 
 describe('funnel-report script (offline --file mode)', () => {
@@ -45,6 +66,25 @@ describe('funnel-report script (offline --file mode)', () => {
     expect(out).toMatch(/no beacon counts recorded yet/i)
   })
 
+  it('excludes the synthetic contract-test pid 999 from the funnel table', () => {
+    const out = runWithCounts({
+      '2026-07-10': { '40': { view: 10, complete: 2 }, '999': { view: 7, complete: 4 } },
+    })
+    // Real traffic stays in the table…
+    expect(out).toContain('| 40 | Website | 10 | 2 |')
+    // …but pid 999 must not appear as a funnel row (it would pollute totals
+    // and filter-rate math).
+    expect(out).not.toMatch(/^\| 999 \|/m)
+    // It is reported on a separate synthetic/test-traffic line instead.
+    expect(out).toMatch(/synthetic\/test traffic \(excluded from the funnel above\)/i)
+    expect(out).toContain('pid 999')
+    expect(out).toContain('7 view(s), 4 complete(s)')
+  })
+
+  it('exports pid 999 in the IGNORED_PIDS list', () => {
+    expect(evalWithModule('m.IGNORED_PIDS')).toContain('999')
+  })
+
   it('exits with a clear message when credentials are missing (no --file)', () => {
     let failed = false
     try {
@@ -60,5 +100,44 @@ describe('funnel-report script (offline --file mode)', () => {
       expect(e.stderr).toMatch(/Never hardcode credentials/i)
     }
     expect(failed).toBe(true)
+  })
+})
+
+describe('funnel-report FTPS helpers (offline)', () => {
+  it('choosePasvHost falls back to the control host when PASV advertises a private address', () => {
+    // NAT misconfiguration: server advertises its internal RFC1918 address.
+    expect(evalWithModule("m.choosePasvHost('192.168.1.20', '203.0.113.7')")).toBe('203.0.113.7')
+    expect(evalWithModule("m.choosePasvHost('10.0.0.5', '203.0.113.7')")).toBe('203.0.113.7')
+    expect(evalWithModule("m.choosePasvHost('172.31.0.9', '203.0.113.7')")).toBe('203.0.113.7')
+    expect(evalWithModule("m.choosePasvHost('127.0.0.1', '203.0.113.7')")).toBe('203.0.113.7')
+  })
+
+  it('choosePasvHost keeps a public PASV address', () => {
+    expect(evalWithModule("m.choosePasvHost('198.51.100.4', '203.0.113.7')")).toBe('198.51.100.4')
+    // 172.32.x.x is outside 172.16/12 — public, keep it.
+    expect(evalWithModule("m.choosePasvHost('172.32.0.9', '203.0.113.7')")).toBe('172.32.0.9')
+  })
+
+  it('choosePasvHost keeps the address when it equals the control host (LAN servers)', () => {
+    expect(evalWithModule("m.choosePasvHost('192.168.1.20', '192.168.1.20')")).toBe('192.168.1.20')
+  })
+
+  it('isPrivateIPv4 classifies RFC1918/loopback/link-local ranges', () => {
+    expect(evalWithModule("m.isPrivateIPv4('10.1.2.3')")).toBe(true)
+    expect(evalWithModule("m.isPrivateIPv4('172.16.0.1')")).toBe(true)
+    expect(evalWithModule("m.isPrivateIPv4('169.254.9.9')")).toBe(true)
+    expect(evalWithModule("m.isPrivateIPv4('8.8.8.8')")).toBe(false)
+    expect(evalWithModule("m.isPrivateIPv4('172.15.0.1')")).toBe(false)
+  })
+
+  it('selectDataSession prefers the latest TLS 1.3 session ticket over getSession()', () => {
+    // Tickets captured from the control socket's 'session' event win —
+    // getSession() is not resumable on TLS 1.3.
+    expect(evalWithModule("m.selectDataSession(['ticket1', 'ticket2'], 'stub')")).toBe('ticket2')
+  })
+
+  it('selectDataSession falls back to the control session (TLS 1.2) when no tickets arrived', () => {
+    expect(evalWithModule("m.selectDataSession([], 'tls12-session')")).toBe('tls12-session')
+    expect(evalWithModule("m.selectDataSession([], null) ?? 'undefined'")).toBe('undefined')
   })
 })

--- a/scripts/funnel-report.mjs
+++ b/scripts/funnel-report.mjs
@@ -14,13 +14,31 @@
  *   FTP_HOST=... FTP_USER=... FTP_PASS=... node scripts/funnel-report.mjs
  *
  * Environment variables:
- *   FTP_HOST  FTPS server hostname (required)
- *   FTP_USER  FTPS username        (required)
- *   FTP_PASS  FTPS password        (required)
- *   FTP_PORT  control port         (optional, default 21 — explicit AUTH TLS)
+ *   FTP_HOST         FTPS server hostname (required)
+ *   FTP_USER         FTPS username        (required)
+ *   FTP_PASS         FTPS password        (required)
+ *   FTP_PORT         control port         (optional, default 21 — explicit AUTH TLS)
+ *   FTP_VERIFY_CERT  set to 1 to enforce TLS certificate verification.
+ *                    Default is OFF: the cPanel host presents a self-signed
+ *                    certificate (the deploy workflow sets
+ *                    `ssl:verify-certificate no` for the same host in
+ *                    .github/workflows/deploy-cpanel.yml). The channel is
+ *                    still encrypted either way.
  *
  * Offline mode (render a previously downloaded counts file, no FTP):
  *   node scripts/funnel-report.mjs --file /path/to/ffc_funnel_counts.json
+ *
+ * TLS notes (Pure-FTPd/cPanel):
+ *   - The server requires the data connection to REUSE the control
+ *     connection's TLS session. On TLS 1.3 `getSession()` does not return a
+ *     resumable session (tickets arrive after the handshake via the
+ *     'session' event), so we capture tickets from that event and hand the
+ *     latest one to the data connection. If the data handshake still fails,
+ *     we retry the whole download once forcing `maxVersion: 'TLSv1.2'` on
+ *     BOTH connections, where synchronous session reuse works reliably.
+ *   - If a PASV reply advertises a private/loopback address that differs
+ *     from the control host (NAT misconfiguration), we connect to the
+ *     control host instead — the same fix-up curl and lftp apply.
  *
  * Node stdlib only — no dependencies. See docs/funnel-beacon.md.
  */
@@ -45,6 +63,13 @@ const PID_LABELS = {
   999: 'Contract-test pid (ignore)',
   all: '(no pid — legacy/complete)',
 }
+
+/**
+ * Synthetic/test product ids excluded from the funnel totals (they would
+ * pollute views/completes and any filter-rate math). They are still shown,
+ * but only on a separate "synthetic/test traffic" line.
+ */
+export const IGNORED_PIDS = ['999']
 
 /* ------------------------------------------------------------------ */
 /* Minimal explicit-FTPS (AUTH TLS) client — control + one RETR.       */
@@ -103,14 +128,47 @@ function connectPlain(host, port) {
   })
 }
 
-function upgradeToTls(socket, host, session) {
+function upgradeToTls(socket, host, { session, rejectUnauthorized = true, maxVersion } = {}) {
   return new Promise((resolve, reject) => {
     const secure = tls.connect(
-      { socket, servername: host, session, rejectUnauthorized: true },
+      {
+        socket,
+        servername: host,
+        session,
+        rejectUnauthorized,
+        ...(maxVersion ? { maxVersion } : {}),
+      },
       () => resolve(secure)
     )
     secure.once('error', reject)
   })
+}
+
+/**
+ * Picks the TLS session for the data connection. TLS 1.3 delivers resumable
+ * session tickets AFTER the handshake via the socket's 'session' event —
+ * `getSession()` there returns a non-resumable stub — so prefer the latest
+ * captured ticket and fall back to `getSession()` (valid for TLS 1.2).
+ */
+export function selectDataSession(capturedSessions, controlSession) {
+  if (capturedSessions.length > 0) return capturedSessions[capturedSessions.length - 1]
+  return controlSession ?? undefined
+}
+
+/** RFC1918 / loopback / link-local IPv4. */
+export function isPrivateIPv4(host) {
+  return /^(10\.|127\.|192\.168\.|169\.254\.|172\.(1[6-9]|2\d|3[01])\.)\d/.test(host)
+}
+
+/**
+ * PASV fix-up (matches curl/lftp behavior): if the 227 reply advertises a
+ * private/loopback address different from the control host, the server is
+ * behind NAT and advertising its internal address — connect to the control
+ * host instead.
+ */
+export function choosePasvHost(pasvHost, controlHost) {
+  if (pasvHost !== controlHost && isPrivateIPv4(pasvHost)) return controlHost
+  return pasvHost
 }
 
 /** Parses "227 Entering Passive Mode (h1,h2,h3,h4,p1,p2)." */
@@ -128,10 +186,12 @@ function parseEpsv(text) {
 }
 
 /**
- * Downloads `filePath` over explicit FTPS. Returns the file contents as a
+ * One download attempt over explicit FTPS. Returns the file contents as a
  * string, or null if the server says the file does not exist (550).
+ * `maxVersion` (optional) caps the TLS version on BOTH connections.
  */
-async function ftpsDownload({ host, port, user, pass }, filePath) {
+async function ftpsDownloadAttempt({ host, port, user, pass, verifyCert }, filePath, maxVersion) {
+  const tlsOpts = { rejectUnauthorized: verifyCert, maxVersion }
   const raw = await connectPlain(host, port)
   let reader = makeReplyReader(raw)
   await expectReply(reader, [220], 'greeting')
@@ -140,7 +200,12 @@ async function ftpsDownload({ host, port, user, pass }, filePath) {
   await expectReply(reader, [234], 'AUTH TLS')
   reader.detach()
 
-  const control = await upgradeToTls(raw, host)
+  const control = await upgradeToTls(raw, host, tlsOpts)
+  // TLS 1.3 session tickets arrive after the handshake — capture them all
+  // so the data connection can resume with the latest one (Pure-FTPd
+  // requires data-connection session reuse under PROT P).
+  const capturedSessions = []
+  control.on('session', (session) => capturedSessions.push(session))
   reader = makeReplyReader(control)
 
   control.write(`USER ${user}\r\n`)
@@ -166,7 +231,7 @@ async function ftpsDownload({ host, port, user, pass }, filePath) {
     control.write('PASV\r\n')
     const pasv = await expectReply(reader, [227], 'PASV')
     const parsed = parsePasv(pasv.text)
-    dataHost = parsed.host
+    dataHost = choosePasvHost(parsed.host, host)
     dataPort = parsed.port
   }
 
@@ -184,9 +249,21 @@ async function ftpsDownload({ host, port, user, pass }, filePath) {
     throw new Error(`FTPS RETR: unexpected reply ${retr.text}`)
   }
 
-  // Data connection is TLS too (PROT P); most servers require reusing the
-  // control connection's TLS session.
-  const data = await upgradeToTls(dataRaw, host, control.getSession())
+  // Data connection is TLS too (PROT P); the server requires reusing the
+  // control connection's TLS session — see selectDataSession().
+  let data
+  try {
+    data = await upgradeToTls(dataRaw, host, {
+      ...tlsOpts,
+      session: selectDataSession(capturedSessions, control.getSession()),
+    })
+  } catch (err) {
+    // Mark data-connection handshake failures so the caller can retry once
+    // on TLS 1.2, where synchronous session reuse works.
+    err.ftpsDataHandshake = true
+    control.destroy()
+    throw err
+  }
   const chunks = []
   await new Promise((resolve, reject) => {
     data.on('data', (c) => chunks.push(c))
@@ -199,13 +276,35 @@ async function ftpsDownload({ host, port, user, pass }, filePath) {
   return Buffer.concat(chunks).toString('utf8')
 }
 
+/**
+ * Downloads `filePath` over explicit FTPS, retrying once on TLS 1.2 if the
+ * data-connection handshake fails (TLS 1.3 session-ticket reuse is not
+ * guaranteed to satisfy Pure-FTPd's reuse requirement; on TLS 1.2 the
+ * session from the control handshake resumes reliably).
+ */
+async function ftpsDownload(config, filePath) {
+  try {
+    return await ftpsDownloadAttempt(config, filePath, undefined)
+  } catch (err) {
+    if (!err?.ftpsDataHandshake) throw err
+    console.error(
+      `note: data-connection TLS handshake failed (${err.message}); ` +
+        'retrying once with maxVersion TLSv1.2 on both connections ' +
+        '(TLS 1.3 session reuse is not reliable for FTPS data connections).'
+    )
+    return await ftpsDownloadAttempt(config, filePath, 'TLSv1.2')
+  }
+}
+
 /* ------------------------------------------------------------------ */
 /* Markdown rendering                                                  */
 /* ------------------------------------------------------------------ */
 
 /**
  * counts shape (from funnel-beacon.php): { "YYYY-MM-DD": { "<pid>": { "view": n, "complete": n } } }
- * Renders a per-pid totals table plus a per-day breakdown.
+ * Renders a per-pid totals table plus a per-day breakdown. Pids in
+ * IGNORED_PIDS (synthetic/contract-test traffic) are excluded from the
+ * funnel table and totals, and reported on a separate line instead.
  */
 export function renderMarkdown(counts) {
   const perPid = new Map()
@@ -232,16 +331,27 @@ export function renderMarkdown(counts) {
   lines.push('')
   lines.push('| PID | Product | Views | Completes |')
   lines.push('| --- | ------- | ----: | --------: |')
-  const pids = [...perPid.keys()].sort((a, b) => {
-    const na = Number(a)
-    const nb = Number(b)
-    if (Number.isNaN(na)) return 1
-    if (Number.isNaN(nb)) return -1
-    return na - nb
-  })
+  const sortPids = (keys) =>
+    keys.sort((a, b) => {
+      const na = Number(a)
+      const nb = Number(b)
+      if (Number.isNaN(na)) return 1
+      if (Number.isNaN(nb)) return -1
+      return na - nb
+    })
+  const pids = sortPids([...perPid.keys()].filter((pid) => !IGNORED_PIDS.includes(pid)))
+  const ignored = sortPids([...perPid.keys()].filter((pid) => IGNORED_PIDS.includes(pid)))
   for (const pid of pids) {
     const { view, complete } = perPid.get(pid)
     lines.push(`| ${pid} | ${PID_LABELS[pid] ?? '—'} | ${view} | ${complete} |`)
+  }
+  if (ignored.length > 0) {
+    lines.push('')
+    const parts = ignored.map((pid) => {
+      const { view, complete } = perPid.get(pid)
+      return `pid ${pid} (${PID_LABELS[pid] ?? '—'}) — ${view} view(s), ${complete} complete(s)`
+    })
+    lines.push(`_Synthetic/test traffic (excluded from the funnel above): ${parts.join('; ')}._`)
   }
   lines.push('')
   lines.push('> **Caveat:** WHMCS order reports are authoritative for submissions — the')
@@ -266,7 +376,7 @@ async function main() {
     }
     raw = readFileSync(path, 'utf8')
   } else {
-    const { FTP_HOST, FTP_USER, FTP_PASS, FTP_PORT } = process.env
+    const { FTP_HOST, FTP_USER, FTP_PASS, FTP_PORT, FTP_VERIFY_CERT } = process.env
     if (!FTP_HOST || !FTP_USER || !FTP_PASS) {
       console.error(
         'Missing credentials. Set FTP_HOST, FTP_USER and FTP_PASS in the environment\n' +
@@ -275,8 +385,22 @@ async function main() {
       )
       process.exit(2)
     }
+    const verifyCert = FTP_VERIFY_CERT === '1'
+    if (!verifyCert) {
+      console.error(
+        'note: channel encrypted; cert not verified — the cPanel host presents a ' +
+          "self-signed certificate (matches deploy workflow behavior: deploy-cpanel.yml's " +
+          '`ssl:verify-certificate no`). Set FTP_VERIFY_CERT=1 to enforce verification.'
+      )
+    }
     raw = await ftpsDownload(
-      { host: FTP_HOST, port: Number(FTP_PORT ?? 21), user: FTP_USER, pass: FTP_PASS },
+      {
+        host: FTP_HOST,
+        port: Number(FTP_PORT ?? 21),
+        user: FTP_USER,
+        pass: FTP_PASS,
+        verifyCert,
+      },
       COUNTS_PATH
     )
     if (raw === null) {

--- a/src/app/charity-onboarding-journey/page.tsx
+++ b/src/app/charity-onboarding-journey/page.tsx
@@ -41,9 +41,14 @@ export default function CharityOnboardingJourney() {
         <ol className="mt-8 space-y-6">
           {journeyStages.map((stage) => (
             <li key={stage.id} className="border border-gray-200 rounded-lg p-6">
-              <h2 className="font-[var(--font-faustina)] text-[26px] leading-[34px] mb-3">
+              <h2 className="font-[var(--font-faustina)] text-[26px] leading-[34px] mb-2">
                 {stage.name}
               </h2>
+              {/* The gate relationship, from the shared journey module —
+                  #A85400 on white is 5.34:1 (WCAG AA). */}
+              <p className="font-[var(--font-lato)] text-[15px] leading-[23px] font-[700] text-[#A85400] mb-3">
+                {stage.gateNote}
+              </p>
               <dl className="font-[var(--font-lato)] text-[17px] leading-[27px] space-y-2">
                 <div>
                   <dt className="font-[700] inline">You: </dt>

--- a/src/app/why-website-first/page.tsx
+++ b/src/app/why-website-first/page.tsx
@@ -1,6 +1,7 @@
 import { pageMetadata } from '@/lib/page-metadata'
 import Link from 'next/link'
 import JourneyDiagram from '@/components/journey/JourneyDiagram'
+import { journeyStages, type JourneyStage } from '@/data/journey'
 
 export const metadata = pageMetadata({
   title: 'Why We Build Your Website Before Buying Your Domain',
@@ -11,33 +12,57 @@ export const metadata = pageMetadata({
 
 const h2 = 'font-[var(--font-faustina)] text-[32px] leading-[40px] mt-8 mb-4'
 
-interface Gate {
+/**
+ * The four gates derive from the shared journey module (src/data/journey.ts)
+ * so the stage/gate FACTS — which stage each gate belongs to, its name, and
+ * its gateNote — cannot drift from the journey page. Only the page-specific
+ * prose (gate label + plain-language explanation) lives here, keyed by the
+ * canonical stage id.
+ */
+interface GateProse {
+  stageId: string
   name: string
   plain: string
 }
 
-const gates: Gate[] = [
+const gateProse: GateProse[] = [
   {
+    stageId: 'application',
     name: 'Gate 1 — Validation',
     plain:
       'Before anything is built, we verify your organization: IRS status, Candid profile, and program fit. Every later stage requires this approval, so nobody invests effort in an organization that cannot qualify.',
   },
   {
+    stageId: 'website',
     name: 'Gate 2 — Website',
     plain:
       'The website application only opens after validation. A volunteer builds your site from an FFC template and you prove the partnership works by getting us your content. The site goes live on its free GitHub Pages address — which costs nothing.',
   },
   {
+    stageId: 'domain',
     name: 'Gate 3 — Funding',
     plain:
       'This is the money gate. We only spend funds on your free .org domain once your website is validated live. The domain order form literally asks for your live GitHub Pages address — that is what unlocks the purchase.',
   },
   {
+    stageId: 'email',
     name: 'Gate 4 — Email',
     plain:
       'Microsoft and Google both require a live website before they approve a nonprofit for free email. Because your site is already proven and your domain is live, your free Microsoft 365 or Google Workspace mailboxes sail through.',
   },
 ]
+
+interface Gate extends GateProse {
+  stage: JourneyStage
+}
+
+const gates: Gate[] = gateProse.map((gate) => {
+  const stage = journeyStages.find((s) => s.id === gate.stageId)
+  if (!stage) {
+    throw new Error(`why-website-first: no journey stage with id "${gate.stageId}"`)
+  }
+  return { ...gate, stage }
+})
 
 export default function WhyWebsiteFirst() {
   return (
@@ -95,9 +120,14 @@ export default function WhyWebsiteFirst() {
         <ol className="mt-4 space-y-6">
           {gates.map((gate) => (
             <li key={gate.name} className="border border-gray-200 rounded-lg p-6">
-              <h3 className="font-[var(--font-faustina)] text-[26px] leading-[34px] mb-3">
+              <h3 className="font-[var(--font-faustina)] text-[26px] leading-[34px] mb-2">
                 {gate.name}
               </h3>
+              {/* Stage name + gate fact from the shared journey module —
+                  #A85400 on white is 5.34:1 (WCAG AA). */}
+              <p className="font-[var(--font-lato)] text-[15px] leading-[23px] font-[700] text-[#A85400] mb-3">
+                {gate.stage.name}: {gate.stage.gateNote}
+              </p>
               <p className="font-[var(--font-lato)] text-[17px] leading-[27px]">{gate.plain}</p>
             </li>
           ))}

--- a/src/components/journey/JourneyDiagram.tsx
+++ b/src/components/journey/JourneyDiagram.tsx
@@ -1,18 +1,49 @@
+'use client'
+
 /**
- * Journey diagram (overnight block 7): the five gated onboarding stages as an
- * inline, responsive SVG. The funding gate — money is only spent after the
- * website is validated live on GitHub Pages — sits between stages 2 and 3 and
- * is highlighted in FFC orange. Rendered on /why-website-first/ and
+ * Journey diagram: the five gated onboarding stages as inline, responsive
+ * SVG. The funding gate — money is only spent after the website is validated
+ * live on GitHub Pages — sits between stages 2 and 3 and is highlighted in
+ * FFC orange. Rendered on /why-website-first/ and
  * /charity-onboarding-journey/.
  *
- * Accessibility: role="img" with <title>/<desc> wired via aria-labelledby /
- * aria-describedby; every visual detail is decorative relative to that
- * summary, and the full journey is described in the surrounding page text.
+ * Two variants are rendered and toggled with Tailwind's responsive classes
+ * on wrapper divs (media queries cannot toggle Tailwind classes INSIDE an
+ * svg, but they work fine on the wrappers):
+ *   - horizontal (>= sm): the five boxes in a row, gate between 2 and 3;
+ *   - vertical (< sm): the boxes stacked, so text renders at a legible size
+ *     on phones instead of scaling a 1002-unit-wide viewBox down to ~375px.
+ *
+ * Color contrast (WCAG AA, computed with the standard relative-luminance
+ * formula): the brand orange #F58C23 is only 2.43:1 on white, which fails
+ * both AA text (4.5:1) and non-text (3:1) minimums — so every orange element
+ * in the diagram uses the deeper ORANGE below instead:
+ *   - #A85400 on #ffffff = 5.34:1 (gate label, box strokes, gate line)
+ *   - #ffffff on #A85400 = 5.34:1 (numerals in the stage circles)
+ *   - #ffffff on #0567B1 = 5.86:1 (text in the pre-gate blue boxes)
+ *   - #1a2e35 on #ffffff = 14.13:1 (body text)
+ *
+ * Accessibility: each variant is role="img" with <title>/<desc> wired via
+ * aria-labelledby / aria-describedby; ids come from React useId so multiple
+ * instances (or the two variants) never collide. Every visual detail is
+ * decorative relative to that summary, and the full journey is described in
+ * the surrounding page text.
  */
 
+import { useId } from 'react'
+
 const BLUE = '#0567B1'
-const ORANGE = '#F58C23'
+// Deep accessible orange — see the contrast table in the header comment.
+const ORANGE = '#A85400'
 const INK = '#1a2e35'
+
+const TITLE = 'The five-stage Free For Charity onboarding journey'
+const DESC =
+  'Flow diagram of five stages: 1 Apply (validation and approval), 2 Website (built and ' +
+  'validated on GitHub Pages), 3 Domain (free .org bought and pointed at your site), 4 Email ' +
+  '(Microsoft 365 or Google Workspace), 5 Ongoing (renewals, DNS and support). An orange ' +
+  'funding gate sits between the Website and Domain stages: no money is spent until your ' +
+  'website is validated live.'
 
 interface DiagramStage {
   number: string
@@ -28,60 +59,108 @@ const diagramStages: DiagramStage[] = [
   { number: '5', title: 'Ongoing', detail: ['Renewals, DNS &', 'support forever'] },
 ]
 
-const BOX_WIDTH = 168
-const BOX_HEIGHT = 96
-const BOX_Y = 92
-const GAP = 30
-const LEFT = 6
-const stageX = (index: number) => LEFT + index * (BOX_WIDTH + GAP)
+/** One stage box, shared by both variants. */
+const StageBox = ({
+  stage,
+  x,
+  y,
+  width,
+  height,
+  isBeforeGate,
+}: {
+  stage: DiagramStage
+  x: number
+  y: number
+  width: number
+  height: number
+  isBeforeGate: boolean
+}) => (
+  <g aria-hidden="true">
+    <rect
+      x={x}
+      y={y}
+      width={width}
+      height={height}
+      rx="10"
+      fill={isBeforeGate ? BLUE : '#ffffff'}
+      stroke={isBeforeGate ? BLUE : ORANGE}
+      strokeWidth={isBeforeGate ? 0 : 3}
+    />
+    <circle cx={x + 24} cy={y + 26} r="13" fill={isBeforeGate ? '#ffffff' : ORANGE} />
+    <text
+      x={x + 24}
+      y={y + 31}
+      textAnchor="middle"
+      fontSize="15"
+      fontWeight="700"
+      fill={isBeforeGate ? BLUE : '#ffffff'}
+    >
+      {stage.number}
+    </text>
+    <text
+      x={x + 46}
+      y={y + 31}
+      fontSize="18"
+      fontWeight="700"
+      fill={isBeforeGate ? '#ffffff' : INK}
+    >
+      {stage.title}
+    </text>
+    <text x={x + 14} y={y + 58} fontSize="14" fill={isBeforeGate ? '#ffffff' : INK}>
+      {stage.detail[0]}
+    </text>
+    <text x={x + 14} y={y + 76} fontSize="14" fill={isBeforeGate ? '#ffffff' : INK}>
+      {stage.detail[1]}
+    </text>
+  </g>
+)
+
+/* ----------------------- horizontal (>= sm) ------------------------ */
+
+const H_BOX_WIDTH = 168
+const H_BOX_HEIGHT = 96
+const H_BOX_Y = 92
+const H_GAP = 30
+const H_LEFT = 6
+const hStageX = (index: number) => H_LEFT + index * (H_BOX_WIDTH + H_GAP)
 
 // The funding gate sits in the connector between stage 2 (website) and
 // stage 3 (domain): the site must be proven before money is spent.
-const GATE_X = stageX(1) + BOX_WIDTH + GAP / 2
+const H_GATE_X = hStageX(1) + H_BOX_WIDTH + H_GAP / 2
 
-const JourneyDiagram = () => {
+const HorizontalDiagram = ({ uid }: { uid: string }) => {
+  const titleId = `${uid}-h-title`
+  const descId = `${uid}-h-desc`
+  const markerId = `${uid}-h-arrow`
   return (
     <svg
       viewBox="0 0 1002 232"
       xmlns="http://www.w3.org/2000/svg"
       role="img"
-      aria-labelledby="journey-diagram-title"
-      aria-describedby="journey-diagram-desc"
+      aria-labelledby={titleId}
+      aria-describedby={descId}
       className="w-full max-w-full h-auto"
       style={{ fontFamily: 'var(--font-lato), Lato, sans-serif' }}
     >
-      <title id="journey-diagram-title">The five-stage Free For Charity onboarding journey</title>
-      <desc id="journey-diagram-desc">
-        Flow diagram of five stages: 1 Apply (validation and approval), 2 Website (built and
-        validated on GitHub Pages), 3 Domain (free .org bought and pointed at your site), 4 Email
-        (Microsoft 365 or Google Workspace), 5 Ongoing (renewals, DNS and support). An orange
-        funding gate sits between the Website and Domain stages: no money is spent until your
-        website is validated live.
-      </desc>
+      <title id={titleId}>{TITLE}</title>
+      <desc id={descId}>{DESC}</desc>
 
       {/* Connector arrows between consecutive stages */}
       <defs>
-        <marker
-          id="journey-arrowhead"
-          markerWidth="8"
-          markerHeight="8"
-          refX="6"
-          refY="4"
-          orient="auto"
-        >
+        <marker id={markerId} markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto">
           <path d="M0 0 L8 4 L0 8 Z" fill={BLUE} />
         </marker>
       </defs>
       {diagramStages.slice(0, -1).map((stage, index) => (
         <line
           key={`connector-${stage.number}`}
-          x1={stageX(index) + BOX_WIDTH}
-          y1={BOX_Y + BOX_HEIGHT / 2}
-          x2={stageX(index + 1) - 2}
-          y2={BOX_Y + BOX_HEIGHT / 2}
+          x1={hStageX(index) + H_BOX_WIDTH}
+          y1={H_BOX_Y + H_BOX_HEIGHT / 2}
+          x2={hStageX(index + 1) - 2}
+          y2={H_BOX_Y + H_BOX_HEIGHT / 2}
           stroke={BLUE}
           strokeWidth="2.5"
-          markerEnd="url(#journey-arrowhead)"
+          markerEnd={`url(#${markerId})`}
           aria-hidden="true"
         />
       ))}
@@ -89,17 +168,17 @@ const JourneyDiagram = () => {
       {/* Funding gate highlight between Website and Domain */}
       <g aria-hidden="true">
         <line
-          x1={GATE_X}
+          x1={H_GATE_X}
           y1="58"
-          x2={GATE_X}
-          y2={BOX_Y + BOX_HEIGHT + 14}
+          x2={H_GATE_X}
+          y2={H_BOX_Y + H_BOX_HEIGHT + 14}
           stroke={ORANGE}
           strokeWidth="4"
           strokeDasharray="7 5"
           strokeLinecap="round"
         />
         <text
-          x={GATE_X}
+          x={H_GATE_X}
           y="26"
           textAnchor="middle"
           fontSize="17"
@@ -109,60 +188,178 @@ const JourneyDiagram = () => {
         >
           FUNDING GATE
         </text>
-        <text x={GATE_X} y="48" textAnchor="middle" fontSize="13.5" fill={INK}>
+        <text x={H_GATE_X} y="48" textAnchor="middle" fontSize="14" fill={INK}>
           Money is spent only after your site is proven
         </text>
-        <text x={GATE_X} y={BOX_Y + BOX_HEIGHT + 34} textAnchor="middle" fontSize="13.5" fill={INK}>
+        <text
+          x={H_GATE_X}
+          y={H_BOX_Y + H_BOX_HEIGHT + 34}
+          textAnchor="middle"
+          fontSize="14"
+          fill={INK}
+        >
           Validated live site unlocks the domain purchase
         </text>
       </g>
 
       {/* Stage boxes */}
-      {diagramStages.map((stage, index) => {
-        const x = stageX(index)
-        const isBeforeGate = index <= 1
-        return (
-          <g key={stage.number} aria-hidden="true">
-            <rect
-              x={x}
-              y={BOX_Y}
-              width={BOX_WIDTH}
-              height={BOX_HEIGHT}
-              rx="10"
-              fill={isBeforeGate ? BLUE : '#ffffff'}
-              stroke={isBeforeGate ? BLUE : ORANGE}
-              strokeWidth={isBeforeGate ? 0 : 3}
-            />
-            <circle cx={x + 24} cy={BOX_Y + 26} r="13" fill={isBeforeGate ? '#ffffff' : ORANGE} />
-            <text
-              x={x + 24}
-              y={BOX_Y + 31}
-              textAnchor="middle"
-              fontSize="15"
-              fontWeight="700"
-              fill={isBeforeGate ? BLUE : '#ffffff'}
-            >
-              {stage.number}
-            </text>
-            <text
-              x={x + 46}
-              y={BOX_Y + 31}
-              fontSize="18"
-              fontWeight="700"
-              fill={isBeforeGate ? '#ffffff' : INK}
-            >
-              {stage.title}
-            </text>
-            <text x={x + 14} y={BOX_Y + 58} fontSize="13.5" fill={isBeforeGate ? '#ffffff' : INK}>
-              {stage.detail[0]}
-            </text>
-            <text x={x + 14} y={BOX_Y + 76} fontSize="13.5" fill={isBeforeGate ? '#ffffff' : INK}>
-              {stage.detail[1]}
-            </text>
-          </g>
-        )
-      })}
+      {diagramStages.map((stage, index) => (
+        <StageBox
+          key={stage.number}
+          stage={stage}
+          x={hStageX(index)}
+          y={H_BOX_Y}
+          width={H_BOX_WIDTH}
+          height={H_BOX_HEIGHT}
+          isBeforeGate={index <= 1}
+        />
+      ))}
     </svg>
+  )
+}
+
+/* ------------------------ vertical (< sm) -------------------------- */
+
+const V_WIDTH = 360
+const V_BOX_WIDTH = 348
+const V_BOX_HEIGHT = 88
+const V_LEFT = 6
+const V_GAP = 40 // between consecutive boxes (connector arrow)
+const V_GATE_GAP = 132 // between stages 2 and 3 (the funding gate)
+const V_CENTER = V_WIDTH / 2
+
+const vStageY = (index: number) => {
+  let y = 6
+  for (let i = 0; i < index; i++) {
+    y += V_BOX_HEIGHT + (i === 1 ? V_GATE_GAP : V_GAP)
+  }
+  return y
+}
+const V_HEIGHT = vStageY(diagramStages.length - 1) + V_BOX_HEIGHT + 6
+// Gate zone spans the gap between box 2's bottom and box 3's top.
+const V_GATE_TOP = vStageY(1) + V_BOX_HEIGHT
+
+const VerticalDiagram = ({ uid }: { uid: string }) => {
+  const titleId = `${uid}-v-title`
+  const descId = `${uid}-v-desc`
+  const markerId = `${uid}-v-arrow`
+  return (
+    <svg
+      viewBox={`0 0 ${V_WIDTH} ${V_HEIGHT}`}
+      xmlns="http://www.w3.org/2000/svg"
+      role="img"
+      aria-labelledby={titleId}
+      aria-describedby={descId}
+      className="w-full max-w-full h-auto"
+      style={{ fontFamily: 'var(--font-lato), Lato, sans-serif' }}
+    >
+      <title id={titleId}>{TITLE}</title>
+      <desc id={descId}>{DESC}</desc>
+
+      <defs>
+        <marker id={markerId} markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto">
+          <path d="M0 0 L8 4 L0 8 Z" fill={BLUE} />
+        </marker>
+      </defs>
+
+      {/* Connector arrows between consecutive stages (the 2→3 connector is
+          split around the funding-gate text so nothing overlaps) */}
+      {diagramStages.slice(0, -1).map((stage, index) =>
+        index === 1 ? (
+          <g key={`connector-${stage.number}`} aria-hidden="true">
+            <line
+              x1={V_CENTER}
+              y1={V_GATE_TOP}
+              x2={V_CENTER}
+              y2={V_GATE_TOP + 12}
+              stroke={BLUE}
+              strokeWidth="2.5"
+            />
+            <line
+              x1={V_CENTER}
+              y1={V_GATE_TOP + V_GATE_GAP - 20}
+              x2={V_CENTER}
+              y2={V_GATE_TOP + V_GATE_GAP - 4}
+              stroke={BLUE}
+              strokeWidth="2.5"
+              markerEnd={`url(#${markerId})`}
+            />
+          </g>
+        ) : (
+          <line
+            key={`connector-${stage.number}`}
+            x1={V_CENTER}
+            y1={vStageY(index) + V_BOX_HEIGHT}
+            x2={V_CENTER}
+            y2={vStageY(index + 1) - 4}
+            stroke={BLUE}
+            strokeWidth="2.5"
+            markerEnd={`url(#${markerId})`}
+            aria-hidden="true"
+          />
+        )
+      )}
+
+      {/* Funding gate between Website and Domain */}
+      <g aria-hidden="true">
+        <text
+          x={V_CENTER}
+          y={V_GATE_TOP + 34}
+          textAnchor="middle"
+          fontSize="16"
+          fontWeight="700"
+          fill={ORANGE}
+          letterSpacing="0.06em"
+        >
+          FUNDING GATE
+        </text>
+        <text x={V_CENTER} y={V_GATE_TOP + 56} textAnchor="middle" fontSize="13" fill={INK}>
+          Money is spent only after your site is proven
+        </text>
+        <line
+          x1="16"
+          y1={V_GATE_TOP + 72}
+          x2={V_WIDTH - 16}
+          y2={V_GATE_TOP + 72}
+          stroke={ORANGE}
+          strokeWidth="4"
+          strokeDasharray="7 5"
+          strokeLinecap="round"
+        />
+        <text x={V_CENTER} y={V_GATE_TOP + 98} textAnchor="middle" fontSize="13" fill={INK}>
+          Validated live site unlocks the domain purchase
+        </text>
+      </g>
+
+      {/* Stage boxes */}
+      {diagramStages.map((stage, index) => (
+        <StageBox
+          key={stage.number}
+          stage={stage}
+          x={V_LEFT}
+          y={vStageY(index)}
+          width={V_BOX_WIDTH}
+          height={V_BOX_HEIGHT}
+          isBeforeGate={index <= 1}
+        />
+      ))}
+    </svg>
+  )
+}
+
+const JourneyDiagram = () => {
+  // useId output contains characters (":" / "«»") that are invalid inside
+  // url(#...) marker references — strip to a safe alphanumeric token.
+  const uid = useId().replace(/[^a-zA-Z0-9_-]/g, '')
+  return (
+    <>
+      <div className="hidden sm:block" data-journey-variant="horizontal">
+        <HorizontalDiagram uid={uid} />
+      </div>
+      <div className="sm:hidden" data-journey-variant="vertical">
+        <VerticalDiagram uid={uid} />
+      </div>
+    </>
   )
 }
 


### PR DESCRIPTION
Refs FreeForCharity/FFC-Cloudflare-Automation#697 (block 8 review fixes)

## Summary

**scripts/funnel-report.mjs** (operator-run; online FTPS mode was dead-on-arrival):
- **Cert verification**: the cPanel host presents a self-signed cert (the repo's own `deploy-cpanel.yml` sets `ssl:verify-certificate no` for the same host). Now defaults to `rejectUnauthorized: false` with a clear stderr note ("channel encrypted; cert not verified — matches deploy workflow behavior"), overridable via `FTP_VERIFY_CERT=1`.
- **TLS 1.3 session reuse**: `control.getSession()` does not yield resumable sessions on TLS 1.3, but Pure-FTPd requires data-connection session reuse under `PROT P`. The script now captures tickets from the control socket's `'session'` event (fires post-handshake on 1.3) and hands the latest one to the data connection; if the data handshake still fails, it retries once forcing `maxVersion: 'TLSv1.2'` on both connections (where synchronous reuse works), with the reasoning documented in the header.
- **PASV private-IP fix-up**: if the 227 address is RFC1918/loopback and differs from the control host, the control host is used instead (standard curl/lftp behavior).
- **pid-999 pollution**: pid 999 (exported `IGNORED_PIDS` list) is excluded from the funnel table/totals and reported only on a separate "synthetic/test traffic" line.

**src/components/journey/JourneyDiagram.tsx**:
- **Contrast (WCAG AA)**: 17px bold `#F58C23` on white is **2.43:1** — fails AA. All diagram orange is now `#A85400`: **5.34:1** on white for the gate label/line/strokes, and **5.34:1** for the white numerals on the (darkened) stage circles. White on FFC blue `#0567B1` is **5.86:1**; ink `#1a2e35` on white is **14.13:1**. Ratios computed with the WCAG relative-luminance formula and documented in the component header.
- **Mobile legibility**: at 375px the 1002-unit viewBox rendered 13.5-unit text at ~5px. The component now renders a horizontal variant (≥ sm) and a stacked vertical variant (< sm, 360-unit viewBox) toggled by Tailwind responsive classes on wrapper divs (media queries can't toggle Tailwind classes inside the svg). Smallest mobile text renders ≥ 11.5px even at 320px; the unit test asserts the rendered-size math for every text node.
- **Hardcoded ids → `useId`** for title/desc/marker ids (sanitized for `url(#…)` marker refs); tests assert id uniqueness across instances instead of pinning a static id.
- **`gateNote` was dead data**: it now renders as an emphasized line in the journey page stage cards, and `/why-website-first/` derives its gate cards from `journeyStages` (stage names + gateNotes from `src/data/journey.ts`; page-specific prose stays local) so the gate facts cannot drift.

## Test plan

- `npm run lint` + `npm run format:check` — clean
- `npm run build` — static export green
- `npm run test` — 49 suites, **651 passed** (new offline coverage: PASV host fix-up, TLS session selection, `IGNORED_PIDS`, 999-exclusion rendering, both diagram variants, mobile font-size math, useId uniqueness, gateNote wiring on both pages)
- `npx playwright test` — **378 passed, 24 skipped** (banned-phrase guard green)
- No live FTPS was exercised (no creds available; offline tests only)
- Visually verified both diagram variants from the built static export at 1280px and 375px

🤖 Generated with [Claude Code](https://claude.com/claude-code)
