### PR TITLE
docs: mark Sentry as a pilot running on this site only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,6 @@ You may have access to these MCP servers. Use them when available:
 | **Playwright MCP** | Browser automation, screenshots, accessibility snapshots |
 | **GitHub MCP**     | Issue/PR management, repository operations               |
 | **Cloudflare MCP** | DNS records, Pages deployments, Workers                  |
-| **Sentry MCP**     | Error tracking, performance monitoring                   |
 
 Check your available tools at the start of each session. If an MCP server is available, prefer it over CLI alternatives for that domain.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,11 +50,12 @@ If any step fails, fix the issue and re-run from that step forward.
 
 You may have access to these MCP servers. Use them when available:
 
-| Server             | What It Provides                                         |
-| ------------------ | -------------------------------------------------------- |
-| **Playwright MCP** | Browser automation, screenshots, accessibility snapshots |
-| **GitHub MCP**     | Issue/PR management, repository operations               |
-| **Cloudflare MCP** | DNS records, Pages deployments, Workers                  |
+| Server             | What It Provides                                                                                                                                    |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Playwright MCP** | Browser automation, screenshots, accessibility snapshots                                                                                            |
+| **GitHub MCP**     | Issue/PR management, repository operations                                                                                                          |
+| **Cloudflare MCP** | DNS records, Pages deployments, Workers                                                                                                             |
+| **Sentry MCP**     | Error tracking, performance monitoring — PILOT: this site is the only FFC property running Sentry; it has not graduated to the wider FFC tech stack |
 
 Check your available tools at the start of each session. If an MCP server is available, prefer it over CLI alternatives for that domain.
 


### PR DESCRIPTION
## Summary

FFC is pilot-testing Sentry, and freeforcharity.org is the pilot site. The `CLAUDE.md` MCP server table now says exactly that: the Sentry MCP row is marked **PILOT — this site is the only FFC property running Sentry; it has not graduated to the wider FFC tech stack**.

(This PR originally removed the row entirely; the direction changed to a scoped pilot, so the row is restored with the pilot annotation instead.)

The Sentry mentions in `docs/CUTOVER-RUNBOOK.md` are a dated historical record and are left untouched.

## Companion PR

The matching updates on FFC-IN-ffcadmin.org (tech-stack page, developer-environment-setup page, and its `CLAUDE.md` — all noting the pilot is scoped to freeforcharity.org) are part of the setup-guides expansion PR in that repo.

## Verification

- `npm run lint` / `npm run format` — clean (docs-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LWjVxGLrU9hRFTZjFYJi5G