### PR TITLE
ci(830): add scheduled Security Audit to freeforcharity.org

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,53 @@
+name: Security Audit
+
+# Runs `npm audit` against production dependencies on a daily cadence and on
+# pull requests that touch package files. Fails on `high` or `critical`, so a
+# dependency change that introduces a known-exploitable library is caught in
+# review, and an advisory published after merge is caught by the next daily
+# run. This is a detection check, NOT a deploy gate — it does not run on every
+# push, so a red audit does not by itself block a deploy.
+#
+# Dependabot still handles the upgrades; this workflow makes sure we notice if
+# a published advisory lands between Dependabot runs.
+#
+# Ported from FFC-IN-FFC_Single_Page_Template's security-audit.yml (issue #830).
+# The cron minute is deliberately distinct from the other FFC repos' audits so
+# the fleet's scheduled runs do not stack: SPT/FOT 06:17, ffcadmin 06:47,
+# this repo 06:37.
+
+on:
+  schedule:
+    - cron: '37 6 * * *' # daily, 06:37 UTC
+  pull_request:
+    branches: ['main']
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    name: npm audit (production)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install (no scripts)
+        run: npm ci --ignore-scripts
+
+      - name: Audit high-severity production deps
+        run: npm run audit:high

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:e2e:headed": "playwright test --headed",
     "visual-regression": "node scripts/visual-regression/capture.mjs",
     "smoke-test": "node scripts/smoke-test.mjs",
+    "audit:high": "npm audit --omit=dev --audit-level=high",
     "prepare": "husky"
   },
   "dependencies": {


### PR DESCRIPTION
Closes the last gap in #830: `freeforcharity.org` was the only FFC repo left without a scheduled
production-dependency audit — and it is the main public website, the one that had been carrying
4 high advisories when #822 found them by hand.

## What this adds

| File | Change |
| --- | --- |
| `.github/workflows/security-audit.yml` | new — daily `npm audit` on production deps, plus PRs touching `package.json` / `package-lock.json`, plus `workflow_dispatch` |
| `package.json` | new `audit:high` script the workflow invokes |

Ported from `FFC-IN-FFC_Single_Page_Template`'s `security-audit.yml` (npm variant). ffcadmin got the
pnpm variant in its #699; FOT got the missing script in its #117.

**The script ships in the same commit as the workflow on purpose.** FOT's #117 uncovered a latent
trap: its workflow had been invoking `npm run audit:high` against a script that did not exist. A
workflow that cannot run its own check is worse than no workflow, because the absence reads as green.

## Design notes

- **Detection, not a deploy gate.** It does not run on every push, so a red audit does not by itself
  block a deploy — it makes sure an advisory published *between* Dependabot runs gets noticed.
- **Cron 06:37 UTC** is deliberately distinct so the fleet's audits do not stack: SPT/FOT 06:17,
  this repo 06:37, ffcadmin 06:47.
- `--ignore-scripts` on install, `contents: read` only.

## Verification

- `npm run audit:high` on this branch → **exits 0, "found 0 vulnerabilities"**. The first scheduled
  run is an expected green, not a guaranteed red — #502 merging is what made that true.
- `npx prettier --check package.json .github/workflows/security-audit.yml` → clean.
- The `package.json` diff is a single inserted line; `prepare` stays last.

Refs #830

🤖 Generated with [Claude Code](https://claude.com/claude-code)