### PR TITLE
feat(security): publish RFC 9116 security.txt to the production docroot

### DIFF
--- a/.github/workflows/deploy-cpanel.yml
+++ b/.github/workflows/deploy-cpanel.yml
@@ -329,6 +329,15 @@ jobs:
             exit 1
           fi
           # Keep the two copies from drifting apart (payload below the comments).
+          # Check the .well-known copy exists BEFORE diffing. Process substitution
+          # on a missing file yields an empty stream, so the diff reports
+          # "payloads differ" — true in a sense, but it points at drift when the
+          # real fault is a missing file. Different fault, different fix.
+          if [ ! -f out/.well-known/security.txt ]; then
+            echo "::error::out/.well-known/security.txt is missing — the export did not produce it, so the root copy cannot be verified against it."
+            exit 1
+          fi
+
           if ! diff <(grep -v '^#' out/.well-known/security.txt) \
                     <(grep -v '^#' out/security.txt) > /dev/null; then
             echo "::error::security.txt payloads differ between out/.well-known/ and out/ — refusing to deploy."

--- a/.github/workflows/deploy-cpanel.yml
+++ b/.github/workflows/deploy-cpanel.yml
@@ -319,6 +319,23 @@ jobs:
             exit 1
           fi
 
+          # SECURITY.TXT GUARD (pre-mirror): the mirror below excludes
+          # '.well-known/' (cPanel system dir — see the exclude list), so
+          # out/.well-known/security.txt does NOT ship to production. The root
+          # copy out/security.txt is the one that lands. Refuse to deploy if it
+          # is missing, otherwise RFC 9116 discovery silently regresses to 404.
+          if [ ! -f out/security.txt ]; then
+            echo "::error::out/security.txt is missing — refusing to deploy (RFC 9116 discovery would 404 on the live apex)."
+            exit 1
+          fi
+          # Keep the two copies from drifting apart (payload below the comments).
+          if ! diff <(grep -v '^#' out/.well-known/security.txt) \
+                    <(grep -v '^#' out/security.txt) > /dev/null; then
+            echo "::error::security.txt payloads differ between out/.well-known/ and out/ — refusing to deploy."
+            exit 1
+          fi
+          echo "security.txt guard passed (root copy present, payloads match)."
+
           # ~/public_html IS the live apex docroot. The apex cutover
           # (cpanel-apex-cutover.yml) mirrored the static export straight into
           # ~/public_html — the docroot was NOT swapped to a sibling dir — so

--- a/.github/workflows/deploy-gh-pages-staging.yml
+++ b/.github/workflows/deploy-gh-pages-staging.yml
@@ -61,6 +61,10 @@ jobs:
         uses: actions/upload-pages-artifact@v5
         with:
           path: ./out
+          # Without this, upload-pages-artifact drops dot-entries such as
+          # .well-known/, so /.well-known/security.txt would silently never
+          # reach the staging site. Refs #788.
+          include-hidden-files: true
 
   deploy:
     name: Deploy to GitHub Pages

--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,0 +1,30 @@
+# RFC 9116 security.txt for freeforcharity.org — canonical well-known path.
+#
+# This file MUST stay byte-for-byte identical to public/security.txt below
+# the header block.
+#
+# DEPLOY NOTE (freeforcharity.org is NOT a plain GitHub Pages site):
+# Production is the InterServer cPanel docroot (~/public_html), mirrored by
+# .github/workflows/deploy-cpanel.yml. That mirror deliberately EXCLUDES
+# '.well-known/' from the lftp --delete mirror, because the directory is a
+# cPanel system dir holding ACME/AutoSSL challenge files — a --delete mirror
+# without that exclusion would wipe them and break certificate renewal.
+#
+# Consequence: this file does NOT ship to production. It is the source of
+# truth for the payload, and it is what the GitHub Pages staging deploy
+# serves. On production the sibling /security.txt is the copy that lands,
+# and the /.well-known/ path is answered by a Cloudflare edge-managed
+# security.txt configured outside this repo — keep that Cloudflare entry in
+# sync with the payload below.
+#
+# RFC 9116 §2.5.2 allows multiple Canonical lines to advertise both URLs.
+# Expires MUST be a future RFC 3339 datetime. Bump it on a regular cadence.
+
+Contact: mailto:clarkemoyer@freeforcharity.org
+Expires: 2027-12-31T00:00:00.000Z
+Preferred-Languages: en
+Canonical: https://freeforcharity.org/.well-known/security.txt
+Canonical: https://freeforcharity.org/security.txt
+Policy: https://freeforcharity.org/vulnerability-disclosure-policy/
+Acknowledgments: https://freeforcharity.org/security-acknowledgements/
+Hiring: https://freeforcharity.org/volunteer/

