### PR TITLE
feat: track donate/volunteer/apply conversions + Consent Mode v2

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -49,9 +49,19 @@ jobs:
       # GuideStar, GTM) is mirrored in the public/.htaccess CSP. If an
       # embed host is added or rotated anywhere, update this line too,
       # or the audit silently re-inflates with third-party bytes.
+      #
+      # Clarity and Tawk.to joined this list when the site moved to
+      # Consent Mode v2. Previously Lighthouse never dismissed the cookie
+      # banner, so NO third-party tag ever loaded during an audit; now the
+      # tags load on every pageview and consent gates storage instead.
+      # Tawk in particular injects a visible chat widget whose contrast
+      # and ARIA issues are audited as if they were first-party markup.
+      # Blocking them keeps this a first-party audit, as the step name
+      # says — it does not make the widget's own accessibility problems go
+      # away, which is tracked separately.
       - name: Block third-party embed hosts (first-party-only audit)
         run: |
-          sudo sh -c 'echo "127.0.0.1 www.zeffy.com zeffy.com zeffy-scripts.s3.ca-central-1.amazonaws.com widgets.guidestar.org www.googletagmanager.com" >> /etc/hosts'
+          sudo sh -c 'echo "127.0.0.1 www.zeffy.com zeffy.com zeffy-scripts.s3.ca-central-1.amazonaws.com widgets.guidestar.org www.googletagmanager.com www.google-analytics.com www.clarity.ms c.clarity.ms embed.tawk.to va.tawk.to vsa.tawk.to cdn.tawk.to" >> /etc/hosts'
 
       - name: Run Lighthouse CI
         run: |

