### PR TITLE
fix(ci): stop discarding next.config.ts on the staging deploy

### DIFF
--- a/.github/workflows/deploy-gh-pages-staging.yml
+++ b/.github/workflows/deploy-gh-pages-staging.yml
@@ -36,8 +36,21 @@ jobs:
 
       - name: Setup Pages
         uses: actions/configure-pages@v6
-        with:
-          static_site_generator: next
+        # `static_site_generator: next` is deliberately NOT set. It only understands
+        # next.config.js/.mjs; this repo uses next.config.ts, so the action logged
+        # "Using default blank configuration" and WROTE ITS OWN next.config.js with
+        # only {output, basePath, images.unoptimized}. Next prefers .js over .ts, so
+        # staging built with this repo's real config discarded — including
+        # `trailingSlash: true` AND the entire withSentryConfig wrapper, meaning
+        # staging had no Sentry instrumentation at all despite the config asking for it.
+        #
+        # Proven inside this repo. Same source, two pipelines:
+        #   staging (configure-pages)  /privacy-policy/ 404, /privacy-policy.html 200
+        #   production (cPanel mirror) /privacy-policy/ 200
+        # Only the pipeline that ran this action lost the setting. Reproduced
+        # independently on Footer_Only_Template. See FFC-Cloudflare-Automation#880.
+        #
+        # Safe to remove: basePath is set explicitly via NEXT_PUBLIC_BASE_PATH below.
 
       - name: Restore Next.js cache
         uses: actions/cache@v6


### PR DESCRIPTION
## What this fixes

`actions/configure-pages` with `static_site_generator: next` only understands
`next.config.js`/`.mjs`. This repo uses **`next.config.ts`**, so the action logs *"Using default
blank configuration"* and **writes its own `next.config.js`** containing only
`{output, basePath, images.unoptimized}`. Next prefers `.js` over `.ts` — so staging has been
building with this repo's real config discarded.

Two settings were lost, and one of them is not cosmetic:

| Discarded | Consequence |
| --- | --- |
| `trailingSlash: true` | staging served the wrong URL shape |
| `withSentryConfig(…)` | **staging had no Sentry instrumentation at all**, despite the config wrapping every build in it |

## Evidence — inside this repo

Same source, two pipelines:

| Pipeline | `/privacy-policy/` | `/privacy-policy.html` |
| --- | --- | --- |
| staging (`configure-pages`) | **404** | **200** |
| production (cPanel mirror) | **200** | 200 |

**Only the pipeline that ran this action lost the setting.** Reproduced independently on
`FFC-IN-Footer_Only_Template`, where removing this single input — with no source change — flipped
`/privacy-policy/` from 404 to 200 and `/privacy-policy.html` from 200 to 404.

## The part worth pausing on

Staging has not been a faithful preview of production. The two were shipping **different URL
structures**, and staging was running **without the error monitoring** production has. That is
exactly what a staging environment exists to rule out, and it has been quietly untrue for as long as
this input has been set.

## Why this is safe

`basePath` is set explicitly via `NEXT_PUBLIC_BASE_PATH: /FFC-IN-freeforcharity.org` in the build
step below, so nothing depends on the action injecting it.

## Verification after merge

Staging should flip to the production shape: `/privacy-policy/` **200**, `/privacy-policy.html`
**404** — matching `trailingSlash: true` and matching production. Sentry should begin receiving
staging events for the first time; if it does not, that is a separate finding worth its own issue,
since the config has been asking for it all along.

Refs FFC-Cloudflare-Automation#880