--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,7 +1,11 @@
 # RFC 9116 security.txt for freeforcharity.org — canonical well-known path.
 #
-# This file MUST stay byte-for-byte identical to public/security.txt below
-# the header block.
+# This file and public/security.txt MUST carry the same payload.
+# The deploy guard enforces that by comparing both files with comment
+# lines ('#') stripped — so the FIELDS must match exactly, while these
+# header comments may differ. Do not read this as byte-for-byte identity
+# of the whole file; CI does not check that, and assuming a stronger
+# guarantee than the one enforced is how drift gets in.
 #
 # DEPLOY NOTE (freeforcharity.org is NOT a plain GitHub Pages site):
 # Production is the InterServer cPanel docroot (~/public_html), mirrored by

--- a/public/security.txt
+++ b/public/security.txt
@@ -1,7 +1,11 @@
 # RFC 9116 security.txt — root-path copy.
 #
-# This file MUST stay byte-for-byte identical to
-# public/.well-known/security.txt below the header block.
+# This file and public/.well-known/security.txt MUST carry the same payload.
+# The deploy guard enforces that by comparing both files with comment
+# lines ('#') stripped — so the FIELDS must match exactly, while these
+# header comments may differ. Do not read this as byte-for-byte identity
+# of the whole file; CI does not check that, and assuming a stronger
+# guarantee than the one enforced is how drift gets in.
 #
 # DEPLOY NOTE (freeforcharity.org is NOT a plain GitHub Pages site):
 # Production is the InterServer cPanel docroot (~/public_html), mirrored by

--- a/public/security.txt
+++ b/public/security.txt
@@ -1,0 +1,29 @@
+# RFC 9116 security.txt — root-path copy.
+#
+# This file MUST stay byte-for-byte identical to
+# public/.well-known/security.txt below the header block.
+#
+# DEPLOY NOTE (freeforcharity.org is NOT a plain GitHub Pages site):
+# Production is the InterServer cPanel docroot (~/public_html), mirrored by
+# .github/workflows/deploy-cpanel.yml. That mirror deliberately EXCLUDES
+# '.well-known/' from the lftp --delete mirror, because the directory is a
+# cPanel system dir holding ACME/AutoSSL challenge files — a --delete mirror
+# without that exclusion would wipe them and break certificate renewal.
+#
+# Consequence: THIS root copy is the one that actually reaches production.
+# The sibling public/.well-known/security.txt is the source of truth for the
+# payload and is what the GitHub Pages staging deploy serves; on production
+# the /.well-known/ path is currently answered by a Cloudflare edge-managed
+# security.txt configured outside this repo.
+#
+# RFC 9116 §2.5.2 allows multiple Canonical lines to advertise both URLs.
+# Expires MUST be a future RFC 3339 datetime. Bump it on a regular cadence.
+
+Contact: mailto:clarkemoyer@freeforcharity.org
+Expires: 2027-12-31T00:00:00.000Z
+Preferred-Languages: en
+Canonical: https://freeforcharity.org/.well-known/security.txt
+Canonical: https://freeforcharity.org/security.txt
+Policy: https://freeforcharity.org/vulnerability-disclosure-policy/
+Acknowledgments: https://freeforcharity.org/security-acknowledgements/
+Hiring: https://freeforcharity.org/volunteer/


### PR DESCRIPTION
## Why

freeforcharity.org ships a `/vulnerability-disclosure-policy/` page and a `/security-acknowledgements/` page, but the repo carried **no security.txt in any form**. The RFC 9116 root fallback 404s:

```
https://freeforcharity.org/security.txt              -> 404
```

### Correcting one assumption up front

The canonical path is **not** 404 — it returns **200**:

```
https://freeforcharity.org/.well-known/security.txt  -> 200
```

But it is **not served from this repo**. It comes from a **Cloudflare edge-managed security.txt** configured outside version control. Evidence — compare the canonical path against a real origin file (`/robots.txt`):

| | `/.well-known/security.txt` | `/robots.txt` (real origin file) |
|---|---|---|
| `last-modified` | absent | present |
| `x-turbo-charged-by: LiteSpeed` | absent | present |
| FFC header suite (CSP, x-frame-options) | absent | present |
| `HEAD` request | **404** (origin's HTML 404 page) | 200 |

`GET` is intercepted at the edge; `HEAD` falls through to the origin, which 404s. So the published contact details were unversioned and could drift from the site with nobody noticing.

## What changed

**1. Dual-published security.txt**, per `FFC-IN-FFC_Single_Page_Template` / `FFC-IN-Footer_Only_Template`:

- `public/security.txt` — **the copy that actually reaches production**
- `public/.well-known/security.txt` — payload source of truth, and what GH Pages staging serves

```
Contact: mailto:clarkemoyer@freeforcharity.org
Expires: 2027-12-31T00:00:00.000Z
Preferred-Languages: en
Canonical: https://freeforcharity.org/.well-known/security.txt
Canonical: https://freeforcharity.org/security.txt
Policy: https://freeforcharity.org/vulnerability-disclosure-policy/
Acknowledgments: https://freeforcharity.org/security-acknowledgements/
Hiring: https://freeforcharity.org/volunteer/
```

`Contact` comes from this site's own disclosure-policy page. All four referenced URLs verified **200** live (trailing slashes match `trailingSlash: true`).

**2. Why the root copy is the load-bearing one here.** Production is the InterServer cPanel docroot, and `deploy-cpanel.yml` **deliberately excludes `.well-known/`** from the `lftp --delete` mirror — it is a cPanel system dir holding ACME/AutoSSL challenge files.

> **I intentionally did NOT touch that exclusion.** Removing `.well-known/` from the exclude list would let a `--delete` mirror wipe the AutoSSL challenge files and break certificate renewal on the live apex. Not a change to make as a side effect of a security.txt PR.

**3. Pre-mirror guard** in `deploy-cpanel.yml` — fails the deploy if the root copy is missing from `out/`, or if the two payloads drift apart.

**4. `include-hidden-files: true`** on the staging Pages upload (`deploy-gh-pages-staging.yml`). `actions/upload-pages-artifact@v5` drops dot-entries without it, so `.well-known/` would never reach staging. Refs #788.

## Verification

```
-rw-r--r-- 1580 out/.well-known/security.txt
-rw-r--r-- 1508 out/security.txt
root copy present: OK
PAYLOADS MATCH
```

| Check | Result |
|---|---|
| `npm run build` | pass — both files in `out/` |
| `npm run lint` | pass |
| `npm run format:check` | pass |
| `npm test` | **652/652 pass**, 49 suites |
| `prettier@3.8.1 --check` on both YAML files | pass |
| husky pre-commit | passed, no `--no-verify` needed |

`prettier` cannot infer a parser for `.txt`, so the two txt files are not prettier-checkable by design; the repo's own `format:check` glob skips them.

## Found but NOT fixed — needs an operator decision

1. **The Cloudflare edge security.txt now has a second source of truth.** Its live payload differs from this PR: it advertises `Expires: 2030-08-31T12:00:00Z` (>4 yrs out; RFC 9116 §2.5.5 advises under a year) and carries **no `Canonical` line**. After this merges, `/.well-known/` (Cloudflare) and `/security.txt` (repo) will serve *different* payloads until someone updates the Cloudflare entry to match. I did not touch Cloudflare config from a code PR.
2. **No `security-txt-expiry.yml`** in this repo. The templates have one that opens an issue as `Expires` approaches. Worth porting so the date does not silently lapse.
3. **No `check:drift` script** here (template-only), so cross-file drift is enforced only by the new deploy guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