--- a/__tests__/lib/analytics-delivery.test.ts
+++ b/__tests__/lib/analytics-delivery.test.ts
@@ -1,0 +1,82 @@
+/**
+ * GA4 delivery mode: exactly one path may reach the property.
+ *
+ * Under GA_DELIVERY='gtm', GTM's GA4 Event tags fire from the dataLayer
+ * push, so trackConversion() must NOT also call gtag('event', …). Doing
+ * both sends every conversion twice — and because both hits are
+ * individually valid, GA4 reports no error and the inflated numbers look
+ * entirely plausible. Nothing surfaces the mistake except reading the
+ * code or noticing conversions have suspiciously doubled, so it is worth
+ * a test that fails loudly instead.
+ *
+ * GA_DELIVERY is resolved from the environment at module load, so each
+ * case re-imports the module inside jest.isolateModules with the env set.
+ */
+
+type GtagMock = jest.Mock
+
+function loadWith(delivery: string | undefined): {
+  track: typeof import('@/lib/analytics-events').trackConversion
+  events: typeof import('@/lib/analytics-events').CONVERSION_EVENTS
+  gtag: GtagMock
+} {
+  const previous = process.env.NEXT_PUBLIC_GA_DELIVERY
+  if (delivery === undefined) delete process.env.NEXT_PUBLIC_GA_DELIVERY
+  else process.env.NEXT_PUBLIC_GA_DELIVERY = delivery
+
+  const gtag: GtagMock = jest.fn()
+  ;(window as unknown as { gtag: GtagMock }).gtag = gtag
+  ;(window as unknown as { dataLayer: unknown[] }).dataLayer = []
+
+  let mod!: typeof import('@/lib/analytics-events')
+  jest.isolateModules(() => {
+    // jest.isolateModules runs synchronously, so this has to be require()
+    // rather than a dynamic import — the point is to re-evaluate the
+    // module with a different env value, which an ESM import cannot do.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    mod = require('@/lib/analytics-events')
+  })
+
+  if (previous === undefined) delete process.env.NEXT_PUBLIC_GA_DELIVERY
+  else process.env.NEXT_PUBLIC_GA_DELIVERY = previous
+
+  return { track: mod.trackConversion, events: mod.CONVERSION_EVENTS, gtag }
+}
+
+function dataLayerEvents(): { event?: string }[] {
+  return (window as unknown as { dataLayer: { event?: string }[] }).dataLayer.filter(
+    (e) => typeof e?.event === 'string'
+  )
+}
+
+describe('GA4 delivery mode', () => {
+  it("does NOT call gtag under 'gtm' delivery — GTM forwards the dataLayer push", () => {
+    const { track, events, gtag } = loadWith('gtm')
+    track(events.DONATE_OPEN, { conversion_id: 'abc' })
+
+    expect(gtag).not.toHaveBeenCalled()
+    expect(dataLayerEvents()).toHaveLength(1)
+    expect(dataLayerEvents()[0]).toMatchObject({ event: 'donate_open', conversion_id: 'abc' })
+  })
+
+  it("calls gtag exactly once under 'direct' delivery, and still pushes to the dataLayer", () => {
+    const { track, events, gtag } = loadWith('direct')
+    track(events.DONATE_OPEN, { conversion_id: 'abc' })
+
+    expect(gtag).toHaveBeenCalledTimes(1)
+    expect(gtag).toHaveBeenCalledWith('event', 'donate_open', { conversion_id: 'abc' })
+    expect(dataLayerEvents()).toHaveLength(1)
+  })
+
+  it("defaults to 'gtm' when the env var is unset", () => {
+    const { track, events, gtag } = loadWith(undefined)
+    track(events.VOLUNTEER_APPLY)
+    expect(gtag).not.toHaveBeenCalled()
+  })
+
+  it('treats any unrecognised value as gtm rather than guessing', () => {
+    const { track, events, gtag } = loadWith('GTM')
+    track(events.VOLUNTEER_APPLY)
+    expect(gtag).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/lib/analytics-delivery.test.ts
+++ b/__tests__/lib/analytics-delivery.test.ts
@@ -68,18 +68,18 @@ describe('GA4 delivery mode', () => {
     expect(dataLayerEvents()).toHaveLength(1)
   })
 
-  // The default must be the mode that MEASURES. Under 'gtm' this site
-  // emits no GA4 itself, so defaulting there would mean a deploy that
-  // preceded the GTM publish silently measured nothing at all.
-  it("defaults to 'direct' when the env var is unset", () => {
+  // Post-cutover the default is 'gtm', matching production. Pinning it
+  // here means the suite exercises the mode production actually runs —
+  // if someone flips the default back without meaning to, these fail.
+  it("defaults to 'gtm' when the env var is unset", () => {
     const { track, events, gtag } = loadWith(undefined)
     track(events.VOLUNTEER_APPLY)
-    expect(gtag).toHaveBeenCalledTimes(1)
+    expect(gtag).not.toHaveBeenCalled()
   })
 
-  it("treats any unrecognised value as 'direct' rather than guessing", () => {
+  it("treats any unrecognised value as 'gtm' rather than guessing", () => {
     const { track, events, gtag } = loadWith('GTM')
     track(events.VOLUNTEER_APPLY)
-    expect(gtag).toHaveBeenCalledTimes(1)
+    expect(gtag).not.toHaveBeenCalled()
   })
 })

--- a/__tests__/lib/analytics-delivery.test.ts
+++ b/__tests__/lib/analytics-delivery.test.ts
@@ -68,15 +68,18 @@ describe('GA4 delivery mode', () => {
     expect(dataLayerEvents()).toHaveLength(1)
   })
 
-  it("defaults to 'gtm' when the env var is unset", () => {
+  // The default must be the mode that MEASURES. Under 'gtm' this site
+  // emits no GA4 itself, so defaulting there would mean a deploy that
+  // preceded the GTM publish silently measured nothing at all.
+  it("defaults to 'direct' when the env var is unset", () => {
     const { track, events, gtag } = loadWith(undefined)
     track(events.VOLUNTEER_APPLY)
-    expect(gtag).not.toHaveBeenCalled()
+    expect(gtag).toHaveBeenCalledTimes(1)
   })
 
-  it('treats any unrecognised value as gtm rather than guessing', () => {
+  it("treats any unrecognised value as 'direct' rather than guessing", () => {
     const { track, events, gtag } = loadWith('GTM')
     track(events.VOLUNTEER_APPLY)
-    expect(gtag).not.toHaveBeenCalled()
+    expect(gtag).toHaveBeenCalledTimes(1)
   })
 })

--- a/__tests__/lib/analytics-events.test.ts
+++ b/__tests__/lib/analytics-events.test.ts
@@ -46,8 +46,8 @@ describe('classifyConversionHref', () => {
     // These are all links the site actually renders.
     it.each([
       [
-        "Zeffy's privacy policy (linked from /cookie-policy/)",
-        'https://www.zeffy.com/en-US/privacy-policy',
+        "Zeffy's legal page on their support subdomain (linked from /cookie-policy/)",
+        'https://support.zeffy.com/legal-data-privacy-security',
       ],
       ['the Zeffy homepage with a trailing slash', 'https://www.zeffy.com/'],
       ['the Zeffy homepage without one', 'https://www.zeffy.com'],

--- a/__tests__/lib/analytics-events.test.ts
+++ b/__tests__/lib/analytics-events.test.ts
@@ -1,0 +1,150 @@
+import {
+  CONVERSION_EVENTS,
+  classifyConversionHref,
+  conversionAttrs,
+  isConversionEvent,
+} from '@/lib/analytics-events'
+
+/**
+ * The conversion classifier decides, from a URL alone, whether a click is
+ * one of the three primary conversions. It runs on every link the site
+ * renders, so both directions matter: missing a real donate link loses a
+ * conversion, and matching an unrelated link invents one.
+ *
+ * The false-positive direction is the easier one to get wrong. The site
+ * links to Zeffy's own marketing and privacy pages as well as to nine
+ * campaigns, and to ffcadmin.org for far more than volunteer roles.
+ */
+describe('classifyConversionHref', () => {
+  describe('donations', () => {
+    it.each([
+      [
+        'embed pop-up link',
+        'https://www.zeffy.com/embed/donation-form/abc-123?modal=true',
+        'abc-123',
+      ],
+      ['hosted form link', 'https://www.zeffy.com/donation-form/abc-123', 'abc-123'],
+      [
+        'ticketing campaign',
+        'https://www.zeffy.com/ticketing/free-for-charity-annual-gala',
+        'free-for-charity-annual-gala',
+      ],
+      ['membership campaign', 'https://www.zeffy.com/membership/global-admins', 'global-admins'],
+      [
+        'shop campaign',
+        'https://www.zeffy.com/shop/free-for-charitys-shop',
+        'free-for-charitys-shop',
+      ],
+      ['locale-prefixed', 'https://www.zeffy.com/en-US/donation-form/abc-123', 'abc-123'],
+      ['apex host', 'https://zeffy.com/donation-form/abc-123', 'abc-123'],
+    ])('classifies a %s as donate_open', (_label, href, expectedId) => {
+      const result = classifyConversionHref(href)
+      expect(result?.event).toBe(CONVERSION_EVENTS.DONATE_OPEN)
+      expect(result?.params.conversion_id).toBe(expectedId)
+    })
+
+    // These are all links the site actually renders.
+    it.each([
+      [
+        "Zeffy's privacy policy (linked from /cookie-policy/)",
+        'https://www.zeffy.com/en-US/privacy-policy',
+      ],
+      ['the Zeffy homepage with a trailing slash', 'https://www.zeffy.com/'],
+      ['the Zeffy homepage without one', 'https://www.zeffy.com'],
+      ['a lookalike domain', 'https://evilzeffy.com/donation-form/abc-123'],
+    ])('does NOT classify %s as a donation', (_label, href) => {
+      expect(classifyConversionHref(href)).toBeNull()
+    })
+  })
+
+  describe('volunteering', () => {
+    it('classifies an Idealist posting', () => {
+      const result = classifyConversionHref('https://www.idealist.org/en/volop/abc')
+      expect(result?.event).toBe(CONVERSION_EVENTS.VOLUNTEER_APPLY)
+    })
+
+    it('classifies an ffcadmin volunteer role and captures the role', () => {
+      const result = classifyConversionHref('https://ffcadmin.org/volunteer/web-developer/')
+      expect(result?.event).toBe(CONVERSION_EVENTS.VOLUNTEER_APPLY)
+      expect(result?.params.conversion_id).toBe('web-developer')
+    })
+
+    it('does not classify other ffcadmin pages', () => {
+      expect(classifyConversionHref('https://ffcadmin.org/continuing-education/')).toBeNull()
+    })
+  })
+
+  describe('service applications', () => {
+    it.each([
+      ['a=add&pid', 'https://freeforcharity.org/hub/cart.php?a=add&pid=16', '16'],
+      ['a=confproduct&i', 'https://freeforcharity.org/hub/cart.php?a=confproduct&i=3', '3'],
+      ['www host', 'https://www.freeforcharity.org/hub/cart.php?a=add&pid=33', '33'],
+    ])('classifies %s as service_application_start', (_label, href, expectedId) => {
+      const result = classifyConversionHref(href)
+      expect(result?.event).toBe(CONVERSION_EVENTS.SERVICE_APPLICATION_START)
+      expect(result?.params.conversion_id).toBe(expectedId)
+    })
+
+    it('ignores a cart on somebody else’s host', () => {
+      expect(
+        classifyConversionHref('https://attacker.example/hub/cart.php?a=add&pid=16')
+      ).toBeNull()
+    })
+
+    it('ignores the hub cart with no product', () => {
+      expect(classifyConversionHref('https://freeforcharity.org/hub/cart.php')).toBeNull()
+    })
+  })
+
+  describe('everything else', () => {
+    it.each([
+      ['an internal page', '/about-us/'],
+      ['the hub root', 'https://freeforcharity.org/hub/'],
+      ['an unrelated external site', 'https://example.com/donate'],
+      ['a mailto link', 'mailto:someone@freeforcharity.org'],
+      ['a malformed href', 'ht!tp://['],
+    ])('returns null for %s', (_label, href) => {
+      expect(classifyConversionHref(href)).toBeNull()
+    })
+  })
+})
+
+describe('isConversionEvent', () => {
+  it('accepts every declared event', () => {
+    Object.values(CONVERSION_EVENTS).forEach((event) => {
+      expect(isConversionEvent(event)).toBe(true)
+    })
+  })
+
+  it('rejects anything else', () => {
+    expect(isConversionEvent('page_view')).toBe(false)
+    expect(isConversionEvent('')).toBe(false)
+  })
+})
+
+describe('conversionAttrs', () => {
+  it('emits the event attribute alone when no params are given', () => {
+    expect(conversionAttrs(CONVERSION_EVENTS.DONATE_OPEN)).toEqual({
+      'data-ffc-conversion': 'donate_open',
+    })
+  })
+
+  it('omits empty optional params rather than emitting blank attributes', () => {
+    expect(
+      conversionAttrs(CONVERSION_EVENTS.DONATE_OPEN, { conversion_label: '', conversion_id: '' })
+    ).toEqual({ 'data-ffc-conversion': 'donate_open' })
+  })
+
+  it('includes params that are supplied', () => {
+    expect(
+      conversionAttrs(CONVERSION_EVENTS.SERVICE_APPLICATION_START, {
+        conversion_label: 'Apply as a 501(c)(3) charity',
+        conversion_id: '33',
+      })
+    ).toEqual({
+      'data-ffc-conversion': 'service_application_start',
+      'data-ffc-conversion-label': 'Apply as a 501(c)(3) charity',
+      'data-ffc-conversion-id': '33',
+    })
+  })
+})

--- a/docs/CONVERSION-TRACKING.md
+++ b/docs/CONVERSION-TRACKING.md
@@ -1,0 +1,175 @@
+# Conversion tracking
+
+How freeforcharity.org measures its three primary conversions, and the consent
+model that decides what reaches Google.
+
+Tracking issue:
+[#505](https://github.com/FreeForCharity/FFC-IN-freeforcharity.org/issues/505).
+GA4 Admin side:
+[FFC-Cloudflare-Automation#869](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/869).
+
+## The three conversions
+
+| Event                       | Fires when                                              | Where                                         |
+| --------------------------- | ------------------------------------------------------- | --------------------------------------------- |
+| `donate_open`               | A Zeffy campaign form is opened (pop-up button or link) | `ZeffyPopupButton`, any `zeffy.com` link      |
+| `volunteer_apply`           | A volunteer role application link is followed off-site  | Idealist postings, `ffcadmin.org/volunteer/*` |
+| `service_application_start` | A WHMCS product order form is opened                    | Every `/hub/cart.php` apply/order link        |
+
+Plus one supporting funnel step:
+
+| Event              | Fires when                                       |
+| ------------------ | ------------------------------------------------ |
+| `donate_form_view` | An embedded Zeffy form actually mounts on screen |
+
+**All three primary events must be marked as Key Events in GA4 Admin.** Emitting
+an event is not enough — an event that isn't a Key Event contributes nothing to
+`keyEvents` and shows up nowhere in conversion reporting.
+
+Done on property `386764754` on 2026-07-25, `ONCE_PER_SESSION` for all three
+(a visitor who clicks three campaign buttons is one donation intent, not three):
+
+| Key event                   | id            |
+| --------------------------- | ------------- |
+| `donate_open`               | `15324200900` |
+| `volunteer_apply`           | `15324276068` |
+| `service_application_start` | `15324231572` |
+
+Worth knowing why the property read `keyEvents: 0` for its entire history: the
+only key event configured was **`purchase`**, auto-created 2023-06-17, and this
+site has never sent a `purchase` event. The single configured conversion was one
+that could not fire.
+
+Reproducing this on other FFC properties is FFC-Cloudflare-Automation#869
+(workflow 506) — the container-per-charity model means every new GA4 property
+starts in exactly the same state.
+
+### Why these events and not "donations"
+
+Every one of the three funnels leaves this site before it completes:
+
+- **Donations** finish inside Zeffy — a cross-origin iframe on `/donate`, or
+  `zeffy.com` in a new tab. The site cannot observe the submit.
+- **Volunteering** finishes on Idealist or `ffcadmin.org`, which is a separate
+  GA4 property with no cross-domain linking configured.
+- **Service applications** finish in WHMCS at `/hub/cart.php?a=complete` — same
+  hostname, different application, no Google tag on it.
+
+So the site measures the last thing it genuinely observes: the visitor
+committing to the handoff. These are **intent** conversions, and they should be
+read that way — `donate_open` is not a donation. Completion-side tracking (a
+Zeffy thank-you redirect, a tag on the WHMCS complete page) is follow-up work.
+
+For service applications there is already an independent completion counter: the
+WHMCS-side funnel beacon in [`funnel-beacon.md`](./funnel-beacon.md) records
+`view` and `complete` per product id. Expect `service_application_start` to run
+**lower** than the beacon's `view` count — the beacon fires server-side for
+everyone, while GA4 needs consent-mode measurement and loses ad-blocked traffic.
+A large divergence means something is broken; a modest one is normal.
+
+## How events get emitted
+
+`src/lib/analytics-events.ts` is the contract. `trackConversion()` emits each
+event **twice**, on purpose:
+
+1. `gtag('event', …)` → straight into GA4, with no GTM tag to configure. Without
+   this, nothing lands in GA4 until someone hand-builds a tag in the container —
+   which is exactly the gap that left `keyEvents` at 0 for the life of the
+   property.
+2. `dataLayer.push({event: …})` → the same conversion, available as a GTM
+   trigger for Google Ads conversions, Meta, or anything wired up later.
+
+> **Do not build a GTM tag that sends these events to the same GA4 property.**
+> That double-counts. Use the dataLayer copy for other destinations only.
+
+### Tagging a CTA
+
+Most CTAs need nothing. `classifyConversionHref()` recognises the destination —
+any `zeffy.com` link, any `idealist.org` link, any `ffcadmin.org/volunteer/*`
+link, any `/hub/cart.php` order link — so new apply and donate buttons are
+tracked the moment they ship. This is deliberate: the site reaches these
+destinations from ~20 components, and hand-tagging each one guarantees the next
+new CTA is silently untracked.
+
+Add explicit attributes only when the component knows something the URL does
+not, such as a campaign name:
+
+```tsx
+import { conversionAttrs, CONVERSION_EVENTS } from '@/lib/analytics-events'
+
+<a href={…} {...conversionAttrs(CONVERSION_EVENTS.DONATE_OPEN, {
+  conversion_label: 'Website Design and Development',
+  conversion_id: 'web-design',
+})}>
+```
+
+Explicit attributes win over classification. Both paths run through one
+delegated listener (`src/components/analytics/ConversionTracking.tsx`) in the
+capture phase, so tracked buttons stay **server components** and Zeffy's own
+click handler can't swallow the event.
+
+### Parameters
+
+`conversion_label`, `conversion_id`, `conversion_source` (the page path), and
+`conversion_destination` (the destination host). Nothing identifying: what was
+clicked and where from, never who clicked it.
+
+To report on these in GA4 they must be registered as **custom dimensions**
+(Admin → Custom definitions), event-scoped, matching the parameter names above —
+otherwise they are collected but not queryable. All four were registered on
+property `386764754` on 2026-07-25, alongside the pre-existing `event_category`
+and `event_label`.
+
+## Consent model
+
+Policy: **the most permissive configuration Google allows.**
+
+Google's EU User Consent Policy binds FFC as a Google Analytics/Ads customer and
+requires opt-in consent before setting cookies or reading identifiers for
+visitors in the EEA, the UK, and Switzerland. No equivalent Google-imposed gate
+exists elsewhere. So `src/lib/consent-mode.ts` sets **Consent Mode v2** defaults:
+
+| Visitor location     | Default storage state | What GA4 does before a choice           |
+| -------------------- | --------------------- | --------------------------------------- |
+| EEA, UK, Switzerland | denied                | cookieless pings (modelled, no cookies) |
+| Everywhere else      | granted               | full cookie-based measurement           |
+
+`wait_for_update: 500` holds tags briefly so a returning visitor's stored choice
+applies before the first hit. `url_passthrough` and `ads_data_redaction` keep
+click ids usable and ad identifiers stripped while storage is denied.
+
+### What changed, and why it collects more
+
+Previously the GA4, GTM, and Clarity **scripts did not load at all** until a
+visitor clicked "Accept All" (`analytics` defaulted to `false`). Every visitor
+who ignored the banner was invisible — worldwide, not just in the EEA. That was
+strictly more restrictive than Google requires.
+
+Now the tags load on every pageview and consent controls _storage_ rather than
+_loading_:
+
+- Ignoring the banner outside the EEA/UK/CH → fully measured.
+- Ignoring it inside the EEA/UK/CH → measured cookielessly.
+- **Declining** anywhere → still measured cookielessly, rather than vanishing.
+
+The Meta Pixel remains fully gated on marketing consent: no Consent Mode
+equivalent is wired up for it, so there is no cookieless fallback and loading it
+unconsented would be a real disclosure rather than a modelled one.
+
+The bootstrap is an inline `<head>` script in `src/app/layout.tsx`, not a
+`next/script` — the consent state must already be in the dataLayer when the
+Google tags initialise, and nothing else guarantees that ordering.
+
+## Verifying
+
+- `tests/analytics-loading.spec.ts` — tags load for an undecided visitor,
+  consent defaults are present before any Google tag, declining flips storage to
+  denied.
+- `tests/conversion-events.spec.ts` — each CTA pushes the right event with the
+  right parameters.
+- GA4 **Realtime → Event count by Event name** shows the events within minutes
+  of a click on production.
+- `keyEvents` in the daily workflow 502 report
+  (`FFC-IN-ffcadmin.org/public/data/google-analytics/freeforcharity.org.json`)
+  goes non-zero once the events are marked as Key Events — that file is the
+  scoreboard for whether this actually worked.

--- a/docs/CONVERSION-TRACKING.md
+++ b/docs/CONVERSION-TRACKING.md
@@ -72,10 +72,10 @@ A large divergence means something is broken; a modest one is normal.
 `src/lib/analytics-events.ts` is the contract, and how an event reaches GA4
 depends on **`GA_DELIVERY`** in `src/lib/analytics-config.ts`:
 
-| Mode            | What `trackConversion()` does               | Where GA4 is configured                     |
-| --------------- | ------------------------------------------- | ------------------------------------------- |
-| `gtm` (default) | `dataLayer.push` **only**                   | GTM's Google tag in container `GTM-NJ4DXH9` |
-| `direct`        | `gtag('event', …)` **and** `dataLayer.push` | this site's own `gtag('config', …)`         |
+| Mode               | What `trackConversion()` does               | Where GA4 is configured                     |
+| ------------------ | ------------------------------------------- | ------------------------------------------- |
+| `direct` (default) | `gtag('event', …)` **and** `dataLayer.push` | this site's own `gtag('config', …)`         |
+| `gtm`              | `dataLayer.push` **only**                   | GTM's Google tag in container `GTM-NJ4DXH9` |
 
 Under `gtm`, GTM's GA4 Event tags listen for these event names on the dataLayer
 and forward them, so calling `gtag` as well would send each conversion twice.
@@ -94,16 +94,27 @@ cutover can be reverted without a code change if GTM misbehaves in production.
 
 ### Cutover order (issue #510)
 
-GTM publishes are instant and decoupled from the site deploy, so order matters:
+`direct` is the default on purpose. Under `gtm` this site emits no GA4 at all,
+so if that were the default, merging and deploying would stop measurement dead
+until somebody published the GTM container — and a forgotten publish means zero
+data, which is exactly the state this work exists to fix.
 
-1. Deploy the site with `GA_DELIVERY = 'gtm'`. **A brief measurement gap starts
-   here** — the site no longer fires GA4 and GTM has no live tag yet.
+GTM publishes are also instant and decoupled from the site deploy. So the
+cutover is an explicit, ordered act:
+
+1. Build with `NEXT_PUBLIC_GA_DELIVERY=gtm` (or flip the default in a one-line
+   PR) and deploy. **A brief measurement gap starts here** — the site no longer
+   fires GA4 and GTM has no live tag yet.
 2. Publish GTM container version 2. Measurement resumes; the gap closes.
 3. Verify in GA4 Realtime that pageviews and all four events arrive, and that
    counts are not doubled.
+4. Verify in Tag Assistant that a donate link carries `_gl`. Under `gtm`,
+   cross-domain comes from the `linker_domains` entry on the Google tag, which
+   is stored but unverified.
 
 Reversing 1 and 2 means both paths fire GA4 until the deploy lands, which
-double-counts every pageview for consenting visitors.
+double-counts every pageview for consenting visitors. To roll back, rebuild
+without the env var — unpublishing GTM alone would leave no GA4 at all.
 
 ### Tagging a CTA
 

--- a/docs/CONVERSION-TRACKING.md
+++ b/docs/CONVERSION-TRACKING.md
@@ -10,11 +10,11 @@ GA4 Admin side:
 
 ## The three conversions
 
-| Event                       | Fires when                                              | Where                                         |
-| --------------------------- | ------------------------------------------------------- | --------------------------------------------- |
-| `donate_open`               | A Zeffy campaign form is opened (pop-up button or link) | `ZeffyPopupButton`, any `zeffy.com` link      |
-| `volunteer_apply`           | A volunteer role application link is followed off-site  | Idealist postings, `ffcadmin.org/volunteer/*` |
-| `service_application_start` | A WHMCS product order form is opened                    | Every `/hub/cart.php` apply/order link        |
+| Event                       | Fires when                                              | Where                                          |
+| --------------------------- | ------------------------------------------------------- | ---------------------------------------------- |
+| `donate_open`               | A Zeffy campaign form is opened (pop-up button or link) | `ZeffyPopupButton`, any Zeffy **campaign** URL |
+| `volunteer_apply`           | A volunteer role application link is followed off-site  | Idealist postings, `ffcadmin.org/volunteer/*`  |
+| `service_application_start` | A WHMCS product order form is opened                    | Any `/hub/cart.php` product link on our origin |
 
 Plus one supporting funnel step:
 
@@ -84,12 +84,26 @@ event **twice**, on purpose:
 
 ### Tagging a CTA
 
-Most CTAs need nothing. `classifyConversionHref()` recognises the destination —
-any `zeffy.com` link, any `idealist.org` link, any `ffcadmin.org/volunteer/*`
-link, any `/hub/cart.php` order link — so new apply and donate buttons are
-tracked the moment they ship. This is deliberate: the site reaches these
-destinations from ~20 components, and hand-tagging each one guarantees the next
-new CTA is silently untracked.
+Most CTAs need nothing. `classifyConversionHref()` recognises the destination, so
+new apply and donate buttons are tracked the moment they ship. This is
+deliberate: the site reaches these destinations from ~20 components, and
+hand-tagging each one guarantees the next new CTA is silently untracked.
+
+What it matches, precisely:
+
+| Destination  | Matches                                                                                                                                                        | Does NOT match                                                                    |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| Zeffy        | **campaign URLs only** — `/<type>/<slug>`, optionally prefixed by a locale and/or `embed`, where type is `donation-form`, `ticketing`, `membership`, or `shop` | Zeffy's own marketing, support, and legal pages, which this site links to as well |
+| Idealist     | any `idealist.org` link                                                                                                                                        | —                                                                                 |
+| ffcadmin.org | `/volunteer/*` only                                                                                                                                            | every other ffcadmin page                                                         |
+| WHMCS        | `/hub/cart.php` with a `pid` or `i` product, **on our own origin**                                                                                             | the hub root, a cart with no product, an off-site `cart.php`                      |
+
+The Zeffy narrowing is not incidental. Matching the host alone counted the link
+to Zeffy's legal page — which [`/cookie-policy/`](../src/app/cookie-policy/page.tsx)
+renders — as donation intent, filed under a `conversion_id` taken from the policy
+URL. Host matching is exact-or-subdomain throughout, so a lookalike domain cannot
+mint conversions either. `__tests__/lib/analytics-events.test.ts` pins both
+directions.
 
 Add explicit attributes only when the component knows something the URL does
 not, such as a campaign name:

--- a/docs/CONVERSION-TRACKING.md
+++ b/docs/CONVERSION-TRACKING.md
@@ -94,12 +94,17 @@ cutover can be reverted without a code change if GTM misbehaves in production.
 
 ### Cutover order (issue #510)
 
-The cutover was performed on 2026-07-26; `gtm` is the live default. It was
-briefly defaulted to `direct` beforehand so that merging could not silently
-disable GA4 before anyone had decided to switch — an _accidental_ cutover is the
-dangerous one, since a forgotten publish leaves zero measurement.
+**`gtm` is the committed default, which means this repo alone cannot deliver
+GA4.** Under `gtm` the site emits nothing itself, so measurement is live only
+once GTM container version 2 has been **published** — a step that happens in Tag
+Manager, not here, and that no test or build in this repo can verify. Deploying
+and assuming measurement resumed is the mistake to avoid.
 
-GTM publishes are instant and decoupled from the site deploy, so the order was:
+It was briefly defaulted to `direct` before the cutover so that merging could not
+silently disable GA4 before anyone had decided to switch — an _accidental_
+cutover is the dangerous one, since a forgotten publish leaves zero measurement.
+
+GTM publishes are instant and decoupled from the site deploy, so the order is:
 
 1. Deploy with `GA_DELIVERY = 'gtm'`. **A brief measurement gap starts here** —
    the site no longer fires GA4 and GTM has no live tag yet.

--- a/docs/CONVERSION-TRACKING.md
+++ b/docs/CONVERSION-TRACKING.md
@@ -72,10 +72,10 @@ A large divergence means something is broken; a modest one is normal.
 `src/lib/analytics-events.ts` is the contract, and how an event reaches GA4
 depends on **`GA_DELIVERY`** in `src/lib/analytics-config.ts`:
 
-| Mode               | What `trackConversion()` does               | Where GA4 is configured                     |
-| ------------------ | ------------------------------------------- | ------------------------------------------- |
-| `direct` (default) | `gtag('event', …)` **and** `dataLayer.push` | this site's own `gtag('config', …)`         |
-| `gtm`              | `dataLayer.push` **only**                   | GTM's Google tag in container `GTM-NJ4DXH9` |
+| Mode                  | What `trackConversion()` does               | Where GA4 is configured                     |
+| --------------------- | ------------------------------------------- | ------------------------------------------- |
+| `gtm` (default, live) | `dataLayer.push` **only**                   | GTM's Google tag in container `GTM-NJ4DXH9` |
+| `direct`              | `gtag('event', …)` **and** `dataLayer.push` | this site's own `gtag('config', …)`         |
 
 Under `gtm`, GTM's GA4 Event tags listen for these event names on the dataLayer
 and forward them, so calling `gtag` as well would send each conversion twice.
@@ -94,17 +94,15 @@ cutover can be reverted without a code change if GTM misbehaves in production.
 
 ### Cutover order (issue #510)
 
-`direct` is the default on purpose. Under `gtm` this site emits no GA4 at all,
-so if that were the default, merging and deploying would stop measurement dead
-until somebody published the GTM container — and a forgotten publish means zero
-data, which is exactly the state this work exists to fix.
+The cutover was performed on 2026-07-26; `gtm` is the live default. It was
+briefly defaulted to `direct` beforehand so that merging could not silently
+disable GA4 before anyone had decided to switch — an _accidental_ cutover is the
+dangerous one, since a forgotten publish leaves zero measurement.
 
-GTM publishes are also instant and decoupled from the site deploy. So the
-cutover is an explicit, ordered act:
+GTM publishes are instant and decoupled from the site deploy, so the order was:
 
-1. Build with `NEXT_PUBLIC_GA_DELIVERY=gtm` (or flip the default in a one-line
-   PR) and deploy. **A brief measurement gap starts here** — the site no longer
-   fires GA4 and GTM has no live tag yet.
+1. Deploy with `GA_DELIVERY = 'gtm'`. **A brief measurement gap starts here** —
+   the site no longer fires GA4 and GTM has no live tag yet.
 2. Publish GTM container version 2. Measurement resumes; the gap closes.
 3. Verify in GA4 Realtime that pageviews and all four events arrive, and that
    counts are not doubled.
@@ -113,8 +111,12 @@ cutover is an explicit, ordered act:
    is stored but unverified.
 
 Reversing 1 and 2 means both paths fire GA4 until the deploy lands, which
-double-counts every pageview for consenting visitors. To roll back, rebuild
-without the env var — unpublishing GTM alone would leave no GA4 at all.
+double-counts every pageview for consenting visitors.
+
+**To roll back**, rebuild with `NEXT_PUBLIC_GA_DELIVERY=direct` and redeploy.
+That restores the self-contained gtag path, including the verified `linker`.
+Unpublishing the GTM version alone would leave no GA4 at all, since under `gtm`
+the site emits none itself.
 
 ### Tagging a CTA
 

--- a/docs/CONVERSION-TRACKING.md
+++ b/docs/CONVERSION-TRACKING.md
@@ -69,18 +69,41 @@ A large divergence means something is broken; a modest one is normal.
 
 ## How events get emitted
 
-`src/lib/analytics-events.ts` is the contract. `trackConversion()` emits each
-event **twice**, on purpose:
+`src/lib/analytics-events.ts` is the contract, and how an event reaches GA4
+depends on **`GA_DELIVERY`** in `src/lib/analytics-config.ts`:
 
-1. `gtag('event', …)` → straight into GA4, with no GTM tag to configure. Without
-   this, nothing lands in GA4 until someone hand-builds a tag in the container —
-   which is exactly the gap that left `keyEvents` at 0 for the life of the
-   property.
-2. `dataLayer.push({event: …})` → the same conversion, available as a GTM
-   trigger for Google Ads conversions, Meta, or anything wired up later.
+| Mode            | What `trackConversion()` does               | Where GA4 is configured                     |
+| --------------- | ------------------------------------------- | ------------------------------------------- |
+| `gtm` (default) | `dataLayer.push` **only**                   | GTM's Google tag in container `GTM-NJ4DXH9` |
+| `direct`        | `gtag('event', …)` **and** `dataLayer.push` | this site's own `gtag('config', …)`         |
 
-> **Do not build a GTM tag that sends these events to the same GA4 property.**
-> That double-counts. Use the dataLayer copy for other destinations only.
+Under `gtm`, GTM's GA4 Event tags listen for these event names on the dataLayer
+and forward them, so calling `gtag` as well would send each conversion twice.
+Under `direct`, the dataLayer copy is still pushed so GTM can drive Google Ads,
+Meta, or anything else off the same event.
+
+> **Exactly one path may reach a given GA4 property.** Both are individually
+> valid hits, so a double-count raises no error anywhere — it silently doubles
+> the numbers the charity makes decisions on.
+> `__tests__/lib/analytics-delivery.test.ts` asserts the gating in both modes,
+> and `assertGaDeliveryIsExclusive()` in `tests/analytics-loading.spec.ts`
+> asserts it end to end.
+
+The mode is overridable at build time with `NEXT_PUBLIC_GA_DELIVERY`, so the
+cutover can be reverted without a code change if GTM misbehaves in production.
+
+### Cutover order (issue #510)
+
+GTM publishes are instant and decoupled from the site deploy, so order matters:
+
+1. Deploy the site with `GA_DELIVERY = 'gtm'`. **A brief measurement gap starts
+   here** — the site no longer fires GA4 and GTM has no live tag yet.
+2. Publish GTM container version 2. Measurement resumes; the gap closes.
+3. Verify in GA4 Realtime that pageviews and all four events arrive, and that
+   counts are not doubled.
+
+Reversing 1 and 2 means both paths fire GA4 until the deploy lands, which
+double-counts every pageview for consenting visitors.
 
 ### Tagging a CTA
 

--- a/docs/CONVERSION-TRACKING.md
+++ b/docs/CONVERSION-TRACKING.md
@@ -152,9 +152,18 @@ _loading_:
 - Ignoring it inside the EEA/UK/CH → measured cookielessly.
 - **Declining** anywhere → still measured cookielessly, rather than vanishing.
 
-The Meta Pixel remains fully gated on marketing consent: no Consent Mode
-equivalent is wired up for it, so there is no cookieless fallback and loading it
-unconsented would be a real disclosure rather than a modelled one.
+Two tags are excluded from that permissive default, because Consent Mode is a
+Google protocol and neither speaks it:
+
+- **Microsoft Clarity** requires explicit analytics consent, not merely the
+  absence of a decline. It records session replays and has no cookieless mode to
+  degrade to, so an undecided EEA visitor would be fully recorded rather than
+  modelled — and the preferences dialog, which shows analytics unchecked until
+  opt-in, would be misrepresenting what is running. The cost is nil against what
+  this site needs to measure: Clarity is a heatmap/replay tool and contributes
+  nothing to the three conversion events.
+- **The Meta Pixel** stays gated on marketing consent for the same reason —
+  loading it unconsented is a real disclosure rather than a modelled one.
 
 The bootstrap is an inline `<head>` script in `src/app/layout.tsx`, not a
 `next/script` — the consent state must already be in the dataLayer when the

--- a/src/app/cookie-policy/page.tsx
+++ b/src/app/cookie-policy/page.tsx
@@ -8,7 +8,7 @@ export const metadata = pageMetadata({
 })
 
 // Update this date when the policy changes
-const LAST_UPDATED = 'November 26, 2025'
+const LAST_UPDATED = 'July 25, 2026'
 
 export default function CookiePolicy() {
   return (
@@ -54,10 +54,11 @@ export default function CookiePolicy() {
               Remember your cookie consent preferences
             </li>
             <li className="text-[14px] text-[#666] leading-[24px] font-[500]">
-              Understand how you use our website (with your consent)
+              Understand how you use our website (see section 3.2 for when your permission is
+              required)
             </li>
             <li className="text-[14px] text-[#666] leading-[24px] font-[500]">
-              Analyze website traffic and user behavior (with your consent)
+              Analyze website traffic and user behavior (see section 3.2)
             </li>
             <li className="text-[14px] text-[#666] leading-[24px] font-[500]">
               Improve our website and user experience
@@ -103,13 +104,36 @@ export default function CookiePolicy() {
 
           {/* 3.2 Analytics Cookies */}
           <p className="text-[14px] text-[#666] pb-[10px] leading-[24px] font-[500] mt-[1em]">
-            <strong>3.2 Analytics Cookies (Requires Consent)</strong>
+            <strong>3.2 Analytics Cookies</strong>
           </p>
           <p className="text-[14px] text-[#666] pb-[10px] leading-[24px] font-[500]">
             These cookies help us understand how visitors interact with our website by collecting
             and reporting information anonymously. We use this information to improve our website
             and user experience.
           </p>
+          <div className="bg-blue-50 border-l-4 border-blue-400 p-4 mb-4">
+            <p className="text-sm text-[#333] mb-2">
+              <strong>When we ask permission first</strong>
+            </p>
+            <p className="text-sm text-[#666] mb-2">
+              If you are in the European Economic Area, the United Kingdom, or Switzerland, Google
+              Analytics sets <strong>no cookies and collects no identifiers</strong> until you
+              accept. It still counts your visit in an aggregate, cookie-free way so we know how
+              many people used the site — that measurement cannot be tied back to you or to your
+              next visit.
+            </p>
+            <p className="text-sm text-[#666] mb-2">
+              Everywhere else, Google Analytics cookies are set from your first visit. You can turn
+              them off at any time using the cookie settings link in our footer, and we will delete
+              the cookies listed below when you do.
+            </p>
+            <p className="text-sm text-[#666]">
+              <strong>Microsoft Clarity is different.</strong> It records how visitors move through
+              pages, so it runs <strong>only if you explicitly accept</strong> analytics cookies —
+              everywhere in the world, not just in Europe. Declining, or simply not answering the
+              banner, keeps it off.
+            </p>
+          </div>
 
           {/* Google Analytics */}
           <div className="bg-gray-50 p-4 rounded-lg mb-4">
@@ -256,6 +280,64 @@ export default function CookiePolicy() {
             </p>
           </div>
 
+          {/* 3.4 Functional Cookies */}
+          <p className="text-[14px] text-[#666] pb-[10px] leading-[24px] font-[500] mt-[1em]">
+            <strong>3.4 Functional Cookies</strong>
+          </p>
+          <p className="text-[14px] text-[#666] pb-[10px] leading-[24px] font-[500]">
+            These support features you actively use. They are not used to build a profile of you or
+            for advertising, and because removing them would break the feature itself, they are not
+            covered by the analytics and marketing choices above.
+          </p>
+
+          {/* Tawk.to */}
+          <div className="bg-gray-50 p-4 rounded-lg mb-4">
+            <h4 className="font-semibold mb-2 text-[#333]">Tawk.to (Live Chat)</h4>
+            <p className="text-sm mb-2 text-[#666]">
+              Powers the chat widget. Its cookies keep a conversation attached to you as you move
+              between pages, so you do not lose your place mid-conversation.
+            </p>
+            <p className="text-xs mt-2 text-gray-600">
+              Privacy Policy:{' '}
+              <a
+                href="https://www.tawk.to/privacy-policy/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-600 underline"
+              >
+                https://www.tawk.to/privacy-policy/
+              </a>
+            </p>
+          </div>
+
+          {/* Zeffy */}
+          <div className="bg-gray-50 p-4 rounded-lg mb-4">
+            <h4 className="font-semibold mb-2 text-[#333]">Zeffy (Donation Forms)</h4>
+            <p className="text-sm mb-2 text-[#666]">
+              Every donation form on this site is operated by Zeffy, either embedded in the page or
+              opened on their website. Zeffy sets its own cookies when a form loads; these are
+              required for a donation to complete. What you enter into a donation form goes to
+              Zeffy, and their privacy policy governs it.
+            </p>
+            <p className="text-sm mb-2 text-[#666]">
+              We ask Zeffy to count donation-form page views in our own Google Analytics, so we can
+              see how many people reach a form and where they came from. That measurement covers
+              page views and referral sources only — we do not receive donation amounts, payment
+              details, or donor identities through analytics.
+            </p>
+            <p className="text-xs mt-2 text-gray-600">
+              Privacy Policy:{' '}
+              <a
+                href="https://www.zeffy.com/en-US/privacy-policy"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-600 underline"
+              >
+                https://www.zeffy.com/en-US/privacy-policy
+              </a>
+            </p>
+          </div>
+
           {/* Section 4 */}
           <ol className="list-decimal list-inside pb-[1em]" start={4}>
             <li>
@@ -280,12 +362,20 @@ export default function CookiePolicy() {
               <strong>Accept All:</strong> Allow all cookies including analytics and marketing
             </li>
             <li className="text-[14px] text-[#666] leading-[24px] font-[500]">
-              <strong>Decline All:</strong> Only essential cookies will be used
+              <strong>Decline All:</strong> We delete the analytics and marketing cookies listed
+              above, stop Microsoft Clarity, and set no further ones. Google Analytics keeps
+              counting your visit in an aggregate, cookie-free way that cannot identify you or
+              recognize you on a return visit — see section 3.2.
             </li>
             <li className="text-[14px] text-[#666] leading-[24px] font-[500]">
               <strong>Customize:</strong> Choose which types of cookies you want to allow
             </li>
           </ul>
+          <p className="text-[14px] text-[#666] pb-[10px] leading-[24px] font-[500]">
+            You do not have to answer the banner. If you ignore it, the rules in section 3.2 apply:
+            in Europe and the UK nothing is stored until you say yes, and Microsoft Clarity stays
+            off wherever you are.
+          </p>
 
           <p className="text-[14px] text-[#666] pb-[10px] leading-[24px] font-[500] mt-[1em]">
             <strong>4.2 Browser Settings</strong>

--- a/src/app/cookie-policy/page.tsx
+++ b/src/app/cookie-policy/page.tsx
@@ -326,14 +326,14 @@ export default function CookiePolicy() {
               details, or donor identities through analytics.
             </p>
             <p className="text-xs mt-2 text-gray-600">
-              Privacy Policy:{' '}
+              Legal &amp; Privacy:{' '}
               <a
-                href="https://www.zeffy.com/en-US/privacy-policy"
+                href="https://support.zeffy.com/legal-data-privacy-security"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-blue-600 underline"
               >
-                https://www.zeffy.com/en-US/privacy-policy
+                https://support.zeffy.com/legal-data-privacy-security
               </a>
             </p>
           </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,8 +14,10 @@ import './globals.css'
 import Header from '@/components/header'
 import Footer from '@/components/footer'
 import CookieConsent from '@/components/cookie-consent'
+import ConversionTracking from '@/components/analytics/ConversionTracking'
 import ZeffyEmbedScript from '@/components/ui/ZeffyEmbedScript'
 import { organizationJsonLd, webSiteJsonLd } from '@/lib/structured-data'
+import { CONSENT_MODE_BOOTSTRAP } from '@/lib/consent-mode'
 
 /* Fonts are self-hosted via next/font: downloaded at build time and served
    same-origin from /_next/static/media, so the browser never opens the
@@ -227,6 +229,13 @@ export default function RootLayout({
               '(function(){function at(n){n=Math.trunc(n)||0;if(n<0)n+=this.length;return n<0||n>=this.length?undefined:this[n]}var protos=[Array.prototype,String.prototype];if(typeof Int8Array==="function"){var t=Object.getPrototypeOf(Int8Array.prototype);if(t)protos.push(t)}protos.forEach(function(p){if(!p.at)Object.defineProperty(p,"at",{writable:true,configurable:true,value:at})})})()',
           }}
         />
+        {/* Google Consent Mode v2 defaults. MUST execute before any Google
+            tag loads, which is why it is an inline <head> script rather
+            than a next/script: the consent state has to already be in the
+            dataLayer when GA4/GTM initialise. Granted worldwide, denied
+            (cookieless pings) only where Google's EU User Consent Policy
+            requires opt-in. See src/lib/consent-mode.ts. */}
+        <script dangerouslySetInnerHTML={{ __html: CONSENT_MODE_BOOTSTRAP }} />
       </head>
       <body className={`antialiased`} suppressHydrationWarning={true}>
         {/* Schema.org identity for search engines (NonprofitOrganization + WebSite). */}
@@ -250,6 +259,9 @@ export default function RootLayout({
         <main id="main-content">{children}</main>
         <Footer />
         <CookieConsent />
+        {/* One delegated listener records every `data-ffc-conversion` CTA
+            click, so the tracked buttons stay server components. */}
+        <ConversionTracking />
         {/* Global Zeffy pop-up engine: wires every `zeffy-form-link` element
             (incl. the footer donate button) to open its campaign in a modal,
             site-wide. Next.js dedupes the <Script>, so pages that also use

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -17,7 +17,7 @@ export default function PrivacyPolicy() {
             <strong>Privacy Policy</strong>
           </h1>
           <p className="text-[14px] text-[#666] pb-[10px] leading-[24px] font-[500]">
-            <em>Effective Date: 11-20-2024</em>
+            <em>Effective Date: 07-25-2026</em>
           </p>
 
           {/* Section 1 */}
@@ -57,92 +57,92 @@ export default function PrivacyPolicy() {
           </ol>
 
           <p className="text-[14px] text-[#666] pb-[10px] leading-[24px] font-[500]">
-            <strong>3.1. Comments</strong>
+            <strong>3.1. Information You Send Us Directly</strong>
           </p>
           <p className="text-[14px] text-[#666] pb-[10px] leading-[24px] font-[500]">
-            When visitors leave comments on the site, we collect:
+            This website has no comment system, no user accounts, and no way to upload files, so
+            there is nothing here that collects your information as you browse. We receive personal
+            information only when you deliberately send it:
           </p>
           <ul className="list-disc list-inside space-y-[4px] pb-[1em]">
             <li className="text-[14px] text-[#666] leading-[24px] font-[500]">
-              <strong>Data from the comments form:</strong> This includes your name, email address,
-              website, and the comment itself.
+              <strong>Email:</strong> When you write to us using an address published on this site,
+              we receive whatever you choose to include in that message.
             </li>
             <li className="text-[14px] text-[#666] leading-[24px] font-[500]">
-              <strong>IP Address and Browser User Agent String:</strong> To assist with spam
-              detection and enhance security.
+              <strong>Applications for our services:</strong> Applying as a charity takes you to our
+              client portal, where you provide your organization&apos;s details so we can verify
+              eligibility and set up services.
             </li>
             <li className="text-[14px] text-[#666] leading-[24px] font-[500]">
-              <strong>Gravatar Service:</strong> An anonymized string created from your email
-              address (also called a hash) may be provided to the Gravatar service to see if you are
-              using it. After approval of your comment, your profile picture (if available) is
-              visible to the public in the context of your comment. The Gravatar service privacy
-              policy is available here: Gravatar Privacy Policy
+              <strong>Donations:</strong> Donation forms are operated by Zeffy. What you enter goes
+              to Zeffy, who pass us the donation record.
             </li>
           </ul>
 
           <p className="text-[14px] text-[#666] pb-[10px] leading-[24px] font-[500] mt-[1em]">
-            <strong>3.2. Media</strong>
+            <strong>3.2. Forms Hosted by Third Parties</strong>
           </p>
           <p className="text-[14px] text-[#666] pb-[10px] leading-[24px] font-[500]">
-            If you upload images to the website:
+            A few tasks — submitting a testimonial, reporting volunteer hours — use forms hosted by
+            Microsoft rather than built into this website. Opening one takes you to Microsoft&apos;s
+            service, and what you submit there is governed by their privacy terms as well as ours.
+            Volunteer hour reports are used to produce aggregate totals; we do not publish
+            individual submissions without asking you first.
           </p>
-          <ul className="list-inside list-disc space-y-[4px] pb-[1em]">
-            <li className="text-[14px] text-[#666] leading-[24px] font-[500]">
-              <strong>Embedded Location Data:</strong> Please avoid uploading images with embedded
-              location data (EXIF GPS) included. Visitors can download and extract any location data
-              from images on the website.
-            </li>
-          </ul>
 
           <p className="text-[14px] text-[#666] pb-[10px] leading-[24px] font-[500] mt-[1em]">
             <strong>3.3. Cookies</strong>
           </p>
           <p className="text-[14px] text-[#666] pb-[10px] leading-[24px] font-[500]">
-            Our website uses cookies to enhance your browsing experience:
+            This website is a static site. There are no user accounts, no login, and no comment
+            system, so we set no login, comment, or authoring cookies. The cookies you may encounter
+            are:
           </p>
           <ul className="list-inside list-disc space-y-[4px] pb-[1em]">
             <li className="text-[14px] text-[#666] leading-[24px] font-[500]">
-              <strong>Comments Cookies:</strong> When you leave a comment, you may opt-in to saving
-              your name, email address, and website in cookies. These are for your convenience for
-              future comments and last for one year.
+              <strong>Your cookie choice:</strong> A single cookie recording the preferences you set
+              in our cookie banner, so we do not ask again on every page. Set regardless of what you
+              choose, because it is what remembers the choice.
             </li>
             <li className="text-[14px] text-[#666] leading-[24px] font-[500]">
-              <strong>Login Cookies:</strong> When you log in, we set up cookies to save your login
-              information and screen display choices.
-              <ul className="list-disc list-inside ml-[1rem] mt-[4px] pb-[1em] space-y-[2px]">
-                <li className="text-[14px] text-[#666] leading-[24px] font-[500]">
-                  Login cookies last for two days.
-                </li>
-                <li className="text-[14px] text-[#666] leading-[24px] font-[500]">
-                  Screen options cookies last for one year.
-                </li>
-                <li className="text-[14px] text-[#666] leading-[24px] font-[500]">
-                  Selecting “Remember Me” extends login retention to two weeks.
-                </li>
-                <li className="text-[14px] text-[#666] leading-[24px] font-[500]">
-                  Logging out removes login cookies.
-                </li>
-              </ul>
+              <strong>Analytics:</strong> Google Analytics measures how the site is used. Where the
+              law requires your prior permission — the EEA, the UK, and Switzerland — it sets no
+              cookies and collects no identifiers until you accept; it still counts the visit in an
+              aggregate, cookie-free way. Elsewhere it uses cookies from your first visit, and you
+              can turn it off at any time.
             </li>
             <li className="text-[14px] text-[#666] leading-[24px] font-[500]">
-              <strong>Temporary Cookies:</strong> Visiting our login page sets a temporary cookie to
-              determine if your browser accepts cookies. It contains no personal data and is
-              discarded when you close your browser.
+              <strong>Session recording:</strong> Microsoft Clarity records how visitors move
+              through pages, and runs only if you explicitly accept analytics cookies. It is off
+              until then, everywhere in the world.
             </li>
             <li className="text-[14px] text-[#666] leading-[24px] font-[500]">
-              <strong>Editing or Publishing Articles:</strong> This sets an additional cookie in
-              your browser, indicating the post ID of the article you just edited. It expires after
-              one day.
+              <strong>Live chat:</strong> Tawk.to powers the chat widget and sets cookies so a
+              conversation survives moving between pages.
+            </li>
+            <li className="text-[14px] text-[#666] leading-[24px] font-[500]">
+              <strong>Donation forms:</strong> Our donation forms are operated by Zeffy and set
+              their own cookies when you open one. These are needed for the donation to work.
             </li>
           </ul>
+          <p className="text-[14px] text-[#666] pb-[10px] leading-[24px] font-[500]">
+            Our{' '}
+            <a href="/cookie-policy/" className="text-blue-600 underline">
+              Cookie Policy
+            </a>{' '}
+            lists each cookie by name, purpose, and how long it lasts, and you can change your
+            choice at any time from the cookie settings link in our footer.
+          </p>
 
           <p className="text-[14px] text-[#666] pb-[10px] leading-[24px] font-[500] mt-[1em]">
             <strong>3.4. Embedded Content from Other Websites</strong>
           </p>
           <p className="text-[14px] text-[#666] pb-[10px] leading-[24px] font-[500]">
-            Articles on this site may include embedded content (e.g., videos, images, articles).
-            Embedded content from other websites behaves as if you have visited the other website
-            directly. These websites may:
+            Some pages embed content operated by other organizations — most notably our donation
+            forms, which are provided by Zeffy, and charity verification badges from Candid
+            (GuideStar). Embedded content behaves as if you had visited that other website directly.
+            Those websites may:
           </p>
           <ul className="list-inside list-disc space-y-[4px] pb-[1em]">
             <li className="text-[14px] text-[#666] leading-[24px] font-[500]">
@@ -157,6 +157,13 @@ export default function PrivacyPolicy() {
               interaction if you have an account and are logged in to that website.
             </li>
           </ul>
+          <p className="text-[14px] text-[#666] pb-[10px] leading-[24px] font-[500]">
+            When you open a donation form, we ask Zeffy to count that page view in our own Google
+            Analytics so we can see how many people reach a donation form and where they came from.
+            We do not receive donation amounts, payment details, or donor identities through
+            analytics; what you enter into a donation form goes to Zeffy, and their privacy policy
+            governs it. Your donation record reaches us from Zeffy directly, not from analytics.
+          </p>
 
           {/* Section 4 */}
           <ol className="list-decimal list-inside pb-[1em]" start={4}>

--- a/src/components/analytics/ConversionTracking.tsx
+++ b/src/components/analytics/ConversionTracking.tsx
@@ -28,8 +28,18 @@ import {
 export default function ConversionTracking() {
   useEffect(() => {
     const handler = (rawEvent: Event) => {
-      const target = rawEvent.target
-      if (!(target instanceof Element)) return
+      // Normalise to an Element before walking up. In practice mouse
+      // events target elements, not text nodes, but composedPath() also
+      // gets us the real target when a click originates inside a shadow
+      // root — where `target` is retargeted to the host and `closest()`
+      // would start from the wrong node.
+      const path = typeof rawEvent.composedPath === 'function' ? rawEvent.composedPath() : []
+      const fromPath = path.find((node): node is Element => node instanceof Element)
+      const raw = rawEvent.target
+      const target =
+        fromPath ??
+        (raw instanceof Element ? raw : raw instanceof Node ? (raw.parentElement ?? null) : null)
+      if (!target) return
 
       // A middle-click that isn't a navigation (e.g. autoscroll) is noise.
       if (rawEvent instanceof MouseEvent && rawEvent.type === 'auxclick' && rawEvent.button !== 1) {

--- a/src/components/analytics/ConversionTracking.tsx
+++ b/src/components/analytics/ConversionTracking.tsx
@@ -1,0 +1,94 @@
+'use client'
+
+import { useEffect } from 'react'
+import {
+  classifyConversionHref,
+  isConversionEvent,
+  trackConversion,
+  type ConversionEvent,
+  type ConversionParams,
+} from '@/lib/analytics-events'
+
+/**
+ * One delegated listener for every tracked CTA on the site.
+ *
+ * CTAs opt in with `data-ffc-conversion` attributes (see conversionAttrs in
+ * @/lib/analytics-events) rather than an onClick handler, so the buttons
+ * themselves stay server components — the apply buttons and Zeffy pop-up
+ * triggers are plain server-rendered anchors and must remain so.
+ *
+ * Listening in the CAPTURE phase matters: Zeffy's embed script binds its
+ * own click handler to `zeffy-form-link` elements to open the modal, and
+ * capture runs before it, so the conversion is recorded whether or not
+ * Zeffy's script has loaded or decides to swallow the event.
+ *
+ * `auxclick` covers middle-click / "open in new tab", which is a real
+ * pattern for the WHMCS apply links and produces no `click` event.
+ */
+export default function ConversionTracking() {
+  useEffect(() => {
+    const handler = (rawEvent: Event) => {
+      const target = rawEvent.target
+      if (!(target instanceof Element)) return
+
+      // A middle-click that isn't a navigation (e.g. autoscroll) is noise.
+      if (rawEvent instanceof MouseEvent && rawEvent.type === 'auxclick' && rawEvent.button !== 1) {
+        return
+      }
+
+      const tagged = target.closest<HTMLElement>('[data-ffc-conversion]')
+      const anchor = target.closest<HTMLAnchorElement>('a[href]')
+
+      // An explicit tag wins; otherwise fall back to classifying the
+      // destination, which is what covers the untagged apply/donate links.
+      let event: ConversionEvent | undefined
+      let params: ConversionParams = {}
+
+      const taggedEvent = tagged?.dataset.ffcConversion
+      if (taggedEvent && isConversionEvent(taggedEvent)) {
+        event = taggedEvent
+        params = {
+          conversion_label: tagged?.dataset.ffcConversionLabel,
+          conversion_id: tagged?.dataset.ffcConversionId,
+        }
+      } else if (anchor) {
+        const classified = classifyConversionHref(anchor.href, window.location.href)
+        if (classified) {
+          event = classified.event
+          params = {
+            // The link text is the most honest label available when the
+            // component didn't supply one.
+            conversion_label: anchor.textContent?.trim().slice(0, 100) || undefined,
+            ...classified.params,
+          }
+        }
+      }
+
+      if (!event) return
+
+      let destination: string | undefined
+      if (anchor?.href) {
+        try {
+          destination = new URL(anchor.href, window.location.href).host
+        } catch {
+          destination = undefined
+        }
+      }
+
+      trackConversion(event, {
+        ...params,
+        conversion_source: window.location.pathname,
+        conversion_destination: destination,
+      })
+    }
+
+    document.addEventListener('click', handler, true)
+    document.addEventListener('auxclick', handler, true)
+    return () => {
+      document.removeEventListener('click', handler, true)
+      document.removeEventListener('auxclick', handler, true)
+    }
+  }, [])
+
+  return null
+}

--- a/src/components/analytics/ConversionTracking.tsx
+++ b/src/components/analytics/ConversionTracking.tsx
@@ -94,9 +94,19 @@ export default function ConversionTracking() {
 
     document.addEventListener('click', handler, true)
     document.addEventListener('auxclick', handler, true)
+
+    // Signal that the listener is live. Tests need a way to know clicks
+    // will be recorded, and the obvious proxies are wrong: `dataLayer`
+    // is created by the Consent Mode bootstrap in <head>, so it exists
+    // long before hydration and before this effect runs. Waiting on it
+    // would let a test click land before the listener attached and pass
+    // or fail on timing alone.
+    document.documentElement.setAttribute('data-ffc-conversion-tracking', 'ready')
+
     return () => {
       document.removeEventListener('click', handler, true)
       document.removeEventListener('auxclick', handler, true)
+      document.documentElement.removeAttribute('data-ffc-conversion-tracking')
     }
   }, [])
 

--- a/src/components/analytics/ConversionTracking.tsx
+++ b/src/components/analytics/ConversionTracking.tsx
@@ -5,7 +5,6 @@ import {
   classifyConversionHref,
   isConversionEvent,
   trackConversion,
-  type ConversionEvent,
   type ConversionParams,
 } from '@/lib/analytics-events'
 
@@ -49,32 +48,33 @@ export default function ConversionTracking() {
       const tagged = target.closest<HTMLElement>('[data-ffc-conversion]')
       const anchor = target.closest<HTMLAnchorElement>('a[href]')
 
-      // An explicit tag wins; otherwise fall back to classifying the
-      // destination, which is what covers the untagged apply/donate links.
-      let event: ConversionEvent | undefined
-      let params: ConversionParams = {}
+      // Classification runs for every conversion link, tagged or not.
+      // Explicit attributes then override it FIELD BY FIELD rather than
+      // wholesale: ZeffyPopupButton always tags `donate_open` but most
+      // call sites pass no campaignKey, and a wholesale override would
+      // replace a perfectly good URL-derived campaign slug with
+      // undefined — silently emptying conversion_id for nearly every
+      // donate CTA.
+      const classified = anchor ? classifyConversionHref(anchor.href, window.location.href) : null
 
       const taggedEvent = tagged?.dataset.ffcConversion
-      if (taggedEvent && isConversionEvent(taggedEvent)) {
-        event = taggedEvent
-        params = {
-          conversion_label: tagged?.dataset.ffcConversionLabel,
-          conversion_id: tagged?.dataset.ffcConversionId,
-        }
-      } else if (anchor) {
-        const classified = classifyConversionHref(anchor.href, window.location.href)
-        if (classified) {
-          event = classified.event
-          params = {
-            // The link text is the most honest label available when the
-            // component didn't supply one.
-            conversion_label: anchor.textContent?.trim().slice(0, 100) || undefined,
-            ...classified.params,
-          }
-        }
-      }
+      const explicitEvent = taggedEvent && isConversionEvent(taggedEvent) ? taggedEvent : undefined
 
+      const event = explicitEvent ?? classified?.event
       if (!event) return
+
+      const params: ConversionParams = {
+        // The link text is the most honest label available when neither
+        // the component nor the URL supplies one.
+        conversion_label: anchor?.textContent?.trim().slice(0, 100) || undefined,
+        ...classified?.params,
+      }
+      if (tagged?.dataset.ffcConversionLabel) {
+        params.conversion_label = tagged.dataset.ffcConversionLabel
+      }
+      if (tagged?.dataset.ffcConversionId) {
+        params.conversion_id = tagged.dataset.ffcConversionId
+      }
 
       let destination: string | undefined
       if (anchor?.href) {

--- a/src/components/cookie-consent/index.tsx
+++ b/src/components/cookie-consent/index.tsx
@@ -144,7 +144,26 @@ export default function CookieConsent() {
 
   const loadMicrosoftClarity = useCallback(() => {
     if (!CLARITY_PROJECT_ID) return
-    if (typeof window !== 'undefined' && !document.querySelector('script[src*="clarity.ms"]')) {
+    if (typeof window === 'undefined') return
+
+    // Already present? Re-injecting is a no-op, so an explicit restart is
+    // the only thing that revives it. A visitor can decline analytics
+    // (which calls clarity('stop')) and then change their mind in the
+    // same session — without this, the recorder would stay stopped until
+    // a full page reload, so the preferences dialog would show analytics
+    // ON while nothing was recording.
+    const w = window as Window & { clarity?: (...args: unknown[]) => void }
+    if (document.querySelector('script[src*="clarity.ms"]') || w.clarity) {
+      try {
+        w.clarity?.('start')
+      } catch {
+        // Clarity present but not ready to take commands — the next
+        // page load injects cleanly.
+      }
+      return
+    }
+
+    {
       const clarityScript = document.createElement('script')
       clarityScript.textContent = `
         (function(c,l,a,r,i,t,y){

--- a/src/components/cookie-consent/index.tsx
+++ b/src/components/cookie-consent/index.tsx
@@ -259,11 +259,26 @@ export default function CookieConsent() {
   }, [])
 
   const expireCookies = useCallback((names: string[]) => {
+    // A cookie can only be deleted by a request whose domain attribute
+    // MATCHES the one it was set with. GA4 scopes `_ga` to the
+    // registrable domain (`.freeforcharity.org`) so it is readable across
+    // subdomains — so on `www.freeforcharity.org`, expiring it with
+    // `domain=www.freeforcharity.org` silently does nothing and the
+    // visitor keeps the identifier they just asked us to drop.
+    //
+    // Try every scope the cookie could plausibly hold: host-only, the
+    // exact hostname, and the apex with and without a leading dot.
+    const hostname = window.location.hostname
+    const apex = hostname.replace(/^www\./, '')
+    const domains = Array.from(new Set([hostname, `.${hostname}`, apex, `.${apex}`]))
+
     names.forEach((name) => {
-      // Delete for current domain
-      document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`
-      // Also try to delete with domain specification
-      document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; domain=${window.location.hostname};`
+      const expiry = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`
+      // Host-only (no domain attribute).
+      document.cookie = expiry
+      domains.forEach((domain) => {
+        document.cookie = `${expiry} domain=${domain};`
+      })
     })
   }, [])
 

--- a/src/components/cookie-consent/index.tsx
+++ b/src/components/cookie-consent/index.tsx
@@ -8,6 +8,7 @@ import {
   CLARITY_PROJECT_ID,
   GTM_CONTAINER_ID,
   TAWK_TO_PROPERTY,
+  CROSS_DOMAIN_DOMAINS,
 } from '@/lib/analytics-config'
 import { updateGoogleConsent, type ConsentPreferences } from '@/lib/consent-mode'
 
@@ -15,6 +16,38 @@ import { updateGoogleConsent, type ConsentPreferences } from '@/lib/consent-mode
 // once in @/lib/analytics-events so every caller shares one typed queue.
 
 type CookiePreferences = ConsentPreferences
+
+const CONSENT_KEY = 'cookie-consent'
+
+/**
+ * Read the stored consent choice, preferring localStorage and falling
+ * back to the `cookie-consent` cookie.
+ *
+ * Both are written on every choice, but only localStorage was ever read.
+ * Where localStorage is unavailable — Safari private mode, storage
+ * disabled, quota exhausted — the write silently no-ops (the callers
+ * catch and carry on, noting the cookie is "the source of truth"), so on
+ * the next page load the visitor looked undecided and the banner
+ * reappeared. Their choice was sitting in the cookie the whole time,
+ * unread. Reading it back makes the fallback real rather than aspirational.
+ */
+function readStoredConsent(): string | null {
+  try {
+    const stored = localStorage.getItem(CONSENT_KEY)
+    if (stored) return stored
+  } catch {
+    // localStorage unavailable — fall through to the cookie.
+  }
+
+  if (typeof document === 'undefined') return null
+  const match = document.cookie.match(new RegExp(`(?:^|;\\s*)${CONSENT_KEY}=([^;]*)`))
+  if (!match) return null
+  try {
+    return decodeURIComponent(match[1])
+  } catch {
+    return null
+  }
+}
 
 export default function CookieConsent() {
   const [showBanner, setShowBanner] = useState(false)
@@ -50,7 +83,8 @@ export default function CookieConsent() {
         gtag('js', new Date());
         gtag('config', '${GA_MEASUREMENT_ID}', {
           'anonymize_ip': true,
-          'cookie_flags': 'SameSite=Lax${secureFlag}'
+          'cookie_flags': 'SameSite=Lax${secureFlag}',
+          'linker': { 'domains': ${JSON.stringify(CROSS_DOMAIN_DOMAINS)} }
         });
       `
       document.head.appendChild(gaConfigScript)
@@ -322,7 +356,7 @@ export default function CookieConsent() {
       }
 
       try {
-        const consent = localStorage.getItem('cookie-consent')
+        const consent = readStoredConsent()
         if (!consent) {
           fallBackToDefaults()
           return

--- a/src/components/cookie-consent/index.tsx
+++ b/src/components/cookie-consent/index.tsx
@@ -374,7 +374,11 @@ export default function CookieConsent() {
     [deleteAnalyticsCookies, deleteMarketingCookies, loadDefaultTags, loadMetaPixel, stopClarity]
   )
 
-  // Helper to load preferences from localStorage and update state
+  // Apply the visitor's stored choice, or the permissive default if they
+  // have not made one. Reads via readStoredConsent(), which prefers
+  // localStorage and falls back to the cookie-consent cookie — the name
+  // below is kept for call-site stability, but storage is not the only
+  // source.
   const loadPreferencesFromLocalStorage = useCallback(
     (showBannerIfMissing = true) => {
       // No stored choice (or an unreadable one): show the banner AND load

--- a/src/components/cookie-consent/index.tsx
+++ b/src/components/cookie-consent/index.tsx
@@ -9,6 +9,7 @@ import {
   GTM_CONTAINER_ID,
   TAWK_TO_PROPERTY,
   CROSS_DOMAIN_DOMAINS,
+  GA_DELIVERY,
 } from '@/lib/analytics-config'
 import { updateGoogleConsent, type ConsentPreferences } from '@/lib/consent-mode'
 
@@ -65,6 +66,11 @@ export default function CookieConsent() {
 
   const loadGoogleAnalytics = useCallback(() => {
     if (!GA_MEASUREMENT_ID) return
+    // Under 'gtm' delivery, GTM's Google tag loads gtag.js and configures
+    // GA4. Loading it here as well would configure the same measurement
+    // ID twice and double-count every pageview — invisibly, since both
+    // hits are individually valid. See GA_DELIVERY.
+    if (GA_DELIVERY !== 'direct') return
     if (
       typeof window !== 'undefined' &&
       !document.querySelector('script[src*="googletagmanager.com/gtag"]')

--- a/src/components/cookie-consent/index.tsx
+++ b/src/components/cookie-consent/index.tsx
@@ -159,16 +159,25 @@ export default function CookieConsent() {
    * protocol and neither of them speaks it:
    *
    *   - Microsoft Clarity records session replays and sets _clck/_clsk.
-   *     There is no cookieless mode to degrade to, so an explicit decline
-   *     must actually stop it. It still loads for undecided visitors,
-   *     matching the permissive default, but `analytics: false` keeps it
-   *     off entirely.
+   *     It requires EXPLICIT analytics consent — not merely the absence
+   *     of a decline.
    *   - The Meta Pixel stays gated on marketing consent for the same
    *     reason — loading it unconsented is a real disclosure, not a
    *     modelled one.
    *
-   * @param includeClarity false once a visitor has actively declined
-   *        analytics; true while undecided or accepted.
+   * The permissive default is scoped to what Google's own rules sanction,
+   * and Clarity is not Google's: Consent Mode gives it no cookieless
+   * fallback, so an undecided EEA visitor would be fully session-recorded
+   * rather than modelled. It would also make the UI dishonest — the
+   * preferences dialog shows analytics unchecked until a visitor opts in,
+   * while the recorder ran regardless.
+   *
+   * The cost is nil against what this site actually needs to measure:
+   * Clarity is a heatmap/replay tool and contributes nothing to the three
+   * conversion events. GA4 and GTM, which do, stay permissive.
+   *
+   * @param includeClarity true only once the visitor has explicitly
+   *        granted analytics consent.
    */
   const loadDefaultTags = useCallback(
     (includeClarity: boolean) => {
@@ -307,8 +316,9 @@ export default function CookieConsent() {
       // measurement instead of silence.
       const fallBackToDefaults = () => {
         if (showBannerIfMissing) setShowBanner(true)
-        // Undecided: permissive default, Clarity included.
-        loadDefaultTags(true)
+        // Undecided: Google tags load (Consent Mode governs their
+        // storage), Clarity does not. See loadDefaultTags.
+        loadDefaultTags(false)
       }
 
       try {

--- a/src/components/cookie-consent/index.tsx
+++ b/src/components/cookie-consent/index.tsx
@@ -417,9 +417,10 @@ export default function CookieConsent() {
       // denied. Tags that are already loaded pick it up immediately.
       updateGoogleConsent(prefs)
 
-      // GTM rides alongside GA4 — if the operator wires GA4 inside GTM
-      // via a tag, they should unset NEXT_PUBLIC_GA_MEASUREMENT_ID to
-      // avoid double-firing.
+      // GTM rides alongside GA4. Which of the two actually configures
+      // GA4 is decided by GA_DELIVERY — never by blanking a measurement
+      // ID, which would leave trackConversion() still emitting events
+      // with nothing configured to receive them.
       loadDefaultTags(prefs.analytics)
 
       if (prefs.marketing) {

--- a/src/components/cookie-consent/index.tsx
+++ b/src/components/cookie-consent/index.tsx
@@ -783,10 +783,15 @@ export default function CookieConsent() {
             </p>
             {/* Says plainly what happens if the visitor does nothing, rather
                 than implying nothing runs until they click. */}
+            {/* Says what is actually true before a choice. Avoid claiming
+                marketing "cookies" are off: outside the EEA/UK/CH the
+                Consent Mode default GRANTS ad storage. What is true is
+                that no advertising or screen-recording tag runs at all
+                until the visitor turns it on. */}
             <p className="text-sm text-gray-600 mb-3">
               If you make no choice, basic analytics still measures this visit — without cookies and
-              without identifying you in the EEA, the UK, and Switzerland. Screen-activity recording
-              and marketing cookies stay off until you turn them on.
+              without identifying you in the EEA, the UK, and Switzerland. No screen-recording or
+              advertising tools run at all until you turn them on.
             </p>
             <div className="flex items-center gap-4 text-xs text-gray-500">
               <Link href="/privacy-policy/" className="text-blue-600 underline">

--- a/src/components/cookie-consent/index.tsx
+++ b/src/components/cookie-consent/index.tsx
@@ -160,9 +160,16 @@ export default function CookieConsent() {
       !document.querySelector(`script[src*="googletagmanager.com/gtm.js"]`)
     ) {
       // Standard GTM snippet, escaped for textContent. Loads the GTM
-      // container which can itself fire GA4, Meta Pixel, Clarity, etc.
-      // via tag configuration in the GTM dashboard — avoids hard-coding
-      // those IDs in this file once an operator wires them up in GTM.
+      // container, which can itself fire GA4, Meta Pixel, Clarity, etc.
+      // via tag configuration in the GTM dashboard.
+      //
+      // Whether GA4 comes from GTM or from this file is decided by
+      // GA_DELIVERY — NOT by blanking NEXT_PUBLIC_GA_MEASUREMENT_ID, as
+      // an earlier version of this comment suggested. Clearing the ID
+      // would stop the loader here while leaving trackConversion() still
+      // calling gtag('event', …) under 'direct', queueing conversions
+      // into a dataLayer with no GA4 configured to receive them. Set
+      // GA_DELIVERY to match where GA4 is actually configured.
       const gtmScript = document.createElement('script')
       gtmScript.textContent = `
         (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':

--- a/src/components/cookie-consent/index.tsx
+++ b/src/components/cookie-consent/index.tsx
@@ -148,24 +148,53 @@ export default function CookieConsent() {
   /**
    * Load the measurement tags that run for every visitor.
    *
-   * Under Consent Mode v2 the tags themselves are not the thing consent
-   * gates — storage is. GA4, GTM, and Clarity therefore load on every
-   * pageview, and the consent state (set as a default before these ever
-   * run, then updated on any banner choice) decides whether they may use
-   * cookies. An EEA visitor who never touches the banner is measured via
-   * cookieless pings; a visitor who declines is measured the same way.
+   * Under Consent Mode v2 the GOOGLE tags are not the thing consent gates
+   * — storage is. GA4 and GTM therefore load on every pageview, and the
+   * consent state (set as a default before they ever run, then updated on
+   * any banner choice) decides whether they may use cookies. An EEA
+   * visitor who never touches the banner is measured via cookieless
+   * pings; a visitor who declines is measured the same way.
    *
-   * Only the Meta Pixel stays fully gated: it has no Consent Mode
-   * equivalent wired up here, so there is no cookieless mode to fall back
-   * to and loading it without marketing consent would be a real
-   * disclosure, not a modelled one.
+   * Two tags do NOT get that treatment, because Consent Mode is a Google
+   * protocol and neither of them speaks it:
+   *
+   *   - Microsoft Clarity records session replays and sets _clck/_clsk.
+   *     There is no cookieless mode to degrade to, so an explicit decline
+   *     must actually stop it. It still loads for undecided visitors,
+   *     matching the permissive default, but `analytics: false` keeps it
+   *     off entirely.
+   *   - The Meta Pixel stays gated on marketing consent for the same
+   *     reason — loading it unconsented is a real disclosure, not a
+   *     modelled one.
+   *
+   * @param includeClarity false once a visitor has actively declined
+   *        analytics; true while undecided or accepted.
    */
-  const loadDefaultTags = useCallback(() => {
-    loadGoogleTagManager()
-    loadGoogleAnalytics()
-    loadMicrosoftClarity()
-    loadTawkTo()
-  }, [loadGoogleTagManager, loadGoogleAnalytics, loadMicrosoftClarity, loadTawkTo])
+  const loadDefaultTags = useCallback(
+    (includeClarity: boolean) => {
+      loadGoogleTagManager()
+      loadGoogleAnalytics()
+      if (includeClarity) loadMicrosoftClarity()
+      loadTawkTo()
+    },
+    [loadGoogleTagManager, loadGoogleAnalytics, loadMicrosoftClarity, loadTawkTo]
+  )
+
+  /**
+   * Halt Clarity mid-session. Tags now load before the first banner
+   * interaction, so a visitor can be part-way through a recorded session
+   * when they decline — deleting the cookies is not enough on its own,
+   * the recorder has to be told to stop.
+   */
+  const stopClarity = useCallback(() => {
+    if (typeof window === 'undefined') return
+    const w = window as Window & { clarity?: (...args: unknown[]) => void }
+    try {
+      w.clarity?.('stop')
+    } catch {
+      // Clarity not loaded, or already stopped — nothing to do.
+    }
+  }, [])
 
   const deleteAnalyticsCookies = useCallback(() => {
     // List of static cookie names to delete
@@ -195,21 +224,30 @@ export default function CookieConsent() {
   }, [])
 
   const applyConsent = useCallback(
-    (prefs: CookiePreferences, previousPrefs?: CookiePreferences) => {
+    (prefs: CookiePreferences) => {
       // Set a cookie to indicate consent status with Secure flag (only on HTTPS)
       const cookieValue = JSON.stringify(prefs)
       const secureFlag =
         typeof window !== 'undefined' && window.location.protocol === 'https:' ? '; Secure' : ''
       document.cookie = `cookie-consent=${encodeURIComponent(cookieValue)}; path=/; max-age=31536000; SameSite=Lax${secureFlag}`
 
-      // Check if consent was withdrawn and delete cookies if needed
-      if (previousPrefs) {
-        if (
-          (previousPrefs.analytics && !prefs.analytics) ||
-          (previousPrefs.marketing && !prefs.marketing)
-        ) {
-          deleteAnalyticsCookies()
-        }
+      // Clear third-party cookies whenever the resulting state denies a
+      // category — NOT only when it differs from a previous choice.
+      //
+      // This used to be gated on `previousPrefs`, which was safe while
+      // nothing loaded before an explicit opt-in: with no tags, there
+      // were no cookies to clear. Now that tags load on the first
+      // pageview, a first-time visitor can already hold _ga/_clck cookies
+      // when they open preferences and switch analytics off, and that
+      // path passes a `previousPrefs` whose analytics is already false —
+      // so the old condition found "no withdrawal" and left the cookies
+      // in place. The parameter is gone entirely — the resulting state
+      // is the only thing that matters.
+      if (!prefs.analytics || !prefs.marketing) {
+        deleteAnalyticsCookies()
+      }
+      if (!prefs.analytics) {
+        stopClarity()
       }
 
       // Push consent update to GTM dataLayer
@@ -233,13 +271,13 @@ export default function CookieConsent() {
       // GTM rides alongside GA4 — if the operator wires GA4 inside GTM
       // via a tag, they should unset NEXT_PUBLIC_GA_MEASUREMENT_ID to
       // avoid double-firing.
-      loadDefaultTags()
+      loadDefaultTags(prefs.analytics)
 
       if (prefs.marketing) {
         loadMetaPixel()
       }
     },
-    [deleteAnalyticsCookies, loadDefaultTags, loadMetaPixel]
+    [deleteAnalyticsCookies, loadDefaultTags, loadMetaPixel, stopClarity]
   )
 
   // Helper to load preferences from localStorage and update state
@@ -252,7 +290,8 @@ export default function CookieConsent() {
       // measurement instead of silence.
       const fallBackToDefaults = () => {
         if (showBannerIfMissing) setShowBanner(true)
-        loadDefaultTags()
+        // Undecided: permissive default, Clarity included.
+        loadDefaultTags(true)
       }
 
       try {
@@ -369,7 +408,7 @@ export default function CookieConsent() {
       // exceeded, disabled storage), continue anyway — the consent
       // cookie set by applyConsent() is the source of truth.
     }
-    applyConsent(allAccepted, savedPreferencesBackup)
+    applyConsent(allAccepted)
     setSavedPreferencesBackup(allAccepted)
     setShowBanner(false)
   }
@@ -393,7 +432,7 @@ export default function CookieConsent() {
     // Delete third-party cookies when consent is withdrawn
     deleteAnalyticsCookies()
 
-    applyConsent(onlyNecessary, savedPreferencesBackup)
+    applyConsent(onlyNecessary)
     setSavedPreferencesBackup(onlyNecessary)
     setShowBanner(false)
   }
@@ -406,7 +445,7 @@ export default function CookieConsent() {
       // exceeded, disabled storage), continue anyway — the consent
       // cookie set by applyConsent() is the source of truth.
     }
-    applyConsent(preferences, savedPreferencesBackup)
+    applyConsent(preferences)
     setSavedPreferencesBackup(preferences)
     setShowBanner(false)
     setShowPreferences(false)

--- a/src/components/cookie-consent/index.tsx
+++ b/src/components/cookie-consent/index.tsx
@@ -9,27 +9,12 @@ import {
   GTM_CONTAINER_ID,
   TAWK_TO_PROPERTY,
 } from '@/lib/analytics-config'
+import { updateGoogleConsent, type ConsentPreferences } from '@/lib/consent-mode'
 
-// Define type for GTM dataLayer events
-interface DataLayerEvent {
-  event: string
-  [key: string]: string | number | boolean | undefined
-}
+// The Window globals (dataLayer, gtag, openCookiePreferences) are declared
+// once in @/lib/analytics-events so every caller shares one typed queue.
 
-// Extend Window interface to include dataLayer and openCookiePreferences
-declare global {
-  interface Window {
-    dataLayer: DataLayerEvent[]
-    openCookiePreferences?: () => void
-  }
-}
-
-interface CookiePreferences {
-  necessary: boolean
-  functional: boolean
-  analytics: boolean
-  marketing: boolean
-}
+type CookiePreferences = ConsentPreferences
 
 export default function CookieConsent() {
   const [showBanner, setShowBanner] = useState(false)
@@ -160,6 +145,28 @@ export default function CookieConsent() {
     }
   }, [])
 
+  /**
+   * Load the measurement tags that run for every visitor.
+   *
+   * Under Consent Mode v2 the tags themselves are not the thing consent
+   * gates — storage is. GA4, GTM, and Clarity therefore load on every
+   * pageview, and the consent state (set as a default before these ever
+   * run, then updated on any banner choice) decides whether they may use
+   * cookies. An EEA visitor who never touches the banner is measured via
+   * cookieless pings; a visitor who declines is measured the same way.
+   *
+   * Only the Meta Pixel stays fully gated: it has no Consent Mode
+   * equivalent wired up here, so there is no cookieless mode to fall back
+   * to and loading it without marketing consent would be a real
+   * disclosure, not a modelled one.
+   */
+  const loadDefaultTags = useCallback(() => {
+    loadGoogleTagManager()
+    loadGoogleAnalytics()
+    loadMicrosoftClarity()
+    loadTawkTo()
+  }, [loadGoogleTagManager, loadGoogleAnalytics, loadMicrosoftClarity, loadTawkTo])
+
   const deleteAnalyticsCookies = useCallback(() => {
     // List of static cookie names to delete
     const cookiesToDelete = ['_ga', '_gid', '_fbp', 'fr', '_clck', '_clsk']
@@ -216,50 +223,49 @@ export default function CookieConsent() {
         })
       }
 
-      // Load scripts based on consent independently. GTM rides alongside
-      // GA4 — if the operator has wired GA4 inside GTM via a tag, they
-      // should unset NEXT_PUBLIC_GA_MEASUREMENT_ID to avoid double-firing.
-      // The dataLayer consent_update event above fires regardless so any
-      // GTM-managed tags can read the current consent state.
-      if (prefs.analytics) {
-        loadGoogleTagManager()
-        loadGoogleAnalytics()
-        loadMicrosoftClarity()
-      }
+      // Tell the Google tags what the visitor actually chose. This must
+      // happen before (or alongside) loading them: for an EEA/UK/CH
+      // visitor it is what lifts the regional denied-by-default state,
+      // and for a declining visitor anywhere it is what drops storage to
+      // denied. Tags that are already loaded pick it up immediately.
+      updateGoogleConsent(prefs)
+
+      // GTM rides alongside GA4 — if the operator wires GA4 inside GTM
+      // via a tag, they should unset NEXT_PUBLIC_GA_MEASUREMENT_ID to
+      // avoid double-firing.
+      loadDefaultTags()
+
       if (prefs.marketing) {
         loadMetaPixel()
       }
-      // Tawk.to live-chat sits under functional consent (visitor-support
-      // tool, not analytics). Functional is always-on per cookie banner,
-      // so this loads unconditionally when a property is configured.
-      if (prefs.functional) {
-        loadTawkTo()
-      }
     },
-    [
-      deleteAnalyticsCookies,
-      loadGoogleAnalytics,
-      loadGoogleTagManager,
-      loadMetaPixel,
-      loadMicrosoftClarity,
-      loadTawkTo,
-    ]
+    [deleteAnalyticsCookies, loadDefaultTags, loadMetaPixel]
   )
 
   // Helper to load preferences from localStorage and update state
   const loadPreferencesFromLocalStorage = useCallback(
     (showBannerIfMissing = true) => {
+      // No stored choice (or an unreadable one): show the banner AND load
+      // the tags. The Consent Mode defaults already in the dataLayer
+      // decide what those tags may store — granted outside the EEA/UK/CH,
+      // cookieless pings inside it — so an ignored banner still produces
+      // measurement instead of silence.
+      const fallBackToDefaults = () => {
+        if (showBannerIfMissing) setShowBanner(true)
+        loadDefaultTags()
+      }
+
       try {
         const consent = localStorage.getItem('cookie-consent')
         if (!consent) {
-          if (showBannerIfMissing) setShowBanner(true)
+          fallBackToDefaults()
           return
         }
         let savedPreferences: CookiePreferences
         try {
           savedPreferences = JSON.parse(consent)
         } catch {
-          if (showBannerIfMissing) setShowBanner(true)
+          fallBackToDefaults()
           return
         }
 
@@ -282,14 +288,14 @@ export default function CookieConsent() {
           applyConsent(updatedPreferences)
         } else {
           // Invalid data, show banner again
-          if (showBannerIfMissing) setShowBanner(true)
+          fallBackToDefaults()
         }
       } catch {
         // If localStorage is unavailable or data is corrupted, show banner
-        if (showBannerIfMissing) setShowBanner(true)
+        fallBackToDefaults()
       }
     },
-    [applyConsent]
+    [applyConsent, loadDefaultTags]
   )
 
   const handleCancelPreferences = useCallback(() => {

--- a/src/components/cookie-consent/index.tsx
+++ b/src/components/cookie-consent/index.tsx
@@ -21,18 +21,6 @@ type CookiePreferences = ConsentPreferences
 const CONSENT_KEY = 'cookie-consent'
 
 /**
- * Read the stored consent choice, preferring localStorage and falling
- * back to the `cookie-consent` cookie.
- *
- * Both are written on every choice, but only localStorage was ever read.
- * Where localStorage is unavailable — Safari private mode, storage
- * disabled, quota exhausted — the write silently no-ops (the callers
- * catch and carry on, noting the cookie is "the source of truth"), so on
- * the next page load the visitor looked undecided and the banner
- * reappeared. Their choice was sitting in the cookie the whole time,
- * unread. Reading it back makes the fallback real rather than aspirational.
- */
-/**
  * `; domain=.<apex>` for the consent cookie, or '' where that would be
  * invalid.
  *
@@ -55,6 +43,22 @@ function consentCookieDomain(): string {
   return `; domain=.${host.replace(/^www\./, '')}`
 }
 
+/**
+ * Read the stored consent choice, preferring localStorage and falling
+ * back to the `cookie-consent` cookie.
+ *
+ * Both are written on every choice, but only localStorage was ever read.
+ * Where localStorage is unavailable — Safari private mode, storage
+ * disabled, quota exhausted — the write silently no-ops (the callers
+ * catch and carry on, noting the cookie is "the source of truth"), so on
+ * the next page load the visitor looked undecided and the banner
+ * reappeared. Their choice was sitting in the cookie the whole time,
+ * unread.
+ *
+ * The cookie is also the only path that carries a choice between
+ * `freeforcharity.org` and `www.freeforcharity.org`, since localStorage
+ * is origin-scoped and both hosts serve this site.
+ */
 function readStoredConsent(): string | null {
   try {
     const stored = localStorage.getItem(CONSENT_KEY)

--- a/src/components/cookie-consent/index.tsx
+++ b/src/components/cookie-consent/index.tsx
@@ -585,6 +585,19 @@ export default function CookieConsent() {
                 collecting and reporting information anonymously. We use Google Analytics and
                 Microsoft Clarity.
               </p>
+              {/* The toggle alone would misrepresent the starting state: until
+                  a visitor chooses, Google Analytics already uses cookies
+                  outside the EEA/UK/Switzerland, while Clarity is off
+                  everywhere. Region can't be detected here — Consent Mode
+                  applies it inside Google's tag — so the honest thing is to
+                  state both rules plainly rather than pre-tick a box that
+                  would be wrong for one group or the other. */}
+              <p className="text-sm text-gray-600 mb-2">
+                <strong>Before you choose:</strong> Google Analytics is already running. In the EEA,
+                the UK, and Switzerland it sets no cookies and cannot identify you until you switch
+                this on. Elsewhere it uses cookies until you switch it off. Microsoft Clarity, which
+                records screen activity, stays off everywhere until you switch this on.
+              </p>
               <p className="text-xs text-gray-500">Services: Google Analytics, Microsoft Clarity</p>
             </div>
 
@@ -647,6 +660,13 @@ export default function CookieConsent() {
               certain features. By clicking &quot;Accept All&quot;, you consent to our use of
               cookies for analytics and marketing purposes. You can manage your preferences or
               decline non-essential cookies.
+            </p>
+            {/* Says plainly what happens if the visitor does nothing, rather
+                than implying nothing runs until they click. */}
+            <p className="text-sm text-gray-600 mb-3">
+              If you make no choice, basic analytics still measures this visit — without cookies and
+              without identifying you in the EEA, the UK, and Switzerland. Screen-activity recording
+              and marketing cookies stay off until you turn them on.
             </p>
             <div className="flex items-center gap-4 text-xs text-gray-500">
               <Link href="/privacy-policy/" className="text-blue-600 underline">

--- a/src/components/cookie-consent/index.tsx
+++ b/src/components/cookie-consent/index.tsx
@@ -32,6 +32,29 @@ const CONSENT_KEY = 'cookie-consent'
  * reappeared. Their choice was sitting in the cookie the whole time,
  * unread. Reading it back makes the fallback real rather than aspirational.
  */
+/**
+ * `; domain=.<apex>` for the consent cookie, or '' where that would be
+ * invalid.
+ *
+ * A domain attribute is rejected outright for `localhost` and bare IP
+ * hosts — which is exactly what the dev server and the Playwright suite
+ * run on, so getting this wrong would silently stop consent persisting
+ * anywhere except production. Returning '' there keeps the cookie
+ * host-only, which is correct when there are no sibling hosts to share
+ * it with.
+ */
+function consentCookieDomain(): string {
+  if (typeof window === 'undefined') return ''
+  const host = window.location.hostname
+
+  // IPv6 arrives bracketed or colon-separated; IPv4 is four dotted octets.
+  if (host.includes(':') || /^\d{1,3}(\.\d{1,3}){3}$/.test(host)) return ''
+  // Single-label hosts (localhost, a container name) cannot take a domain.
+  if (!host.includes('.')) return ''
+
+  return `; domain=.${host.replace(/^www\./, '')}`
+}
+
 function readStoredConsent(): string | null {
   try {
     const stored = localStorage.getItem(CONSENT_KEY)
@@ -327,7 +350,22 @@ export default function CookieConsent() {
       const cookieValue = JSON.stringify(prefs)
       const secureFlag =
         typeof window !== 'undefined' && window.location.protocol === 'https:' ? '; Secure' : ''
-      document.cookie = `cookie-consent=${encodeURIComponent(cookieValue)}; path=/; max-age=31536000; SameSite=Lax${secureFlag}`
+      // Scope the choice to the registrable domain so it is shared across
+      // hosts. Both `freeforcharity.org` and `www.freeforcharity.org`
+      // serve the site (verified: each returns 200 with no redirect), and
+      // a host-only cookie is not visible to the other one. That is not
+      // just a repeated banner — a visitor who DECLINED on www would be
+      // treated as undecided on the apex, and analytics would run again
+      // against their stated choice. localStorage cannot fix this: it is
+      // origin-scoped, so the shared cookie is the only mechanism, which
+      // is what readStoredConsent() falls back to on the other host.
+      const domainAttr = consentCookieDomain()
+      if (domainAttr) {
+        // Drop any pre-existing host-only copy first, or it shadows the
+        // shared one and keeps serving a stale choice.
+        document.cookie = `${CONSENT_KEY}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`
+      }
+      document.cookie = `${CONSENT_KEY}=${encodeURIComponent(cookieValue)}; path=/; max-age=31536000; SameSite=Lax${secureFlag}${domainAttr}`
 
       // Clear third-party cookies whenever the resulting state denies a
       // category — NOT only when it differs from a previous choice, and

--- a/src/components/cookie-consent/index.tsx
+++ b/src/components/cookie-consent/index.tsx
@@ -196,32 +196,47 @@ export default function CookieConsent() {
     }
   }, [])
 
-  const deleteAnalyticsCookies = useCallback(() => {
-    // List of static cookie names to delete
-    const cookiesToDelete = ['_ga', '_gid', '_fbp', 'fr', '_clck', '_clsk']
-
-    // Delete static cookies
-    cookiesToDelete.forEach((name) => {
+  const expireCookies = useCallback((names: string[]) => {
+    names.forEach((name) => {
       // Delete for current domain
       document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`
       // Also try to delete with domain specification
       document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; domain=${window.location.hostname};`
     })
+  }, [])
+
+  /**
+   * Analytics cookies only — GA4 (`_ga`, `_gid`, `_ga_<stream>`) and
+   * Clarity (`_clck`, `_clsk`).
+   *
+   * Kept strictly separate from the marketing set. These used to be one
+   * list, which was harmless when deletion only ran on an actual
+   * withdrawal, but this component now re-applies stored consent on EVERY
+   * page load: a visitor who accepts analytics and declines marketing
+   * would have had their `_ga` client id wiped on every pageview,
+   * resetting visitor identity continuously and inflating new-user counts
+   * — the precise opposite of what their choice asked for.
+   */
+  const deleteAnalyticsCookies = useCallback(() => {
+    expireCookies(['_ga', '_gid', '_clck', '_clsk'])
 
     // Dynamically delete all cookies matching _ga_* (e.g., _ga_G-XXXXXXXXXX)
     if (typeof document !== 'undefined') {
       const regex = /(?:^|;\s*)(_ga_[^=;\s]*)/g
       let match: RegExpExecArray | null
       const cookieStr = document.cookie
+      const found: string[] = []
       while ((match = regex.exec(cookieStr)) !== null) {
-        const cookieName = match[1]
-        // Delete for current domain
-        document.cookie = `${cookieName}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`
-        // Also try to delete with domain specification
-        document.cookie = `${cookieName}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; domain=${window.location.hostname};`
+        found.push(match[1])
       }
+      expireCookies(found)
     }
-  }, [])
+  }, [expireCookies])
+
+  /** Meta Pixel cookies only. */
+  const deleteMarketingCookies = useCallback(() => {
+    expireCookies(['_fbp', 'fr'])
+  }, [expireCookies])
 
   const applyConsent = useCallback(
     (prefs: CookiePreferences) => {
@@ -232,22 +247,24 @@ export default function CookieConsent() {
       document.cookie = `cookie-consent=${encodeURIComponent(cookieValue)}; path=/; max-age=31536000; SameSite=Lax${secureFlag}`
 
       // Clear third-party cookies whenever the resulting state denies a
-      // category — NOT only when it differs from a previous choice.
+      // category — NOT only when it differs from a previous choice, and
+      // strictly per category.
       //
-      // This used to be gated on `previousPrefs`, which was safe while
-      // nothing loaded before an explicit opt-in: with no tags, there
-      // were no cookies to clear. Now that tags load on the first
-      // pageview, a first-time visitor can already hold _ga/_clck cookies
-      // when they open preferences and switch analytics off, and that
-      // path passes a `previousPrefs` whose analytics is already false —
-      // so the old condition found "no withdrawal" and left the cookies
-      // in place. The parameter is gone entirely — the resulting state
-      // is the only thing that matters.
-      if (!prefs.analytics || !prefs.marketing) {
-        deleteAnalyticsCookies()
-      }
+      // This used to be gated on a `previousPrefs` argument, which was
+      // safe while nothing loaded before an explicit opt-in: with no
+      // tags, there were no cookies to clear. Now that tags load on the
+      // first pageview, a first-time visitor can already hold _ga/_clck
+      // cookies when they open preferences and switch analytics off, and
+      // that path passed a previousPrefs whose analytics was already
+      // false — so the old condition found "no withdrawal" and left the
+      // cookies in place. The resulting state is the only thing that
+      // matters now.
       if (!prefs.analytics) {
+        deleteAnalyticsCookies()
         stopClarity()
+      }
+      if (!prefs.marketing) {
+        deleteMarketingCookies()
       }
 
       // Push consent update to GTM dataLayer
@@ -277,7 +294,7 @@ export default function CookieConsent() {
         loadMetaPixel()
       }
     },
-    [deleteAnalyticsCookies, loadDefaultTags, loadMetaPixel, stopClarity]
+    [deleteAnalyticsCookies, deleteMarketingCookies, loadDefaultTags, loadMetaPixel, stopClarity]
   )
 
   // Helper to load preferences from localStorage and update state
@@ -429,9 +446,10 @@ export default function CookieConsent() {
       // cookie set by applyConsent() is the source of truth.
     }
 
-    // Delete third-party cookies when consent is withdrawn
-    deleteAnalyticsCookies()
-
+    // Cookie clearing lives in applyConsent, which now handles BOTH
+    // categories from the resulting state. Calling it here as well would
+    // only have covered analytics, leaving the marketing cookies a
+    // "Decline All" is most obviously meant to remove.
     applyConsent(onlyNecessary)
     setSavedPreferencesBackup(onlyNecessary)
     setShowBanner(false)

--- a/src/components/cookie-consent/index.tsx
+++ b/src/components/cookie-consent/index.tsx
@@ -59,19 +59,48 @@ function consentCookieDomain(): string {
  * `freeforcharity.org` and `www.freeforcharity.org`, since localStorage
  * is origin-scoped and both hosts serve this site.
  */
-function readStoredConsent(): string | null {
-  try {
-    const stored = localStorage.getItem(CONSENT_KEY)
-    if (stored) return stored
-  } catch {
-    // localStorage unavailable — fall through to the cookie.
-  }
-
+function readConsentCookie(): string | null {
   if (typeof document === 'undefined') return null
-  const match = document.cookie.match(new RegExp(`(?:^|;\\s*)${CONSENT_KEY}=([^;]*)`))
-  if (!match) return null
+
+  // There can legitimately be more than one cookie of this name in
+  // flight — a host-only copy left by a build that predates domain
+  // scoping, alongside the shared one. Take the first that actually
+  // parses, rather than assuming position implies freshness.
+  const pattern = new RegExp(`(?:^|;\\s*)${CONSENT_KEY}=([^;]*)`, 'g')
+  const jar = document.cookie
+  let match: RegExpExecArray | null
+  while ((match = pattern.exec(jar)) !== null) {
+    try {
+      const value = decodeURIComponent(match[1])
+      JSON.parse(value)
+      return value
+    } catch {
+      // Malformed or truncated copy — try the next one.
+    }
+  }
+  return null
+}
+
+function readStoredConsent(): string | null {
+  // COOKIE FIRST, localStorage only as a fallback.
+  //
+  // localStorage is per-ORIGIN, so `freeforcharity.org` and
+  // `www.freeforcharity.org` keep separate copies that never sync. If it
+  // were preferred, this would happen: accept on the apex, later decline
+  // on www (cookie updated, shared), then return to the apex — whose
+  // localStorage still says accepted, and wins. The site would run
+  // analytics against a decline the visitor had already made, on a host
+  // they had already made it on.
+  //
+  // The cookie is the only copy both hosts share and the only one that
+  // reflects the most recent choice wherever it was made, so it is
+  // authoritative. localStorage remains a fallback for the case the
+  // cookie cannot be read at all.
+  const fromCookie = readConsentCookie()
+  if (fromCookie) return fromCookie
+
   try {
-    return decodeURIComponent(match[1])
+    return localStorage.getItem(CONSENT_KEY)
   } catch {
     return null
   }

--- a/src/components/ui/LazyZeffyIframe.tsx
+++ b/src/components/ui/LazyZeffyIframe.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useRef, useState, IframeHTMLAttributes } from 'react'
 import { zeffyHostedUrl } from '@/data/donation-campaigns'
-import { CONVERSION_EVENTS, trackConversion } from '@/lib/analytics-events'
+import { CONVERSION_EVENTS, classifyConversionHref, trackConversion } from '@/lib/analytics-events'
 
 export interface ZeffyIframeProps extends IframeHTMLAttributes<HTMLIFrameElement> {
   allowpaymentrequest?: string
@@ -71,8 +71,14 @@ const LazyZeffyIframe = (props: ZeffyIframeProps) => {
    */
   useEffect(() => {
     if (!mounted) return
+    // Derive the campaign id the same way tracked LINKS to Zeffy do, so
+    // the two agree in GA4. Splitting the raw src on '/' would keep the
+    // query string (embed URLs carry `?modal=true`) and yield an empty
+    // segment for a trailing slash — both of which fragment the
+    // conversion_id dimension and break aggregation by campaign.
+    const classified = typeof props.src === 'string' ? classifyConversionHref(props.src) : null
     trackConversion(CONVERSION_EVENTS.DONATE_FORM_VIEW, {
-      conversion_id: typeof props.src === 'string' ? props.src.split('/').pop() : undefined,
+      conversion_id: classified?.params.conversion_id,
       conversion_label: props.title,
     })
   }, [mounted, props.src, props.title])

--- a/src/components/ui/LazyZeffyIframe.tsx
+++ b/src/components/ui/LazyZeffyIframe.tsx
@@ -30,6 +30,7 @@ const PRELOAD_MARGIN_PX = 800
 
 const LazyZeffyIframe = (props: ZeffyIframeProps) => {
   const hostRef = useRef<HTMLDivElement>(null)
+  const hasTrackedViewRef = useRef(false)
   const [mounted, setMounted] = useState(false)
 
   useEffect(() => {
@@ -63,14 +64,20 @@ const LazyZeffyIframe = (props: ZeffyIframeProps) => {
    * observe — the visitor scrolls to it and fills it in inside a
    * cross-origin frame. Mounting is the last thing this site can see, so
    * it is recorded as the funnel step it is: the form was actually put in
-   * front of someone. Fires once (mounted only ever flips false → true).
+   * front of someone.
+   *
+   * Fires at most once per mounted iframe, enforced by a ref rather than
+   * left to the dependency list: `mounted` only ever flips false → true,
+   * but a change to `src` or `title` after mount would otherwise re-run
+   * the effect and emit a second conversion for the same form.
    *
    * Deliberately NOT a `donate_open`: that event means an explicit act of
    * intent, and conflating the two would inflate the donation funnel with
    * everyone who scrolled past the homepage form.
    */
   useEffect(() => {
-    if (!mounted) return
+    if (!mounted || hasTrackedViewRef.current) return
+    hasTrackedViewRef.current = true
     // Derive the campaign id the same way tracked LINKS to Zeffy do, so
     // the two agree in GA4. Splitting the raw src on '/' would keep the
     // query string (embed URLs carry `?modal=true`) and yield an empty

--- a/src/components/ui/LazyZeffyIframe.tsx
+++ b/src/components/ui/LazyZeffyIframe.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useRef, useState, IframeHTMLAttributes } from 'react'
 import { zeffyHostedUrl } from '@/data/donation-campaigns'
+import { CONVERSION_EVENTS, trackConversion } from '@/lib/analytics-events'
 
 export interface ZeffyIframeProps extends IframeHTMLAttributes<HTMLIFrameElement> {
   allowpaymentrequest?: string
@@ -56,6 +57,25 @@ const LazyZeffyIframe = (props: ZeffyIframeProps) => {
     observer.observe(el)
     return () => observer.disconnect()
   }, [])
+
+  /**
+   * The embedded form is the one donation surface with no click to
+   * observe — the visitor scrolls to it and fills it in inside a
+   * cross-origin frame. Mounting is the last thing this site can see, so
+   * it is recorded as the funnel step it is: the form was actually put in
+   * front of someone. Fires once (mounted only ever flips false → true).
+   *
+   * Deliberately NOT a `donate_open`: that event means an explicit act of
+   * intent, and conflating the two would inflate the donation funnel with
+   * everyone who scrolled past the homepage form.
+   */
+  useEffect(() => {
+    if (!mounted) return
+    trackConversion(CONVERSION_EVENTS.DONATE_FORM_VIEW, {
+      conversion_id: typeof props.src === 'string' ? props.src.split('/').pop() : undefined,
+      conversion_label: props.title,
+    })
+  }, [mounted, props.src, props.title])
 
   // Before mount the reserved box simply stays empty — the same thing
   // visitors saw while the Zeffy app booted when the iframe was eager.

--- a/src/components/ui/LazyZeffyIframe.tsx
+++ b/src/components/ui/LazyZeffyIframe.tsx
@@ -84,9 +84,26 @@ const LazyZeffyIframe = (props: ZeffyIframeProps) => {
     // segment for a trailing slash — both of which fragment the
     // conversion_id dimension and break aggregation by campaign.
     const classified = typeof props.src === 'string' ? classifyConversionHref(props.src) : null
+
+    // conversion_source/destination are set on every click-tracked
+    // conversion, and they are registered as GA4 custom dimensions — so
+    // omitting them here would leave this event unbreakable by page or
+    // destination, and make it the odd one out in every report that
+    // segments the others.
+    let destination: string | undefined
+    if (typeof props.src === 'string') {
+      try {
+        destination = new URL(props.src, window.location.href).host
+      } catch {
+        destination = undefined
+      }
+    }
+
     trackConversion(CONVERSION_EVENTS.DONATE_FORM_VIEW, {
       conversion_id: classified?.params.conversion_id,
       conversion_label: props.title,
+      conversion_source: window.location.pathname,
+      conversion_destination: destination,
     })
   }, [mounted, props.src, props.title])
 

--- a/src/components/ui/ZeffyPopupButton.tsx
+++ b/src/components/ui/ZeffyPopupButton.tsx
@@ -11,10 +11,16 @@ interface ZeffyPopupButtonProps {
   variant?: 'primary' | 'secondary'
   className?: string
   /**
-   * Campaign name recorded on the `donate_open` conversion. Defaults to
-   * the button label, which is right for the general-fund CTAs; campaign
-   * cards pass the campaign title so GA4 can break donations down by
-   * appeal rather than by button text.
+   * Optional overrides for the `donate_open` conversion. Nothing passes
+   * them today: the campaign slug is derived from the Zeffy URL and the
+   * label falls back to the button text, which is accurate for every
+   * current CTA.
+   *
+   * They exist for the case where a component knows something the URL
+   * does not — e.g. surfacing a readable appeal name against a campaign
+   * whose Zeffy slug is an opaque UUID (several are; see
+   * src/data/donation-campaigns.ts). Passing only one is fine: the
+   * conversion merges these over the URL-derived values field by field.
    */
   campaignName?: string
   /** Stable campaign key (DonationCampaign.key) for the conversion id. */

--- a/src/components/ui/ZeffyPopupButton.tsx
+++ b/src/components/ui/ZeffyPopupButton.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { zeffyHostedUrl } from '@/data/donation-campaigns'
+import { conversionAttrs, CONVERSION_EVENTS } from '@/lib/analytics-events'
 
 interface ZeffyPopupButtonProps {
   /** Zeffy pop-up embed link, e.g. https://www.zeffy.com/embed/<type>/<slug>?modal=true */
@@ -9,6 +10,15 @@ interface ZeffyPopupButtonProps {
   /** 'primary' = filled brand button; 'secondary' = outlined. */
   variant?: 'primary' | 'secondary'
   className?: string
+  /**
+   * Campaign name recorded on the `donate_open` conversion. Defaults to
+   * the button label, which is right for the general-fund CTAs; campaign
+   * cards pass the campaign title so GA4 can break donations down by
+   * appeal rather than by button text.
+   */
+  campaignName?: string
+  /** Stable campaign key (DonationCampaign.key) for the conversion id. */
+  campaignKey?: string
 }
 
 /**
@@ -26,6 +36,8 @@ const ZeffyPopupButton: React.FC<ZeffyPopupButtonProps> = ({
   label,
   variant = 'primary',
   className = '',
+  campaignName,
+  campaignKey,
 }) => {
   const styles =
     variant === 'primary'
@@ -37,6 +49,10 @@ const ZeffyPopupButton: React.FC<ZeffyPopupButtonProps> = ({
       target="_blank"
       rel="noopener noreferrer"
       {...{ 'zeffy-form-link': formLink }}
+      {...conversionAttrs(CONVERSION_EVENTS.DONATE_OPEN, {
+        conversion_label: campaignName ?? label,
+        conversion_id: campaignKey,
+      })}
       className={`inline-block cursor-pointer rounded-[10px] text-center font-[600] text-[16px] px-[24px] py-[14px] ${styles} ${className}`}
       data-font="lato-font"
     >

--- a/src/components/ui/apply-buttons.tsx
+++ b/src/components/ui/apply-buttons.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { hubAddProduct, ONBOARDING_PID } from '@/lib/config'
+import { conversionAttrs, CONVERSION_EVENTS } from '@/lib/analytics-events'
 
 /**
  * The two charity onboarding "Apply" buttons, kept in a plain (non-client)
@@ -13,18 +14,32 @@ export const APPLY = {
   full501c3: {
     label: 'Apply as a 501(c)(3) charity',
     href: hubAddProduct(ONBOARDING_PID.full501c3),
+    pid: String(ONBOARDING_PID.full501c3),
   },
   pre501c3: {
     label: 'Apply as a pre-501(c)(3) organization',
     href: hubAddProduct(ONBOARDING_PID.pre501c3),
+    pid: String(ONBOARDING_PID.pre501c3),
   },
 } as const
 
+/**
+ * These links leave the Next.js site for WHMCS in the SAME tab, so the
+ * conversion has to survive the navigation — GA4's beacon transport is
+ * what makes that work (see trackConversion). The WHMCS side counts the
+ * same step independently via the funnel beacon (docs/funnel-beacon.md);
+ * the two are expected to reconcile, with GA4 running lower because it
+ * needs consent-mode measurement and the beacon does not.
+ */
 export const ApplyButton = ({ kind, className = '' }: { kind: ApplyKind; className?: string }) => (
   <a
     href={APPLY[kind].href}
     className={`inline-flex items-center justify-center rounded-[10px] bg-[#0567B1] px-[26px] py-[14px] text-[17px] font-[700] text-white transition-transform duration-200 hover:scale-[1.03] hover:bg-[#045a9b] ${className}`}
     data-font="lato-font"
+    {...conversionAttrs(CONVERSION_EVENTS.SERVICE_APPLICATION_START, {
+      conversion_label: APPLY[kind].label,
+      conversion_id: APPLY[kind].pid,
+    })}
   >
     {APPLY[kind].label}
   </a>

--- a/src/lib/analytics-config.ts
+++ b/src/lib/analytics-config.ts
@@ -47,12 +47,17 @@ export const GTM_CONTAINER_ID = process.env.NEXT_PUBLIC_GTM_CONTAINER_ID ?? 'GTM
  * and double-counted pageviews look entirely plausible in GA4 — there is
  * no error, no warning, and no way to separate them afterwards.
  *
- * DEFAULT IS 'gtm' as of the cutover (2026-07-26, issue #510). This value
- * briefly defaulted to 'direct' so that merging could not silently
- * disable GA4 before anyone had decided to switch — an accidental cutover
- * is the dangerous one, because a forgotten GTM publish leaves zero
- * measurement. That decision has now been made deliberately, so the
- * default reflects production.
+ * DEFAULT IS 'gtm' as of the cutover (issue #510) — which means THIS REPO
+ * ALONE DOES NOT DELIVER GA4. Under 'gtm' the site emits nothing itself;
+ * measurement exists only while GTM container version 2 is published, a
+ * state nothing here can assert. A green build is not evidence that
+ * anything is being measured.
+ *
+ * This value briefly defaulted to 'direct' so that merging could not
+ * silently disable GA4 before anyone had decided to switch — an
+ * accidental cutover is the dangerous one, because a forgotten GTM
+ * publish leaves zero measurement. That decision has since been made
+ * deliberately, so the default reflects the intended production setup.
  *
  * It is set here rather than as a deploy-only env var on purpose: the
  * tests assert behaviour against this constant, so a build-time override

--- a/src/lib/analytics-config.ts
+++ b/src/lib/analytics-config.ts
@@ -47,15 +47,24 @@ export const GTM_CONTAINER_ID = process.env.NEXT_PUBLIC_GTM_CONTAINER_ID ?? 'GTM
  * and double-counted pageviews look entirely plausible in GA4 — there is
  * no error, no warning, and no way to separate them afterwards.
  *
- * Overridable at build time via NEXT_PUBLIC_GA_DELIVERY so the cutover
- * can be reverted without a code change if GTM misbehaves in production.
+ * DEFAULT IS 'direct', and deliberately so. Under 'gtm' this site emits
+ * no GA4 at all — measurement depends entirely on GTM container version 2
+ * being published. If that default applied on merge, deploying this
+ * change would stop GA4 dead until somebody remembered to publish, and a
+ * forgotten publish means zero measurement: precisely the condition this
+ * work exists to fix, reintroduced silently.
  *
- * CUTOVER ORDER (see issue #510): deploy this set to 'gtm' FIRST, then
- * publish GTM container version 2. Publishing first means the site and
- * GTM both fire GA4 until the deploy lands.
+ * So the cutover is an explicit act, not a side effect of merging. Set
+ * NEXT_PUBLIC_GA_DELIVERY=gtm at build time (or flip this default in a
+ * one-line PR), deploy, and THEN publish GTM version 2 — see issue #510.
+ * Publishing before the deploy lands means both paths fire GA4 at once.
+ *
+ * Any unrecognised value resolves to 'direct' for the same reason: the
+ * failure mode of guessing wrong should be "measured twice and noticed",
+ * never "measured not at all and unnoticed".
  */
 export const GA_DELIVERY: 'gtm' | 'direct' =
-  process.env.NEXT_PUBLIC_GA_DELIVERY === 'direct' ? 'direct' : 'gtm'
+  process.env.NEXT_PUBLIC_GA_DELIVERY === 'gtm' ? 'gtm' : 'direct'
 
 export const CLARITY_PROJECT_ID = process.env.NEXT_PUBLIC_CLARITY_PROJECT_ID ?? 'nzldyj4h3k'
 

--- a/src/lib/analytics-config.ts
+++ b/src/lib/analytics-config.ts
@@ -34,6 +34,33 @@ export const CLARITY_PROJECT_ID = process.env.NEXT_PUBLIC_CLARITY_PROJECT_ID ?? 
 export const TAWK_TO_PROPERTY =
   process.env.NEXT_PUBLIC_TAWK_TO_PROPERTY ?? '65bf15eb0ff6374032c915d9/1hlp6r8hc'
 
+// Domains that share a measurement session with this site.
+//
+// Zeffy hosts every donation form, and once Zeffy fires this property's
+// measurement ID on their pages (requested via their Google Analytics
+// set-up form), an undecorated hop from here to there starts a NEW
+// session attributed to freeforcharity.org as a referral — double-counting
+// sessions and detaching donations from the campaign that drove them.
+//
+// The gtag `linker` below decorates outbound ANCHOR clicks with `_gl`,
+// which covers the pop-up buttons and hosted-form links. Two caveats,
+// deliberately recorded rather than papered over:
+//
+//  1. It does NOT cover the embedded iframe on /donate — a linker
+//     decorates links, not iframe `src` attributes. Continuity for the
+//     embed would need `_gl` appended to the src explicitly.
+//  2. For GA4, the authoritative cross-domain setting lives in the Admin
+//     UI (Data Streams -> Configure tag settings -> Configure your
+//     domains). It is exposed by NO API: verified against the
+//     analyticsadmin v1beta and v1alpha discovery documents (no
+//     domain/tag-settings resource), and the Tag Manager `gtag_config`
+//     endpoint only governs tags fired through a GTM container, which
+//     this property's tag is not. The UI step is still required.
+//
+// ffcadmin.org is deliberately absent: it reports to a separate GA4
+// property, and cross-domain linking only joins sessions within one.
+export const CROSS_DOMAIN_DOMAINS = ['freeforcharity.org', 'zeffy.com']
+
 // No Meta Pixel configured yet — stays empty until an operator sets the
 // env var (or adds a default here once a real ID exists). Empty = the
 // corresponding loader is a no-op.

--- a/src/lib/analytics-config.ts
+++ b/src/lib/analytics-config.ts
@@ -57,9 +57,22 @@ export const TAWK_TO_PROPERTY =
 //     endpoint only governs tags fired through a GTM container, which
 //     this property's tag is not. The UI step is still required.
 //
+// Both apex and `www.` hosts are listed explicitly. Every campaign link
+// this site renders is built from ZEFFY_BASE, which is
+// `https://www.zeffy.com` — so listing only the apex would rely on the
+// linker's host matching being suffix-based, and a mismatch fails
+// silently: links go undecorated, sessions split on the hop, and nothing
+// in the UI or the logs says so. Naming the exact hosts we link to costs
+// nothing and removes the assumption.
+//
 // ffcadmin.org is deliberately absent: it reports to a separate GA4
 // property, and cross-domain linking only joins sessions within one.
-export const CROSS_DOMAIN_DOMAINS = ['freeforcharity.org', 'zeffy.com']
+export const CROSS_DOMAIN_DOMAINS = [
+  'freeforcharity.org',
+  'www.freeforcharity.org',
+  'zeffy.com',
+  'www.zeffy.com',
+]
 
 // No Meta Pixel configured yet — stays empty until an operator sets the
 // env var (or adds a default here once a real ID exists). Empty = the

--- a/src/lib/analytics-config.ts
+++ b/src/lib/analytics-config.ts
@@ -29,6 +29,34 @@ export const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID ?? 'G
 
 export const GTM_CONTAINER_ID = process.env.NEXT_PUBLIC_GTM_CONTAINER_ID ?? 'GTM-NJ4DXH9'
 
+/**
+ * How GA4 is delivered. This is the cutover switch, and getting it wrong
+ * in either direction is silent, so it is a single named value rather
+ * than an inference from what happens to be on `window`.
+ *
+ *   'gtm'    — GTM's Google tag loads gtag.js and configures GA4, and the
+ *              conversion events reach GA4 through GTM tags listening on
+ *              the dataLayer. This site must NOT load gtag.js itself and
+ *              must NOT call gtag('event', …): the GTM event tags fire
+ *              from the same dataLayer push, so doing both double-counts
+ *              every conversion.
+ *   'direct' — this site loads gtag.js and calls gtag('event', …) itself.
+ *              GTM may still load, but carries no GA4 tag.
+ *
+ * The two modes must never overlap. Both send to the same measurement ID,
+ * and double-counted pageviews look entirely plausible in GA4 — there is
+ * no error, no warning, and no way to separate them afterwards.
+ *
+ * Overridable at build time via NEXT_PUBLIC_GA_DELIVERY so the cutover
+ * can be reverted without a code change if GTM misbehaves in production.
+ *
+ * CUTOVER ORDER (see issue #510): deploy this set to 'gtm' FIRST, then
+ * publish GTM container version 2. Publishing first means the site and
+ * GTM both fire GA4 until the deploy lands.
+ */
+export const GA_DELIVERY: 'gtm' | 'direct' =
+  process.env.NEXT_PUBLIC_GA_DELIVERY === 'direct' ? 'direct' : 'gtm'
+
 export const CLARITY_PROJECT_ID = process.env.NEXT_PUBLIC_CLARITY_PROJECT_ID ?? 'nzldyj4h3k'
 
 export const TAWK_TO_PROPERTY =
@@ -56,6 +84,16 @@ export const TAWK_TO_PROPERTY =
 //     domain/tag-settings resource), and the Tag Manager `gtag_config`
 //     endpoint only governs tags fired through a GTM container, which
 //     this property's tag is not. The UI step is still required.
+//
+// APPLIES ONLY IN 'direct' DELIVERY. The linker rides on the gtag config
+// this site emits, and under GA_DELIVERY = 'gtm' that config is GTM's,
+// not ours — cross-domain then comes from the `linker_domains` entry on
+// the Google tag in container version 2. That entry is stored but
+// UNVERIFIED (the Tag Manager API accepts arbitrary config keys, which
+// proves storage and nothing else), so confirm decoration with Tag
+// Assistant at cutover: click a donate link and check the Zeffy URL
+// carries a `_gl` parameter. If it does not, cross-domain is silently
+// off and donations detach from the campaign that drove them.
 //
 // Both apex and `www.` hosts are listed explicitly. Every campaign link
 // this site renders is built from ZEFFY_BASE, which is

--- a/src/lib/analytics-config.ts
+++ b/src/lib/analytics-config.ts
@@ -47,24 +47,29 @@ export const GTM_CONTAINER_ID = process.env.NEXT_PUBLIC_GTM_CONTAINER_ID ?? 'GTM
  * and double-counted pageviews look entirely plausible in GA4 — there is
  * no error, no warning, and no way to separate them afterwards.
  *
- * DEFAULT IS 'direct', and deliberately so. Under 'gtm' this site emits
- * no GA4 at all — measurement depends entirely on GTM container version 2
- * being published. If that default applied on merge, deploying this
- * change would stop GA4 dead until somebody remembered to publish, and a
- * forgotten publish means zero measurement: precisely the condition this
- * work exists to fix, reintroduced silently.
+ * DEFAULT IS 'gtm' as of the cutover (2026-07-26, issue #510). This value
+ * briefly defaulted to 'direct' so that merging could not silently
+ * disable GA4 before anyone had decided to switch — an accidental cutover
+ * is the dangerous one, because a forgotten GTM publish leaves zero
+ * measurement. That decision has now been made deliberately, so the
+ * default reflects production.
  *
- * So the cutover is an explicit act, not a side effect of merging. Set
- * NEXT_PUBLIC_GA_DELIVERY=gtm at build time (or flip this default in a
- * one-line PR), deploy, and THEN publish GTM version 2 — see issue #510.
- * Publishing before the deploy lands means both paths fire GA4 at once.
+ * It is set here rather than as a deploy-only env var on purpose: the
+ * tests assert behaviour against this constant, so a build-time override
+ * in production alone would leave every test exercising the mode
+ * production does NOT run. Keeping them identical is the point.
  *
- * Any unrecognised value resolves to 'direct' for the same reason: the
- * failure mode of guessing wrong should be "measured twice and noticed",
- * never "measured not at all and unnoticed".
+ * Under 'gtm' this site emits no GA4 itself — measurement depends
+ * entirely on GTM container version 2 being published. Order of
+ * operations, once more: deploy this, THEN publish. Publishing first
+ * means both paths fire GA4 until the deploy lands.
+ *
+ * ROLLBACK: build with NEXT_PUBLIC_GA_DELIVERY=direct and redeploy, which
+ * restores the self-contained gtag path including the verified `linker`.
+ * Unpublishing the GTM version alone would leave no GA4 at all.
  */
 export const GA_DELIVERY: 'gtm' | 'direct' =
-  process.env.NEXT_PUBLIC_GA_DELIVERY === 'gtm' ? 'gtm' : 'direct'
+  process.env.NEXT_PUBLIC_GA_DELIVERY === 'direct' ? 'direct' : 'gtm'
 
 export const CLARITY_PROJECT_ID = process.env.NEXT_PUBLIC_CLARITY_PROJECT_ID ?? 'nzldyj4h3k'
 

--- a/src/lib/analytics-events.ts
+++ b/src/lib/analytics-events.ts
@@ -27,6 +27,8 @@
 // property — that double-counts. Use the dataLayer copy for other
 // destinations only.
 
+import { SITE_ORIGIN } from '@/lib/config'
+
 /** The three primary conversions, plus the supporting funnel steps. */
 export const CONVERSION_EVENTS = {
   /** Donor opened a Zeffy campaign form (pop-up button or hosted link). */
@@ -105,6 +107,31 @@ export function trackConversion(event: ConversionEvent, params: ConversionParams
 }
 
 /**
+ * True when `host` is exactly `domain` or a subdomain of it.
+ *
+ * A bare `host.endsWith('zeffy.com')` also matches `evilzeffy.com` and
+ * `notzeffy.com`, which would let an unrelated (or hostile) link be
+ * counted as a donation. The leading dot is what makes it a real
+ * subdomain check rather than a substring one.
+ */
+function isHost(host: string, domain: string): boolean {
+  return host === domain || host.endsWith(`.${domain}`)
+}
+
+/**
+ * Registrable host of the configured site origin, `www.` stripped so both
+ * apex and `www.` links match. WHMCS is deployed as a sibling directory
+ * of the export on this same host.
+ */
+const HUB_HOST = (() => {
+  try {
+    return new URL(SITE_ORIGIN).host.toLowerCase().replace(/^www\./, '')
+  } catch {
+    return 'freeforcharity.org'
+  }
+})()
+
+/**
  * Classify a link by where it GOES, so conversions are tracked without
  * every call site having to remember to tag itself.
  *
@@ -127,7 +154,7 @@ export function classifyConversionHref(
 ): { event: ConversionEvent; params: ConversionParams } | null {
   let url: URL
   try {
-    url = new URL(href, base ?? 'https://www.freeforcharity.org')
+    url = new URL(href, base ?? SITE_ORIGIN)
   } catch {
     return null
   }
@@ -136,7 +163,7 @@ export function classifyConversionHref(
   const path = url.pathname.toLowerCase()
 
   // Donations: any Zeffy campaign, hosted page or embed link.
-  if (host.endsWith('zeffy.com')) {
+  if (isHost(host, 'zeffy.com')) {
     // .../embed/donation-form/<slug> or .../donation-form/<slug>
     const slug = url.pathname.split('/').filter(Boolean).pop()
     return {
@@ -147,10 +174,10 @@ export function classifyConversionHref(
 
   // Volunteering: Idealist postings and the ffcadmin role pages, which
   // are where an application is actually started.
-  if (host.endsWith('idealist.org')) {
+  if (isHost(host, 'idealist.org')) {
     return { event: CONVERSION_EVENTS.VOLUNTEER_APPLY, params: {} }
   }
-  if (host.endsWith('ffcadmin.org') && path.startsWith('/volunteer/')) {
+  if (isHost(host, 'ffcadmin.org') && path.startsWith('/volunteer/')) {
     const role = path.split('/').filter(Boolean)[1]
     return {
       event: CONVERSION_EVENTS.VOLUNTEER_APPLY,
@@ -161,7 +188,15 @@ export function classifyConversionHref(
   // Service applications: any WHMCS product order form. Both link shapes
   // are in use — `a=add&pid=N` (preferred, stable product id) and the
   // older `a=confproduct&i=N` cart-index form.
-  if (path.endsWith('/hub/cart.php')) {
+  //
+  // Constrained to our own origin: WHMCS is deployed as a sibling
+  // directory of the export on the same host, so an off-site
+  // `/hub/cart.php` is somebody else's cart, not an FFC application.
+  // Checked against SITE_ORIGIN — the origin these links are generated
+  // from — rather than the page host, so it stays correct both on staging
+  // and in local/CI builds where the page is served from localhost but
+  // the hub links still point at the configured origin.
+  if (isHost(host, HUB_HOST) && path.endsWith('/hub/cart.php')) {
     const pid = url.searchParams.get('pid') ?? url.searchParams.get('i')
     if (pid) {
       return {

--- a/src/lib/analytics-events.ts
+++ b/src/lib/analytics-events.ts
@@ -14,20 +14,21 @@
 // funnels visible at all, and they are what get marked as Key Events in
 // GA4 Admin.
 //
-// Events are emitted TWICE, deliberately:
-//   1. `gtag('event', …)` — reaches GA4 directly, with no GTM tag to
-//      configure. Without this, nothing lands in GA4 until someone builds
-//      a tag by hand in the container, which is precisely the gap that
-//      left keyEvents at 0.
-//   2. `dataLayer.push({event: …})` — makes the same conversion available
-//      as a GTM trigger for Google Ads conversions, Meta, or anything else
-//      wired up later.
+// How an event reaches GA4 depends on GA_DELIVERY (see analytics-config):
 //
-// DO NOT also build a GTM tag that sends these same events to the SAME GA4
-// property — that double-counts. Use the dataLayer copy for other
-// destinations only.
+//   'gtm'    — ONLY `dataLayer.push({event: …})`. GTM's GA4 Event tags
+//              listen for these event names and forward them, so calling
+//              gtag as well would send each conversion twice.
+//   'direct' — `gtag('event', …)` reaches GA4 with no GTM tag to build,
+//              AND the dataLayer push still happens so GTM can drive
+//              Google Ads, Meta, or anything else off the same event.
+//
+// Exactly one path may reach a given GA4 property. Both are individually
+// valid hits, so a double-count produces no error anywhere — it just
+// quietly doubles the numbers the charity makes decisions on.
 
 import { SITE_ORIGIN } from '@/lib/config'
+import { GA_DELIVERY } from '@/lib/analytics-config'
 
 /** The three primary conversions, plus the supporting funnel steps. */
 export const CONVERSION_EVENTS = {
@@ -105,7 +106,17 @@ export function trackConversion(event: ConversionEvent, params: ConversionParams
     if (typeof value === 'string' && value.length > 0) clean[key] = value
   }
 
-  window.gtag?.('event', event, clean)
+  // Direct delivery only. Under 'gtm', GTM's GA4 Event tags fire from the
+  // dataLayer push below, so calling gtag as well sends the same
+  // conversion to the same property twice.
+  //
+  // This is gated on the declared mode rather than on `window.gtag` being
+  // undefined, because GTM's Google tag also defines `window.gtag` — an
+  // optional-chaining guard would look like protection while quietly
+  // doubling every conversion.
+  if (GA_DELIVERY === 'direct') {
+    window.gtag?.('event', event, clean)
+  }
 
   window.dataLayer = window.dataLayer || []
   window.dataLayer.push({ event, ...clean })

--- a/src/lib/analytics-events.ts
+++ b/src/lib/analytics-events.ts
@@ -72,7 +72,12 @@ interface DataLayerEvent {
 
 declare global {
   interface Window {
-    dataLayer: DataLayerEvent[]
+    // Two shapes share this queue: plain objects pushed directly (the
+    // `{event: …}` records GTM triggers on) and the `arguments` objects
+    // gtag pushes for its own commands. Typing it as DataLayerEvent[]
+    // alone would let a reader assume every entry has an `event` field,
+    // which is false for every consent/config call.
+    dataLayer: (DataLayerEvent | IArguments)[]
     // gtag's real signature is variadic and untyped by design (it proxies
     // straight into dataLayer as an arguments object).
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/lib/analytics-events.ts
+++ b/src/lib/analytics-events.ts
@@ -1,0 +1,193 @@
+// Conversion event contract for freeforcharity.org.
+//
+// Three primary conversions carry the mission, and every one of them ends
+// at a boundary GA4 cannot observe on its own:
+//
+//   Donations  → Zeffy (cross-origin iframe or zeffy.com in a new tab)
+//   Volunteer  → Idealist postings and ffcadmin.org (separate origins)
+//   Services   → /hub/cart.php (WHMCS, a different app on the same host)
+//
+// So the site measures the last thing it CAN see — the visitor committing
+// to the handoff — and names it explicitly. Completion tracking on the far
+// side of each boundary is tracked separately (see
+// docs/CONVERSION-TRACKING.md); these intent events are what make the
+// funnels visible at all, and they are what get marked as Key Events in
+// GA4 Admin.
+//
+// Events are emitted TWICE, deliberately:
+//   1. `gtag('event', …)` — reaches GA4 directly, with no GTM tag to
+//      configure. Without this, nothing lands in GA4 until someone builds
+//      a tag by hand in the container, which is precisely the gap that
+//      left keyEvents at 0.
+//   2. `dataLayer.push({event: …})` — makes the same conversion available
+//      as a GTM trigger for Google Ads conversions, Meta, or anything else
+//      wired up later.
+//
+// DO NOT also build a GTM tag that sends these same events to the SAME GA4
+// property — that double-counts. Use the dataLayer copy for other
+// destinations only.
+
+/** The three primary conversions, plus the supporting funnel steps. */
+export const CONVERSION_EVENTS = {
+  /** Donor opened a Zeffy campaign form (pop-up button or hosted link). */
+  DONATE_OPEN: 'donate_open',
+  /** A Zeffy donation form was actually rendered on screen (iframe embed). */
+  DONATE_FORM_VIEW: 'donate_form_view',
+  /** Visitor followed a volunteer role application link off-site. */
+  VOLUNTEER_APPLY: 'volunteer_apply',
+  /** Charity opened a WHMCS onboarding/service application form. */
+  SERVICE_APPLICATION_START: 'service_application_start',
+} as const
+
+export type ConversionEvent = (typeof CONVERSION_EVENTS)[keyof typeof CONVERSION_EVENTS]
+
+/** Every value CONVERSION_EVENTS can produce, for runtime validation. */
+const VALID_EVENTS: readonly string[] = Object.values(CONVERSION_EVENTS)
+
+export function isConversionEvent(value: string): value is ConversionEvent {
+  return VALID_EVENTS.includes(value)
+}
+
+/**
+ * Parameters carried on a conversion. Kept deliberately small and
+ * non-identifying: what was clicked and where from, never who clicked it.
+ */
+export interface ConversionParams {
+  /** Human-readable thing being converted on, e.g. a campaign or role name. */
+  conversion_label?: string
+  /** Stable id where one exists — Zeffy campaign key, WHMCS product id. */
+  conversion_id?: string
+  /** Where the click happened, e.g. '/donate/'. */
+  conversion_source?: string
+  /** Destination host for handoffs, e.g. 'www.zeffy.com'. */
+  conversion_destination?: string
+}
+
+interface DataLayerEvent {
+  event: string
+  [key: string]: string | number | boolean | undefined
+}
+
+declare global {
+  interface Window {
+    dataLayer: DataLayerEvent[]
+    // gtag's real signature is variadic and untyped by design (it proxies
+    // straight into dataLayer as an arguments object).
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    gtag?: (...args: any[]) => void
+    openCookiePreferences?: () => void
+  }
+}
+
+/**
+ * Emit a conversion. Safe to call during SSR (no-ops) and safe to call
+ * before the Google tag has loaded — gtag calls queue in dataLayer and are
+ * replayed once GA4 initialises, so a conversion on the very first
+ * interaction is not lost.
+ *
+ * GA4's transport uses `sendBeacon`/keepalive, so events survive the
+ * navigation they were triggered by — which matters for the WHMCS apply
+ * links, since those replace the page rather than opening a new tab.
+ */
+export function trackConversion(event: ConversionEvent, params: ConversionParams = {}): void {
+  if (typeof window === 'undefined') return
+
+  // Drop undefined values so GA4 doesn't receive empty parameters.
+  const clean: Record<string, string> = {}
+  for (const [key, value] of Object.entries(params)) {
+    if (typeof value === 'string' && value.length > 0) clean[key] = value
+  }
+
+  window.gtag?.('event', event, clean)
+
+  window.dataLayer = window.dataLayer || []
+  window.dataLayer.push({ event, ...clean })
+}
+
+/**
+ * Classify a link by where it GOES, so conversions are tracked without
+ * every call site having to remember to tag itself.
+ *
+ * The three funnels each leave for a small, stable set of destinations —
+ * Zeffy for donations, Idealist / ffcadmin.org for volunteering, WHMCS
+ * `/hub/cart.php` for service applications — and those destinations are
+ * reached from ~20 components (every `Transparentbtn` apply pair, the
+ * footer donate button, the campaign cards). Hand-tagging each one
+ * guarantees the next new CTA is silently untracked, which is how the
+ * site ended up at zero conversions in the first place.
+ *
+ * Explicit `data-ffc-conversion` attributes still win where a component
+ * knows something the URL does not — a campaign name, a product label.
+ *
+ * Returns null for links that aren't conversions.
+ */
+export function classifyConversionHref(
+  href: string,
+  base?: string
+): { event: ConversionEvent; params: ConversionParams } | null {
+  let url: URL
+  try {
+    url = new URL(href, base ?? 'https://www.freeforcharity.org')
+  } catch {
+    return null
+  }
+
+  const host = url.host.toLowerCase()
+  const path = url.pathname.toLowerCase()
+
+  // Donations: any Zeffy campaign, hosted page or embed link.
+  if (host.endsWith('zeffy.com')) {
+    // .../embed/donation-form/<slug> or .../donation-form/<slug>
+    const slug = url.pathname.split('/').filter(Boolean).pop()
+    return {
+      event: CONVERSION_EVENTS.DONATE_OPEN,
+      params: { conversion_id: slug },
+    }
+  }
+
+  // Volunteering: Idealist postings and the ffcadmin role pages, which
+  // are where an application is actually started.
+  if (host.endsWith('idealist.org')) {
+    return { event: CONVERSION_EVENTS.VOLUNTEER_APPLY, params: {} }
+  }
+  if (host.endsWith('ffcadmin.org') && path.startsWith('/volunteer/')) {
+    const role = path.split('/').filter(Boolean)[1]
+    return {
+      event: CONVERSION_EVENTS.VOLUNTEER_APPLY,
+      params: { conversion_id: role },
+    }
+  }
+
+  // Service applications: any WHMCS product order form. Both link shapes
+  // are in use — `a=add&pid=N` (preferred, stable product id) and the
+  // older `a=confproduct&i=N` cart-index form.
+  if (path.endsWith('/hub/cart.php')) {
+    const pid = url.searchParams.get('pid') ?? url.searchParams.get('i')
+    if (pid) {
+      return {
+        event: CONVERSION_EVENTS.SERVICE_APPLICATION_START,
+        params: { conversion_id: pid },
+      }
+    }
+  }
+
+  return null
+}
+
+/**
+ * Data attributes that turn any anchor into a tracked conversion without
+ * making its component a client component. The delegated listener in
+ * <ConversionTracking /> reads these on click, so server-rendered CTAs
+ * (the apply buttons, the Zeffy pop-up buttons) stay server-rendered.
+ *
+ *   <a {...conversionAttrs(CONVERSION_EVENTS.DONATE_OPEN, {conversion_label: 'General Fund'})} …>
+ */
+export function conversionAttrs(
+  event: ConversionEvent,
+  params: Pick<ConversionParams, 'conversion_label' | 'conversion_id'> = {}
+): Record<string, string> {
+  const attrs: Record<string, string> = { 'data-ffc-conversion': event }
+  if (params.conversion_label) attrs['data-ffc-conversion-label'] = params.conversion_label
+  if (params.conversion_id) attrs['data-ffc-conversion-id'] = params.conversion_id
+  return attrs
+}

--- a/src/lib/analytics-events.ts
+++ b/src/lib/analytics-events.ts
@@ -124,6 +124,14 @@ function isHost(host: string, domain: string): boolean {
 }
 
 /**
+ * Zeffy campaign path types. Mirrors the `<type>` segment of the links in
+ * src/data/donation-campaigns.ts — note the type does NOT track the
+ * campaign's category (the "Website Design and Development" appeal is a
+ * `ticketing` URL), so this list is about URL shape, not semantics.
+ */
+const ZEFFY_CAMPAIGN_TYPES = new Set(['donation-form', 'ticketing', 'membership', 'shop'])
+
+/**
  * Registrable host of the configured site origin, `www.` stripped so both
  * apex and `www.` links match. WHMCS is deployed as a sibling directory
  * of the export on this same host.
@@ -167,14 +175,37 @@ export function classifyConversionHref(
   const host = url.host.toLowerCase()
   const path = url.pathname.toLowerCase()
 
-  // Donations: any Zeffy campaign, hosted page or embed link.
+  // Donations: Zeffy CAMPAIGN links only.
+  //
+  // Not every zeffy.com link is a donation. The site also links to
+  // Zeffy's own marketing pages — `zeffy.com/` from the donations guide,
+  // and their privacy policy from our cookie policy. Matching the host
+  // alone counted those as donation intent and handed GA4 a
+  // conversion_id of "privacy-policy".
+  //
+  // Campaign URLs are `/<type>/<slug>`, optionally prefixed with a
+  // locale and/or `embed` (the pop-up form of the same link):
+  //   /embed/donation-form/<uuid>?modal=true
+  //   /ticketing/free-for-charity-annual-gala
+  //   /en-US/donation-form/<uuid>
   if (isHost(host, 'zeffy.com')) {
-    // .../embed/donation-form/<slug> or .../donation-form/<slug>
-    const slug = url.pathname.split('/').filter(Boolean).pop()
-    return {
-      event: CONVERSION_EVENTS.DONATE_OPEN,
-      params: { conversion_id: slug },
+    const segments = url.pathname.split('/').filter(Boolean)
+    let i = 0
+    // Optional locale segment, e.g. `en-US`. No campaign type is two
+    // letters, so this cannot swallow one.
+    if (segments[i] && /^[a-z]{2}(-[a-zA-Z]{2})?$/.test(segments[i])) i++
+    if (segments[i] === 'embed') i++
+
+    const type = segments[i]
+    const slug = segments[i + 1]
+    if (type && ZEFFY_CAMPAIGN_TYPES.has(type) && slug) {
+      return {
+        event: CONVERSION_EVENTS.DONATE_OPEN,
+        params: { conversion_id: slug },
+      }
     }
+    // A Zeffy link that isn't a campaign is not a conversion.
+    return null
   }
 
   // Volunteering: Idealist postings and the ffcadmin role pages, which

--- a/src/lib/consent-mode.ts
+++ b/src/lib/consent-mode.ts
@@ -1,0 +1,164 @@
+// Google Consent Mode v2 defaults.
+//
+// Policy: the most permissive configuration Google's own rules allow.
+//
+// Google's EU User Consent Policy binds us as a Google Analytics / Ads
+// customer, and it requires opt-IN consent before setting cookies or
+// reading identifiers for visitors in the EEA, the UK, and Switzerland.
+// Everywhere else, no such Google-imposed requirement exists, so storage
+// defaults to GRANTED and measurement is complete from the first pageview.
+//
+// This is strictly MORE data than the previous model, where the GA4 and
+// GTM scripts did not load at all until a visitor clicked "Accept All" —
+// every visitor who ignored the banner (the large majority) was invisible,
+// worldwide. Under Consent Mode the tags always load; what changes by
+// region is whether they may use cookies:
+//
+//   - Outside EEA/UK/CH  → granted immediately; full cookie-based
+//                          measurement, no banner interaction needed.
+//   - Inside EEA/UK/CH   → denied until the visitor accepts, but GA4 still
+//                          sends COOKIELESS pings, so pageviews and events
+//                          are modeled rather than lost. Accepting flips
+//                          storage to granted via a `consent update`.
+//
+// `wait_for_update` holds tags briefly so a returning EEA visitor's stored
+// choice is applied before the first hit fires, instead of the hit going
+// out as denied and the consent arriving a beat too late.
+//
+// See docs/CONVERSION-TRACKING.md for the full model and the GA4 Admin
+// steps that must accompany it.
+
+/**
+ * ISO 3166 region codes where Google's EU User Consent Policy applies:
+ * the 27 EU member states + the 3 non-EU EEA states (IS, LI, NO), plus
+ * the UK (GB) and Switzerland (CH).
+ */
+export const EU_CONSENT_REGIONS = [
+  'AT',
+  'BE',
+  'BG',
+  'HR',
+  'CY',
+  'CZ',
+  'DK',
+  'EE',
+  'FI',
+  'FR',
+  'DE',
+  'GR',
+  'HU',
+  'IE',
+  'IT',
+  'LV',
+  'LT',
+  'LU',
+  'MT',
+  'NL',
+  'PL',
+  'PT',
+  'RO',
+  'SK',
+  'SI',
+  'ES',
+  'SE',
+  // Non-EU EEA
+  'IS',
+  'LI',
+  'NO',
+  // UK + Switzerland
+  'GB',
+  'CH',
+] as const
+
+/**
+ * Milliseconds tags wait for a `consent update` before firing with the
+ * default state. 500ms is Google's documented starting point: long enough
+ * for this site's synchronous localStorage read, short enough not to
+ * meaningfully delay the first hit.
+ */
+export const CONSENT_WAIT_FOR_UPDATE_MS = 500
+
+/**
+ * The inline bootstrap that must execute BEFORE any Google tag loads.
+ *
+ * Emitted into <head> in the root layout. Two `consent default` calls, in
+ * Google's documented order: the region-scoped denial first, then the
+ * global grant. Region-specific settings always take precedence over the
+ * unscoped one, so EEA/UK/CH visitors get denied-by-default and everyone
+ * else gets granted-by-default.
+ *
+ * `url_passthrough` keeps click ids (gclid/wbraid) flowing through
+ * navigation when cookies are denied, and `ads_data_redaction` strips ad
+ * identifiers from tag requests while `ad_storage` is denied — both are
+ * no-ops once consent is granted, so they cost nothing outside the EEA.
+ *
+ * Declared as a function declaration so `gtag` lands on `window` and every
+ * later caller (the GA4 loader, the consent banner, the conversion
+ * tracker) shares one queue.
+ */
+export const CONSENT_MODE_BOOTSTRAP = `
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('consent', 'default', {
+  'ad_storage': 'denied',
+  'ad_user_data': 'denied',
+  'ad_personalization': 'denied',
+  'analytics_storage': 'denied',
+  'functionality_storage': 'granted',
+  'personalization_storage': 'denied',
+  'security_storage': 'granted',
+  'wait_for_update': ${CONSENT_WAIT_FOR_UPDATE_MS},
+  'region': ${JSON.stringify([...EU_CONSENT_REGIONS])}
+});
+gtag('consent', 'default', {
+  'ad_storage': 'granted',
+  'ad_user_data': 'granted',
+  'ad_personalization': 'granted',
+  'analytics_storage': 'granted',
+  'functionality_storage': 'granted',
+  'personalization_storage': 'granted',
+  'security_storage': 'granted'
+});
+gtag('set', 'url_passthrough', true);
+gtag('set', 'ads_data_redaction', true);
+`.trim()
+
+/** The consent categories the cookie banner exposes. */
+export interface ConsentPreferences {
+  necessary: boolean
+  functional: boolean
+  analytics: boolean
+  marketing: boolean
+}
+
+/**
+ * Push a Consent Mode `update` reflecting the visitor's actual choice.
+ *
+ * This runs on every banner interaction AND on page load when a stored
+ * choice exists. For an EEA/UK/CH visitor it is what lifts the regional
+ * default from denied to granted; for everyone else it mostly re-affirms
+ * the granted default, and only matters when they actively DECLINE — at
+ * which point storage flips to denied and GA4 falls back to cookieless
+ * pings rather than disappearing entirely.
+ *
+ * That last part is the substantive difference from the previous model:
+ * declining used to mean zero measurement. Now a declining visitor is
+ * still counted, just not identified across sessions — which is both more
+ * data for FFC and unchanged in what it reveals about the individual.
+ */
+export function updateGoogleConsent(prefs: ConsentPreferences): void {
+  if (typeof window === 'undefined' || typeof window.gtag !== 'function') return
+
+  const analytics = prefs.analytics ? 'granted' : 'denied'
+  const marketing = prefs.marketing ? 'granted' : 'denied'
+
+  window.gtag('consent', 'update', {
+    analytics_storage: analytics,
+    ad_storage: marketing,
+    ad_user_data: marketing,
+    ad_personalization: marketing,
+    personalization_storage: marketing,
+    functionality_storage: prefs.functional ? 'granted' : 'denied',
+    security_storage: 'granted',
+  })
+}

--- a/tests/analytics-loading.spec.ts
+++ b/tests/analytics-loading.spec.ts
@@ -21,15 +21,18 @@ import {
  * hard-coded value the app no longer uses.
  *
  * Consent model (Consent Mode v2 — see docs/CONVERSION-TRACKING.md):
- * consent gates STORAGE, not script loading. GA4, GTM, and Clarity load
- * on every pageview; the consent state decides whether they may use
- * cookies. Storage defaults to granted worldwide and denied only in the
- * EEA/UK/CH, where Google's EU User Consent Policy requires opt-in — so
- * a visitor who ignores or declines the banner is still measured, via
- * cookieless pings, instead of disappearing entirely.
+ * for the GOOGLE tags, consent gates STORAGE rather than script loading.
+ * GA4 and GTM load on every pageview; the consent state decides whether
+ * they may use cookies. Storage defaults to granted worldwide and denied
+ * only in the EEA/UK/CH, where Google's EU User Consent Policy requires
+ * opt-in — so a visitor who ignores or declines the banner is still
+ * measured, via cookieless pings, instead of disappearing entirely.
  *
- * The Meta Pixel is the exception: no Consent Mode equivalent is wired
- * up for it, so it stays fully gated on marketing consent.
+ * Two tags are NOT loaded on that basis, because Consent Mode is a
+ * Google protocol and neither speaks it:
+ *   - Microsoft Clarity (session recording) needs EXPLICIT analytics
+ *     consent — there is no cookieless mode to degrade to.
+ *   - The Meta Pixel stays fully gated on marketing consent.
  */
 
 // Count <script> elements whose src OR inline text references a marker.

--- a/tests/analytics-loading.spec.ts
+++ b/tests/analytics-loading.spec.ts
@@ -112,7 +112,13 @@ test.describe('Analytics + widget loading', () => {
     await clearConsent(page)
 
     const defaults = await consentCalls(page, 'default')
-    expect(defaults.length).toBe(2)
+    // At least the regional denial and the global grant. Not an exact
+    // count: adding a further region-scoped override (a jurisdiction
+    // beyond the EEA/UK/CH adopting the same rule) would be correct and
+    // should not fail this test. What matters is asserted below — that
+    // both the regional and global defaults exist and say the right
+    // things, and that they precede the first tag command.
+    expect(defaults.length).toBeGreaterThanOrEqual(2)
 
     // Region-scoped denial for the EEA/UK/CH, per Google's EU User
     // Consent Policy — the only place opt-in is actually required.

--- a/tests/analytics-loading.spec.ts
+++ b/tests/analytics-loading.spec.ts
@@ -184,11 +184,10 @@ test.describe('Analytics + widget loading', () => {
     await clearConsent(page)
     await page.getByRole('button', { name: 'Decline All' }).click()
 
-    // Clarity is not a Google tag, so Consent Mode does nothing for it and
-    // there is no cookieless mode to fall back to — a decline has to keep
-    // the session recorder off outright. On THIS load it was already
-    // injected under the permissive default (and is stopped via its own
-    // API), so the durable behaviour is what the next load does.
+    // Clarity requires explicit analytics consent, so it was never
+    // injected on this load either. Reloading proves the stored decline
+    // keeps it off on every subsequent visit — not just that it happened
+    // to be absent before any choice was made.
     // domcontentloaded, not the default 'load': tags now load on every
     // pageview, so waiting on third-party subresources hangs the reload.
     await page.reload({ waitUntil: 'domcontentloaded' })

--- a/tests/analytics-loading.spec.ts
+++ b/tests/analytics-loading.spec.ts
@@ -20,11 +20,16 @@ import {
  * test aligned with the build under test rather than asserting a
  * hard-coded value the app no longer uses.
  *
- * Consent model (from cookie-consent/index.tsx):
- *   - necessary + functional: always on  → Tawk.to (functional) loads
- *     once the banner is dismissed by any choice
- *   - analytics (opt-in)                 → GA4 + GTM + Clarity
- *   - marketing (opt-in)                 → Meta Pixel (no ID yet, no-op)
+ * Consent model (Consent Mode v2 — see docs/CONVERSION-TRACKING.md):
+ * consent gates STORAGE, not script loading. GA4, GTM, and Clarity load
+ * on every pageview; the consent state decides whether they may use
+ * cookies. Storage defaults to granted worldwide and denied only in the
+ * EEA/UK/CH, where Google's EU User Consent Policy requires opt-in — so
+ * a visitor who ignores or declines the banner is still measured, via
+ * cookieless pings, instead of disappearing entirely.
+ *
+ * The Meta Pixel is the exception: no Consent Mode equivalent is wired
+ * up for it, so it stays fully gated on marketing consent.
  */
 
 // Count <script> elements whose src OR inline text references a marker.
@@ -33,6 +38,26 @@ async function scriptCount(page: Page, marker: string): Promise<number> {
     const scripts = Array.from(document.querySelectorAll('script'))
     return scripts.filter((s) => (s.src && s.src.includes(m)) || s.textContent?.includes(m)).length
   }, marker)
+}
+
+/**
+ * Read the Consent Mode calls out of the dataLayer.
+ *
+ * gtag pushes an `arguments` object, so entries look like
+ * `{0:'consent', 1:'default'|'update', 2:{…state}}` — this pulls out the
+ * state objects for the requested kind.
+ */
+async function consentCalls(
+  page: Page,
+  kind: 'default' | 'update'
+): Promise<Record<string, unknown>[]> {
+  return page.evaluate((k) => {
+    const dl = (window as unknown as { dataLayer?: unknown[] }).dataLayer ?? []
+    return dl
+      .map((entry) => Array.from(entry as ArrayLike<unknown>))
+      .filter((args) => args[0] === 'consent' && args[1] === k)
+      .map((args) => args[2] as Record<string, unknown>)
+  }, kind)
 }
 
 async function clearConsent(page: Page) {
@@ -49,12 +74,56 @@ test.describe('Analytics + widget loading', () => {
     await context.clearCookies()
   })
 
-  test('no analytics scripts load before the visitor consents', async ({ page }) => {
+  test('consent defaults are set before any Google tag loads', async ({ page }) => {
     await clearConsent(page)
-    // Banner is showing; no choice made yet. Analytics must NOT be present.
-    expect(await scriptCount(page, 'googletagmanager.com/gtag')).toBe(0)
-    expect(await scriptCount(page, 'googletagmanager.com/gtm.js')).toBe(0)
-    expect(await scriptCount(page, 'clarity.ms')).toBe(0)
+
+    const defaults = await consentCalls(page, 'default')
+    expect(defaults.length).toBe(2)
+
+    // Region-scoped denial for the EEA/UK/CH, per Google's EU User
+    // Consent Policy — the only place opt-in is actually required.
+    const regional = defaults.find((c) => Array.isArray(c.region))
+    expect(regional).toBeDefined()
+    expect(regional!.region).toContain('DE')
+    expect(regional!.region).toContain('GB')
+    expect(regional!.region).toContain('CH')
+    expect(regional!.analytics_storage).toBe('denied')
+    expect(regional!.ad_user_data).toBe('denied')
+    expect(regional!.wait_for_update).toBe(500)
+
+    // Granted everywhere else — the permissive default.
+    const global = defaults.find((c) => !Array.isArray(c.region))
+    expect(global).toBeDefined()
+    expect(global!.analytics_storage).toBe('granted')
+    expect(global!.ad_storage).toBe('granted')
+    expect(global!.ad_personalization).toBe('granted')
+
+    // The bootstrap must run before the tag, or the first hit goes out
+    // with no consent state at all.
+    const bootstrapRanFirst = await page.evaluate(() => {
+      const scripts = Array.from(document.querySelectorAll('script'))
+      const bootstrap = scripts.findIndex((s) =>
+        s.textContent?.includes("gtag('consent', 'default'")
+      )
+      return bootstrap !== -1
+    })
+    expect(bootstrapRanFirst).toBe(true)
+  })
+
+  test('analytics tags load for a visitor who never touches the banner', async ({ page }) => {
+    await clearConsent(page)
+    // Banner is showing and no choice has been made. Under Consent Mode
+    // the tags still load — consent gates STORAGE, not loading — so an
+    // ignored banner produces measurement instead of silence.
+    await expect
+      .poll(() => scriptCount(page, `gtag/js?id=${GA_MEASUREMENT_ID}`), { timeout: 8000 })
+      .toBeGreaterThan(0)
+    await expect
+      .poll(() => scriptCount(page, GTM_CONTAINER_ID), { timeout: 8000 })
+      .toBeGreaterThan(0)
+    await expect
+      .poll(() => scriptCount(page, CLARITY_PROJECT_ID), { timeout: 8000 })
+      .toBeGreaterThan(0)
   })
 
   test('Accept All injects GA4, GTM, and Clarity with the right IDs', async ({ page }) => {
@@ -77,19 +146,22 @@ test.describe('Analytics + widget loading', () => {
       .toBeGreaterThan(0)
   })
 
-  test('Decline All keeps analytics scripts out', async ({ page }) => {
+  test('Decline All flips storage to denied rather than removing measurement', async ({ page }) => {
     await clearConsent(page)
     await page.getByRole('button', { name: 'Decline All' }).click()
-    // Bound the wait on a real event instead of an arbitrary sleep:
-    // Decline All still grants functional consent, so Tawk.to loads.
-    // Once Tawk is present we know the post-consent loaders have run —
-    // at which point analytics must still be absent.
-    await expect
-      .poll(() => scriptCount(page, `embed.tawk.to/${TAWK_TO_PROPERTY}`), { timeout: 8000 })
-      .toBeGreaterThan(0)
-    expect(await scriptCount(page, `gtag/js?id=${GA_MEASUREMENT_ID}`)).toBe(0)
-    expect(await scriptCount(page, 'googletagmanager.com/gtm.js')).toBe(0)
-    expect(await scriptCount(page, 'clarity.ms')).toBe(0)
+
+    // A consent update must be pushed, denying every optional category.
+    await expect.poll(() => consentCalls(page, 'update'), { timeout: 8000 }).not.toHaveLength(0)
+    const updates = await consentCalls(page, 'update')
+    const last = updates[updates.length - 1]
+    expect(last.analytics_storage).toBe('denied')
+    expect(last.ad_storage).toBe('denied')
+    expect(last.ad_user_data).toBe('denied')
+    expect(last.ad_personalization).toBe('denied')
+
+    // The Meta Pixel is the one tag with no cookieless fallback, so it
+    // must stay off entirely without marketing consent.
+    expect(await scriptCount(page, 'fbevents.js')).toBe(0)
   })
 
   test('Tawk.to live chat loads on functional consent (any dismissal)', async ({ page }) => {

--- a/tests/analytics-loading.spec.ts
+++ b/tests/analytics-loading.spec.ts
@@ -4,6 +4,7 @@ import {
   GTM_CONTAINER_ID,
   CLARITY_PROJECT_ID,
   TAWK_TO_PROPERTY,
+  GA_DELIVERY,
 } from '../src/lib/analytics-config'
 
 /**
@@ -61,6 +62,24 @@ async function consentCalls(
       .filter((args) => args[0] === 'consent' && args[1] === k)
       .map((args) => args[2] as Record<string, unknown>)
   }, kind)
+}
+
+/**
+ * GA4 must be delivered by EXACTLY ONE path.
+ *
+ * Under GA_DELIVERY='gtm' the site must not inject gtag.js itself — GTM's
+ * Google tag does it — and under 'direct' it must. Both at once configures
+ * the same measurement ID twice and doubles every pageview, which produces
+ * no error and looks entirely plausible in GA4, so it needs asserting
+ * rather than eyeballing.
+ */
+async function assertGaDeliveryIsExclusive(page: Page) {
+  const selfInjected = await scriptCount(page, `gtag/js?id=${GA_MEASUREMENT_ID}`)
+  if (GA_DELIVERY === 'direct') {
+    expect(selfInjected).toBeGreaterThan(0)
+  } else {
+    expect(selfInjected).toBe(0)
+  }
 }
 
 async function clearConsent(page: Page) {
@@ -130,11 +149,9 @@ test.describe('Analytics + widget loading', () => {
     // the tags still load — consent gates STORAGE, not loading — so an
     // ignored banner produces measurement instead of silence.
     await expect
-      .poll(() => scriptCount(page, `gtag/js?id=${GA_MEASUREMENT_ID}`), { timeout: 8000 })
-      .toBeGreaterThan(0)
-    await expect
       .poll(() => scriptCount(page, GTM_CONTAINER_ID), { timeout: 8000 })
       .toBeGreaterThan(0)
+    await assertGaDeliveryIsExclusive(page)
 
     // Clarity is NOT part of the permissive default. It is a session
     // recorder with no Consent Mode fallback, so it waits for explicit
@@ -145,19 +162,16 @@ test.describe('Analytics + widget loading', () => {
     expect(await scriptCount(page, CLARITY_PROJECT_ID)).toBe(0)
   })
 
-  test('Accept All injects GA4, GTM, and Clarity with the right IDs', async ({ page }) => {
+  test('Accept All injects the analytics tags with the right IDs', async ({ page }) => {
     await clearConsent(page)
     await page.getByRole('button', { name: 'Accept All' }).click()
-
-    // GA4 direct gtag loader
-    await expect
-      .poll(() => scriptCount(page, `gtag/js?id=${GA_MEASUREMENT_ID}`), { timeout: 8000 })
-      .toBeGreaterThan(0)
 
     // GTM container loader (inline snippet references the container ID)
     await expect
       .poll(() => scriptCount(page, GTM_CONTAINER_ID), { timeout: 8000 })
       .toBeGreaterThan(0)
+
+    await assertGaDeliveryIsExclusive(page)
 
     // Microsoft Clarity (inline snippet references the project ID)
     await expect
@@ -196,10 +210,12 @@ test.describe('Analytics + widget loading', () => {
     await page.reload({ waitUntil: 'domcontentloaded' })
     await page.waitForFunction(() => Array.isArray((window as { dataLayer?: unknown[] }).dataLayer))
     await expect
-      .poll(() => scriptCount(page, `gtag/js?id=${GA_MEASUREMENT_ID}`), { timeout: 8000 })
+      .poll(() => scriptCount(page, GTM_CONTAINER_ID), { timeout: 8000 })
       .toBeGreaterThan(0)
 
-    // GA4 still loads (cookieless); Clarity must not.
+    // GA4 still measures (cookieless, via whichever delivery path is
+    // configured); Clarity must not run at all.
+    await assertGaDeliveryIsExclusive(page)
     expect(await scriptCount(page, 'clarity.ms')).toBe(0)
     expect(await scriptCount(page, CLARITY_PROJECT_ID)).toBe(0)
   })

--- a/tests/analytics-loading.spec.ts
+++ b/tests/analytics-loading.spec.ts
@@ -132,9 +132,14 @@ test.describe('Analytics + widget loading', () => {
     await expect
       .poll(() => scriptCount(page, GTM_CONTAINER_ID), { timeout: 8000 })
       .toBeGreaterThan(0)
-    await expect
-      .poll(() => scriptCount(page, CLARITY_PROJECT_ID), { timeout: 8000 })
-      .toBeGreaterThan(0)
+
+    // Clarity is NOT part of the permissive default. It is a session
+    // recorder with no Consent Mode fallback, so it waits for explicit
+    // analytics consent — otherwise an undecided EEA visitor would be
+    // fully recorded, and the preferences dialog (which shows analytics
+    // unchecked) would be lying about it.
+    expect(await scriptCount(page, 'clarity.ms')).toBe(0)
+    expect(await scriptCount(page, CLARITY_PROJECT_ID)).toBe(0)
   })
 
   test('Accept All injects GA4, GTM, and Clarity with the right IDs', async ({ page }) => {

--- a/tests/analytics-loading.spec.ts
+++ b/tests/analytics-loading.spec.ts
@@ -1,6 +1,5 @@
 import { test, expect, type Page } from '@playwright/test'
 import {
-  GA_MEASUREMENT_ID,
   GTM_CONTAINER_ID,
   CLARITY_PROJECT_ID,
   TAWK_TO_PROPERTY,
@@ -74,11 +73,24 @@ async function consentCalls(
  * rather than eyeballing.
  */
 async function assertGaDeliveryIsExclusive(page: Page) {
-  const selfInjected = await scriptCount(page, `gtag/js?id=${GA_MEASUREMENT_ID}`)
+  // Detect the site's OWN inline gtag config, not the presence of
+  // gtag.js.
+  //
+  // Under 'gtm', GTM's Google tag injects gtag.js itself once the
+  // container is published — so counting that script would flip this
+  // assertion from passing to failing the moment the container went
+  // live, while the site was behaving exactly as designed. The failure
+  // would look like a regression in the site and would in fact be a
+  // regression in the test.
+  //
+  // `anonymize_ip` appears only in the config snippet this component
+  // builds, so it is present in 'direct' and absent in 'gtm' regardless
+  // of what GTM does.
+  const selfConfigured = await scriptCount(page, 'anonymize_ip')
   if (GA_DELIVERY === 'direct') {
-    expect(selfInjected).toBeGreaterThan(0)
+    expect(selfConfigured).toBeGreaterThan(0)
   } else {
-    expect(selfInjected).toBe(0)
+    expect(selfConfigured).toBe(0)
   }
 }
 

--- a/tests/analytics-loading.spec.ts
+++ b/tests/analytics-loading.spec.ts
@@ -98,16 +98,27 @@ test.describe('Analytics + widget loading', () => {
     expect(global!.ad_storage).toBe('granted')
     expect(global!.ad_personalization).toBe('granted')
 
-    // The bootstrap must run before the tag, or the first hit goes out
-    // with no consent state at all.
-    const bootstrapRanFirst = await page.evaluate(() => {
-      const scripts = Array.from(document.querySelectorAll('script'))
-      const bootstrap = scripts.findIndex((s) =>
-        s.textContent?.includes("gtag('consent', 'default'")
-      )
-      return bootstrap !== -1
+    // Ordering is the whole point: a consent default that lands AFTER
+    // gtag('js')/gtag('config') is too late — the first hit has already
+    // gone out with no consent state. Assert the actual queue order
+    // rather than mere presence, so moving the bootstrap below the tag
+    // injection fails this test.
+    const order = await page.evaluate(() => {
+      const dl = (window as unknown as { dataLayer?: unknown[] }).dataLayer ?? []
+      const commands = dl.map((entry) => {
+        const args = Array.from(entry as ArrayLike<unknown>)
+        return `${args[0]}:${args[1]}`
+      })
+      return {
+        firstDefault: commands.findIndex((c) => c === 'consent:default'),
+        firstTagCommand: commands.findIndex((c) => c.startsWith('js:') || c.startsWith('config:')),
+      }
     })
-    expect(bootstrapRanFirst).toBe(true)
+
+    expect(order.firstDefault).toBeGreaterThanOrEqual(0)
+    if (order.firstTagCommand !== -1) {
+      expect(order.firstDefault).toBeLessThan(order.firstTagCommand)
+    }
   })
 
   test('analytics tags load for a visitor who never touches the banner', async ({ page }) => {
@@ -162,6 +173,28 @@ test.describe('Analytics + widget loading', () => {
     // The Meta Pixel is the one tag with no cookieless fallback, so it
     // must stay off entirely without marketing consent.
     expect(await scriptCount(page, 'fbevents.js')).toBe(0)
+  })
+
+  test('a stored analytics decline keeps Clarity off on subsequent loads', async ({ page }) => {
+    await clearConsent(page)
+    await page.getByRole('button', { name: 'Decline All' }).click()
+
+    // Clarity is not a Google tag, so Consent Mode does nothing for it and
+    // there is no cookieless mode to fall back to — a decline has to keep
+    // the session recorder off outright. On THIS load it was already
+    // injected under the permissive default (and is stopped via its own
+    // API), so the durable behaviour is what the next load does.
+    // domcontentloaded, not the default 'load': tags now load on every
+    // pageview, so waiting on third-party subresources hangs the reload.
+    await page.reload({ waitUntil: 'domcontentloaded' })
+    await page.waitForFunction(() => Array.isArray((window as { dataLayer?: unknown[] }).dataLayer))
+    await expect
+      .poll(() => scriptCount(page, `gtag/js?id=${GA_MEASUREMENT_ID}`), { timeout: 8000 })
+      .toBeGreaterThan(0)
+
+    // GA4 still loads (cookieless); Clarity must not.
+    expect(await scriptCount(page, 'clarity.ms')).toBe(0)
+    expect(await scriptCount(page, CLARITY_PROJECT_ID)).toBe(0)
   })
 
   test('Tawk.to live chat loads on functional consent (any dismissal)', async ({ page }) => {

--- a/tests/conversion-events.spec.ts
+++ b/tests/conversion-events.spec.ts
@@ -46,8 +46,12 @@ async function suppressNavigation(page: Page) {
     document.addEventListener(
       'click',
       (e) => {
-        const anchor = (e.target as Element | null)?.closest('a')
-        if (anchor) e.preventDefault()
+        // Optional chaining guards null, not a missing method — a
+        // non-Element target would throw on .closest(). Normalise the
+        // same way the app's listener does.
+        const raw = e.target
+        const node = raw instanceof Element ? raw : raw instanceof Node ? raw.parentElement : null
+        if (node?.closest('a')) e.preventDefault()
       },
       true
     )
@@ -122,11 +126,11 @@ test.describe('Primary conversion events', () => {
   })
 
   test('a non-campaign zeffy.com link does not fire donate_open', async ({ page }) => {
-    // /cookie-policy/ links to Zeffy's own privacy policy. Classification
-    // is destination-based, so a host-only match would count that click
-    // as donation intent and file it under conversion_id
-    // "privacy-policy" — inflating the donation funnel with people
-    // reading a policy page.
+    // /cookie-policy/ links to Zeffy's own legal & privacy page.
+    // Classification is destination-based, so a host-only match would
+    // count that click as donation intent and file it under a
+    // conversion_id taken from the policy URL's last path segment —
+    // inflating the donation funnel with people reading a policy page.
     await ready(page, '/cookie-policy/')
 
     const zeffyPolicyLink = page.locator('a[href*="zeffy.com"]').first()

--- a/tests/conversion-events.spec.ts
+++ b/tests/conversion-events.spec.ts
@@ -1,0 +1,126 @@
+import { test, expect, type Page } from '@playwright/test'
+
+/**
+ * Conversion event tests.
+ *
+ * The three primary conversions (donate, volunteer, apply) are what the
+ * site exists to produce, and all three were silently untracked until
+ * #505 — GA4 reported keyEvents: 0 against 3,507 events. These tests
+ * exist so that cannot regress unnoticed.
+ *
+ * Clicks are neutralised with a preventDefault listener registered AFTER
+ * the app's own capture listener, so the conversion is still recorded but
+ * the browser never navigates or opens a tab. Capture listeners on the
+ * same node fire in registration order, and the app's is attached on
+ * mount, so ordering is deterministic rather than a race.
+ */
+
+interface DataLayerRecord {
+  event?: string
+  conversion_label?: string
+  conversion_id?: string
+  conversion_source?: string
+  conversion_destination?: string
+}
+
+/** Plain (non-gtag) dataLayer pushes, i.e. the ones carrying `event`. */
+async function conversionEvents(page: Page): Promise<DataLayerRecord[]> {
+  return page.evaluate(() => {
+    const dl = (window as unknown as { dataLayer?: unknown[] }).dataLayer ?? []
+    return dl.filter(
+      (entry): entry is DataLayerRecord =>
+        typeof entry === 'object' &&
+        entry !== null &&
+        !('callee' in entry) &&
+        typeof (entry as { event?: unknown }).event === 'string'
+    )
+  })
+}
+
+/**
+ * Swallow navigation so a CTA click can be asserted on. Registered after
+ * the app's listener, so the conversion is recorded first.
+ */
+async function suppressNavigation(page: Page) {
+  await page.evaluate(() => {
+    document.addEventListener(
+      'click',
+      (e) => {
+        const anchor = (e.target as Element | null)?.closest('a')
+        if (anchor) e.preventDefault()
+      },
+      true
+    )
+  })
+}
+
+async function ready(page: Page, path: string) {
+  await page.goto(path)
+  // The delegated listener attaches on mount; wait for hydration to have
+  // produced a dataLayer before interacting.
+  await page.waitForFunction(() => Array.isArray((window as { dataLayer?: unknown[] }).dataLayer))
+  await suppressNavigation(page)
+}
+
+test.describe('Primary conversion events', () => {
+  test('opening a Zeffy campaign fires donate_open', async ({ page }) => {
+    await ready(page, '/donate/')
+
+    const zeffyLink = page.locator('a[href*="zeffy.com"]').first()
+    await expect(zeffyLink).toBeAttached()
+    await zeffyLink.click({ force: true })
+
+    await expect
+      .poll(async () => (await conversionEvents(page)).map((e) => e.event), { timeout: 8000 })
+      .toContain('donate_open')
+
+    const donate = (await conversionEvents(page)).find((e) => e.event === 'donate_open')
+    expect(donate?.conversion_destination).toContain('zeffy.com')
+    expect(donate?.conversion_source).toBe('/donate/')
+  })
+
+  test('an apply button fires service_application_start with the WHMCS product id', async ({
+    page,
+  }) => {
+    await ready(page, '/help-for-charities/')
+
+    const applyLink = page.locator('a[href*="/hub/cart.php"]').first()
+    await expect(applyLink).toBeAttached()
+    await applyLink.click({ force: true })
+
+    await expect
+      .poll(async () => (await conversionEvents(page)).map((e) => e.event), { timeout: 8000 })
+      .toContain('service_application_start')
+
+    const apply = (await conversionEvents(page)).find(
+      (e) => e.event === 'service_application_start'
+    )
+    // 16 = pre-501(c)(3), 33 = full 501(c)(3) — the two onboarding forms.
+    expect(['16', '33']).toContain(apply?.conversion_id)
+  })
+
+  test('a volunteer role link fires volunteer_apply', async ({ page }) => {
+    await ready(page, '/volunteer-roles/')
+
+    const roleLink = page.locator('a[href*="ffcadmin.org/volunteer/"]').first()
+    await expect(roleLink).toBeAttached()
+    await roleLink.click({ force: true })
+
+    await expect
+      .poll(async () => (await conversionEvents(page)).map((e) => e.event), { timeout: 8000 })
+      .toContain('volunteer_apply')
+  })
+
+  test('ordinary links do not fire conversions', async ({ page }) => {
+    await ready(page, '/about-us/')
+
+    const internal = page.locator('a[href^="/"]').first()
+    await expect(internal).toBeAttached()
+    await internal.click({ force: true })
+
+    const events = (await conversionEvents(page)).map((e) => e.event)
+    expect(events).not.toContain('donate_open')
+    expect(events).not.toContain('volunteer_apply')
+    expect(events).not.toContain('service_application_start')
+  })
+})

--- a/tests/conversion-events.spec.ts
+++ b/tests/conversion-events.spec.ts
@@ -77,6 +77,13 @@ test.describe('Primary conversion events', () => {
     const donate = (await conversionEvents(page)).find((e) => e.event === 'donate_open')
     expect(donate?.conversion_destination).toContain('zeffy.com')
     expect(donate?.conversion_source).toBe('/donate/')
+
+    // The campaign identifier must survive. ZeffyPopupButton tags every
+    // donate CTA explicitly but call sites rarely pass a campaignKey, so
+    // an explicit tag that replaced the classifier wholesale would leave
+    // conversion_id empty on nearly every donation — making the GA4
+    // dimension useless for telling campaigns apart.
+    expect(donate?.conversion_id).toBeTruthy()
   })
 
   test('an apply button fires service_application_start with the WHMCS product id', async ({

--- a/tests/conversion-events.spec.ts
+++ b/tests/conversion-events.spec.ts
@@ -56,9 +56,12 @@ async function suppressNavigation(page: Page) {
 
 async function ready(page: Page, path: string) {
   await page.goto(path)
-  // The delegated listener attaches on mount; wait for hydration to have
-  // produced a dataLayer before interacting.
-  await page.waitForFunction(() => Array.isArray((window as { dataLayer?: unknown[] }).dataLayer))
+  // Wait for the delegated listener itself, which sets this attribute
+  // when it attaches. Waiting on `window.dataLayer` instead would prove
+  // nothing: the Consent Mode bootstrap creates it in <head>, so it
+  // exists before hydration and a click could land before the listener
+  // was registered — making these tests pass or fail on timing.
+  await page.waitForSelector('html[data-ffc-conversion-tracking="ready"]', { state: 'attached' })
   await suppressNavigation(page)
 }
 
@@ -116,6 +119,23 @@ test.describe('Primary conversion events', () => {
     await expect
       .poll(async () => (await conversionEvents(page)).map((e) => e.event), { timeout: 8000 })
       .toContain('volunteer_apply')
+  })
+
+  test('a non-campaign zeffy.com link does not fire donate_open', async ({ page }) => {
+    // /cookie-policy/ links to Zeffy's own privacy policy. Classification
+    // is destination-based, so a host-only match would count that click
+    // as donation intent and file it under conversion_id
+    // "privacy-policy" — inflating the donation funnel with people
+    // reading a policy page.
+    await ready(page, '/cookie-policy/')
+
+    const zeffyPolicyLink = page.locator('a[href*="zeffy.com"]').first()
+    await expect(zeffyPolicyLink).toBeAttached()
+    expect(await zeffyPolicyLink.getAttribute('href')).not.toContain('donation-form')
+    await zeffyPolicyLink.click({ force: true })
+
+    const events = (await conversionEvents(page)).map((e) => e.event)
+    expect(events).not.toContain('donate_open')
   })
 
   test('ordinary links do not fire conversions', async ({ page }) => {


### PR DESCRIPTION
Refs #505, #402, #409, #507, #508, #510
Refs FreeForCharity/FFC-Cloudflare-Automation#869

## Problem

GA4 property `386764754` reported **`keyEvents: 0`** against 3,507 events over 28 days (workflow 502 report, 2026-07-25T15:11Z). None of FFC's three primary conversions — donations, volunteering, service applications — were measured at all.

Three independent causes, all confirmed:

1. **No conversion events existed.** The codebase contained exactly one `dataLayer.push` (`consent_update`) and initialised GA4 with a bare `gtag('config', …)`.
2. **The tags barely loaded.** GA4/GTM/Clarity were injected only after an "Accept All" click (`analytics` defaulted to `false`), so every visitor who ignored the banner was invisible — worldwide, not just in the EEA.
3. **The property's only key event was `purchase`**, auto-created 2023-06-17, which this site has never sent. The single configured conversion could not fire.

## Changes

**Conversion events** — `src/lib/analytics-events.ts` defines the contract.

| Event | Fires when |
| --- | --- |
| `donate_open` | a Zeffy **campaign** form is opened |
| `volunteer_apply` | a volunteer role application link is followed off-site |
| `service_application_start` | a WHMCS product order form is opened on our origin |
| `donate_form_view` | an embedded Zeffy form mounts on screen |

Events are **classified by destination** rather than hand-tagged, because those destinations are reached from ~20 components and tagging each one guarantees the next new CTA ships untracked. Classification is deliberately narrow — exact-or-subdomain host matching, and Zeffy campaign URL shapes only, so the site's links to Zeffy's own legal and marketing pages are not counted as donation intent. `__tests__/lib/analytics-events.test.ts` pins both directions with 29 cases.

**GA4 delivered through GTM** — `GA_DELIVERY` (`'gtm'` default, `'direct'` fallback, overridable via `NEXT_PUBLIC_GA_DELIVERY`). `GTM-NJ4DXH9` was the only confirmed-empty container across all 40 FFC containers while 28 others carry a `googtag`, so this site was the exception. Under `'gtm'` the site does not inject `gtag.js` and `trackConversion()` does not call `gtag('event', …)`; GTM's Google tag and GA4 Event tags handle both from the dataLayer.

The gate is on the declared mode, **not** on `window.gtag` being undefined — GTM's Google tag also defines it, so an optional-chaining guard would look like protection while silently doubling every conversion. `__tests__/lib/analytics-delivery.test.ts` and `assertGaDeliveryIsExclusive()` assert exclusivity in both modes.

**Consent Mode v2** — `src/lib/consent-mode.ts`, bootstrapped as an inline `<head>` script so consent state is in the dataLayer before any Google tag initialises. Storage is **granted by default worldwide** and **denied only in the EEA/UK/CH**, where Google's EU User Consent Policy requires opt-in; those visitors get cookieless pings until they accept. Consent gates *storage*, not script loading.

Two tags are excluded from that default, because Consent Mode is a Google protocol and neither speaks it: **Microsoft Clarity** (session recording, no cookieless fallback) requires explicit analytics consent, and the **Meta Pixel** stays gated on marketing consent.

The consent choice is stored on the registrable domain. Both `freeforcharity.org` and `www.freeforcharity.org` serve this site with no redirect between them, so a host-only cookie meant a visitor who **declined** on one host was treated as undecided on the other.

**Policy pages** — `/privacy-policy/` and `/cookie-policy/` rewritten. Beyond matching the new consent model, the privacy policy's §3.1–3.3 described comment cookies, login cookies, Gravatar hashes and visitor image uploads: WordPress boilerplate for a static site with no CMS, accounts, or comments. The cookie policy also never disclosed Tawk.to or Zeffy despite both setting cookies.

## Changes made outside this repo

GA4 property `386764754`, via the Admin API (both reversible):

- `donate_open`, `volunteer_apply`, `service_application_start` marked as **Key Events** (`ONCE_PER_SESSION`).
- `conversion_label`, `conversion_id`, `conversion_source`, `conversion_destination` registered as event-scoped **custom dimensions**.

GTM container `GTM-NJ4DXH9`: **version 2 created and NOT published** — Google tag, 4 GA4 Event tags, 4 custom-event triggers, 4 dataLayer variables.

## Cutover (see #510)

Merging this **stops the site firing GA4**; GTM takes over only once version 2 is published. Order matters:

1. Merge and deploy this PR. Brief measurement gap begins.
2. Publish GTM version 2. Measurement resumes.
3. Verify GA4 Realtime — pageviews plus all four events, counts not doubled.
4. Verify in Tag Assistant that donate links carry `_gl`. Cross-domain under `'gtm'` relies on a `linker_domains` entry that is **stored but unverified**.

Rollback: rebuild with `NEXT_PUBLIC_GA_DELIVERY=direct`. Unpublishing GTM alone would leave no GA4 at all.

## Testing

- `npm run lint` — clean
- `npm run build` — static export succeeds
- `npm test` — **685 passing**, 51 suites
- `npx playwright test tests/conversion-events.spec.ts tests/analytics-loading.spec.ts` — **11 passing**
- CI green on `4eaf59ce`: Build and Test, Lighthouse, Lychee, Copilot review

`tests/analytics-loading.spec.ts` needed rewriting: its "no analytics scripts load before the visitor consents" assertion encoded exactly the behaviour this PR removes.

## Notes for review

These are **intent** conversions. `donate_open` is not a donation — every funnel completes on a third-party origin the site cannot observe. `docs/CONVERSION-TRACKING.md` explains the boundary and how `service_application_start` should reconcile against the WHMCS funnel beacon.

**Please read the consent paths and `classifyConversionHref` closely.** Ten review rounds found real bugs here, and they share a shape: silent in production, invisible in the UI, detectable only by reading the code or querying GA4 weeks later. Examples fixed along the way — `_ga` wiped on every pageview for anyone who accepted analytics but declined marketing; cookie deletion missing the registrable-domain scope so a decline left the identifier in place; `conversion_id` empty on every donation while looking correctly wired; Zeffy's legal-page link counted as donation intent; a decline on `www` not applying on the apex.

Follow-ups out of scope: Tawk.to widget accessibility (#507) and the unverified-links-on-pinned-hosts sweep (#508).
