### PR TITLE
feat: link Cloudflare account setup guide from domains page

### DIFF
--- a/src/components/domains/Verify-Your-Domain/index.tsx
+++ b/src/components/domains/Verify-Your-Domain/index.tsx
@@ -5,6 +5,8 @@ import { IoCall } from 'react-icons/io5'
 import { IoMdMail } from 'react-icons/io'
 import { hubUrl } from '@/lib/config'
 import { assetPath } from '@/lib/assetPath'
+import AdminGuideLink from '@/components/ui/AdminGuideLink'
+import { adminLinks, ffcAdminUrl } from '@/data/admin-links'
 
 const index = () => {
   return (
@@ -64,6 +66,14 @@ const index = () => {
               </p>
             </div>
           </div>
+        </div>
+
+        <div className="mb-[13px] max-w-[610px] mx-auto">
+          <AdminGuideLink
+            href={ffcAdminUrl(adminLinks['cloudflare-account'].newModel)}
+            label="Cloudflare account setup guide on FFC Admin"
+            description="New to Cloudflare? Our step-by-step guide walks you through creating your free personal account with two-factor authentication so it's ready for our invite. One important rule: don't add your domain to your personal account — we manage it for you in the FFC Cloudflare account."
+          />
         </div>
 
         {/* Bottom note */}

--- a/src/data/admin-links.ts
+++ b/src/data/admin-links.ts
@@ -47,6 +47,9 @@ export const adminLinks = {
     newModel: '/guides/microsoft-365-email/',
     legacy: '/legacy-wordpress-administration/wordpress-domains/',
   },
+  'cloudflare-account': {
+    newModel: '/guides/cloudflare-account/',
+  },
   'web-developer-training': {
     newModel: '/training/web-developer/',
     legacy: '/legacy-wordpress-administration/wordpress-web-developer-training/',


### PR DESCRIPTION
## Summary

Links the new **personal Cloudflare account setup guide** on ffcadmin.org from the `/domains/` page, so charities being onboarded know exactly how to get their account ready for FFC's invitation to the FFC Cloudflare account.

- Adds a `cloudflare-account` entry to the FFC Admin deep-links registry (`src/data/admin-links.ts`), pointing at `https://ffcadmin.org/guides/cloudflare-account/`
- Surfaces a standard `AdminGuideLink` callout in the "Your domain is managed in Cloudflare" section of `/domains/`, directly under the existing **Step 1** card ("Create a free personal Cloudflare account and send us the email address you used")
- The callout copy reinforces the two things the guide is built around: create the account **with two-factor authentication**, and **don't add your domain to the personal account** — FFC manages it in the FFC Cloudflare account

## Companion PR

The guide itself is added in FreeForCharity/FFC-IN-ffcadmin.org#648 — that PR should merge (and deploy) first so this link doesn't 404.

## Verification

- `npm run lint` — clean
- `npm run build` — static export succeeds; the callout and the `ffcadmin.org/guides/cloudflare-account/` href render in `out/domains/index.html`
- `npm run test` — 651/651 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LWjVxGLrU9hRFTZjFYJi5G

---
_Generated by [Claude Code](https://claude.ai/code/session_01LWjVxGLrU9hRFTZjFYJi5G)_