### PR TITLE
fix: stop automated browsers polluting GA4

### DIFF
--- a/__tests__/lib/automated-browser.test.ts
+++ b/__tests__/lib/automated-browser.test.ts
@@ -1,0 +1,60 @@
+/**
+ * The automated-browser guard.
+ *
+ * Analytics used to be invisible to crawlers by accident — nothing loaded
+ * until someone clicked "Accept All", and automation never clicks.
+ * Consent Mode removed that gate, and a single crawl of the ~58-page
+ * sitemap then produced ~100 sessions against a site that sees ~950 a
+ * month. It read as growth, not noise.
+ *
+ * The e2e suite deliberately opts back in (it exists to exercise tag
+ * loading), so without these the guard would have no coverage at all.
+ */
+
+function loadFresh(): typeof import('@/lib/analytics-config') {
+  let mod!: typeof import('@/lib/analytics-config')
+  jest.isolateModules(() => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    mod = require('@/lib/analytics-config')
+  })
+  return mod
+}
+
+function setWebdriver(value: boolean | undefined) {
+  Object.defineProperty(window.navigator, 'webdriver', {
+    value,
+    configurable: true,
+    writable: true,
+  })
+}
+
+describe('isAutomatedBrowser', () => {
+  afterEach(() => {
+    setWebdriver(undefined)
+    delete (window as { __ffcAllowAutomatedAnalytics?: boolean }).__ffcAllowAutomatedAnalytics
+  })
+
+  it('is false for an ordinary browser', () => {
+    setWebdriver(undefined)
+    expect(loadFresh().isAutomatedBrowser()).toBe(false)
+  })
+
+  it('is true when navigator.webdriver is set (Playwright, Puppeteer, Lighthouse)', () => {
+    setWebdriver(true)
+    expect(loadFresh().isAutomatedBrowser()).toBe(true)
+  })
+
+  it('treats webdriver === false as a real browser', () => {
+    setWebdriver(false)
+    expect(loadFresh().isAutomatedBrowser()).toBe(false)
+  })
+
+  // The e2e suite relies on this escape hatch, so it is load-bearing:
+  // if it stops working, tag-loading coverage silently disappears rather
+  // than failing loudly.
+  it('honours the __ffcAllowAutomatedAnalytics opt-in used by the e2e suite', () => {
+    setWebdriver(true)
+    ;(window as { __ffcAllowAutomatedAnalytics?: boolean }).__ffcAllowAutomatedAnalytics = true
+    expect(loadFresh().isAutomatedBrowser()).toBe(false)
+  })
+})

--- a/docs/CONVERSION-TRACKING.md
+++ b/docs/CONVERSION-TRACKING.md
@@ -123,6 +123,32 @@ That restores the self-contained gtag path, including the verified `linker`.
 Unpublishing the GTM version alone would leave no GA4 at all, since under `gtm`
 the site emits none itself.
 
+### Automated browsers are excluded
+
+`isAutomatedBrowser()` (in `analytics-config.ts`) skips **all** tag loading when
+`navigator.webdriver` is set — Playwright, Puppeteer, and Lighthouse.
+
+This is not general bot defence; it targets our own automation. Before Consent
+Mode, crawlers were invisible to analytics _by accident_: nothing loaded until a
+visitor clicked "Accept All", and automation never clicks. Removing that gate
+handed every headless run a full set of pageviews. One crawl of the ~58-page
+sitemap produces roughly **100 sessions with a fresh client id per page**, against
+a site that sees about **950 sessions a month** — so a few runs a day would
+outnumber real visitors, and it would read as growth rather than noise. The pages
+are real, the events are well-formed, and nothing in GA4 marks them synthetic.
+
+This repo's own `scripts/visual-regression/capture.mjs` drives real Chromium at
+production, and the scheduled prod-smoke and outbound-link workflows touch it too.
+
+The Playwright suite opts back in via `window.__ffcAllowAutomatedAnalytics`, set
+in `addInitScript` — it exists to exercise tag loading. The guard therefore has
+its own unit coverage in `__tests__/lib/automated-browser.test.ts`, since the e2e
+tests deliberately bypass it.
+
+Note this does **not** suppress `dataLayer` pushes from `trackConversion()`. Those
+are harmless with no tags loaded — nothing forwards them — and keeping them means
+the conversion e2e tests stay meaningful without the opt-in.
+
 ### Tagging a CTA
 
 Most CTAs need nothing. `classifyConversionHref()` recognises the destination, so

--- a/src/components/cookie-consent/index.tsx
+++ b/src/components/cookie-consent/index.tsx
@@ -10,6 +10,7 @@ import {
   TAWK_TO_PROPERTY,
   CROSS_DOMAIN_DOMAINS,
   GA_DELIVERY,
+  isAutomatedBrowser,
 } from '@/lib/analytics-config'
 import { updateGoogleConsent, type ConsentPreferences } from '@/lib/consent-mode'
 
@@ -303,6 +304,13 @@ export default function CookieConsent() {
    */
   const loadDefaultTags = useCallback(
     (includeClarity: boolean) => {
+      // Load nothing for automated browsers. See isAutomatedBrowser —
+      // one crawl of the sitemap otherwise produces ~100 sessions against
+      // a site that sees ~950 a month, and it looks like real growth.
+      // Placed here rather than in each loader so a future tag cannot be
+      // added past the guard by accident.
+      if (isAutomatedBrowser()) return
+
       loadGoogleTagManager()
       loadGoogleAnalytics()
       if (includeClarity) loadMicrosoftClarity()
@@ -452,7 +460,7 @@ export default function CookieConsent() {
       // with nothing configured to receive them.
       loadDefaultTags(prefs.analytics)
 
-      if (prefs.marketing) {
+      if (prefs.marketing && !isAutomatedBrowser()) {
         loadMetaPixel()
       }
     },

--- a/src/lib/analytics-config.ts
+++ b/src/lib/analytics-config.ts
@@ -135,3 +135,40 @@ export const CROSS_DOMAIN_DOMAINS = [
 // env var (or adds a default here once a real ID exists). Empty = the
 // corresponding loader is a no-op.
 export const META_PIXEL_ID = process.env.NEXT_PUBLIC_META_PIXEL_ID ?? ''
+
+/**
+ * Escape hatch so the Playwright suite can still exercise tag loading.
+ * Set via `page.addInitScript` before any app code runs.
+ */
+declare global {
+  interface Window {
+    __ffcAllowAutomatedAnalytics?: boolean
+  }
+}
+
+/**
+ * True for browsers being driven by automation.
+ *
+ * Analytics used to be invisible to crawlers by accident: nothing loaded
+ * until a visitor clicked "Accept All", and an automated browser never
+ * clicks. Consent Mode removed that gate — tags now load on the first
+ * pageview — which handed every headless run a full set of pageviews.
+ *
+ * The damage is out of proportion to the traffic. This site averages
+ * roughly 950 sessions a MONTH, while one crawl of the ~58-page sitemap
+ * produces ~100 sessions with a fresh client id per page. A few runs a
+ * day would outnumber real visitors several times over, and it would read
+ * as growth rather than as noise: the pages are real, the events are
+ * well-formed, and nothing in GA4 marks them as synthetic.
+ *
+ * `navigator.webdriver` is set by Playwright, Puppeteer, and Lighthouse,
+ * which covers this repo's own visual-regression capture and prod-smoke
+ * workflows. It is not a general bot defence — a determined scraper can
+ * unset it — but it is exactly targeted at the automation we run
+ * ourselves, which is the source that matters here.
+ */
+export function isAutomatedBrowser(): boolean {
+  if (typeof navigator === 'undefined') return false
+  if (typeof window !== 'undefined' && window.__ffcAllowAutomatedAnalytics) return false
+  return navigator.webdriver === true
+}

--- a/src/lib/analytics-config.ts
+++ b/src/lib/analytics-config.ts
@@ -138,7 +138,8 @@ export const META_PIXEL_ID = process.env.NEXT_PUBLIC_META_PIXEL_ID ?? ''
 
 /**
  * Escape hatch so the Playwright suite can still exercise tag loading.
- * Set via `page.addInitScript` before any app code runs.
+ * Set via `context.addInitScript` in the suite's `beforeEach`, so it
+ * applies to every page in the context before any app code runs.
  */
 declare global {
   interface Window {

--- a/tests/analytics-loading.spec.ts
+++ b/tests/analytics-loading.spec.ts
@@ -106,6 +106,16 @@ async function clearConsent(page: Page) {
 test.describe('Analytics + widget loading', () => {
   test.beforeEach(async ({ context }) => {
     await context.clearCookies()
+    // Playwright sets navigator.webdriver, and the site now skips all tag
+    // loading for automated browsers so crawls stop polluting GA4 (see
+    // isAutomatedBrowser). This suite exists precisely to exercise tag
+    // loading, so it opts back in explicitly — which also means the guard
+    // itself is covered by its own unit test rather than by omission here.
+    await context.addInitScript(() => {
+      ;(
+        window as unknown as { __ffcAllowAutomatedAnalytics?: boolean }
+      ).__ffcAllowAutomatedAnalytics = true
+    })
   })
 
   test('consent defaults are set before any Google tag loads', async ({ page }) => {


### PR DESCRIPTION
Refs #505, #510

## Problem, observed live

While verifying the #506 cutover, GA4 Realtime showed:

| Device | Users | Events |
| --- | --- | --- |
| desktop | **148** | **454** |
| mobile | 1 | 9 |

The mobile session was a real person clicking donate/volunteer/apply. The desktop traffic was ~58 pages at 1–2 views each with a fresh client id per page — a crawl.

**This is a direct consequence of #506, and I should have predicted it.** Analytics used to be invisible to crawlers *by accident*: nothing loaded until a visitor clicked "Accept All", and automation never clicks. Consent Mode removed that gate, so every headless run now gets a full set of pageviews.

The damage is out of proportion to the traffic:

- One crawl of the ~58-page sitemap ≈ **100 sessions**
- This site averages ~**950 sessions per month**

So a few runs a day outnumber real visitors — and it reads as **growth, not noise**. The pages are real, the events well-formed, and nothing in GA4 marks them synthetic. That's what makes it dangerous: it silently corrupts the baseline this work exists to establish.

Sources include this repo's own automation: `scripts/visual-regression/capture.mjs` drives real Chromium at production, and the scheduled prod-smoke and outbound-links workflows touch it too.

`docs/ANALYTICS-STAGING-FILTER.md` doesn't cover this — it addresses *hostname*-based staging pollution, and these hits arrive on the production hostname.

## Change

`isAutomatedBrowser()` gates all tag loading on `navigator.webdriver`, which Playwright, Puppeteer, and Lighthouse set. Not general bot defence — a determined scraper can unset it — but precisely aimed at the automation we run ourselves, which is the source that matters here.

Two deliberate choices:

- **The guard lives in `loadDefaultTags`**, not in each individual loader, so a tag added later cannot slip past it.
- **`dataLayer` pushes from `trackConversion()` are NOT suppressed.** With no tags loaded nothing forwards them, so they're harmless, and keeping them means the conversion e2e tests stay meaningful without needing the opt-in.

The Playwright suite opts back in via `window.__ffcAllowAutomatedAnalytics` (set in `addInitScript`) because it exists to exercise tag loading. That means the guard would otherwise be verified only by its own bypass, so it has dedicated unit coverage in `__tests__/lib/automated-browser.test.ts`.

## Testing

- `npm run lint` — clean
- `npm run build` — static export succeeds
- `npm test` — **689 passing**, 52 suites (4 new)
- `npx playwright test tests/analytics-loading.spec.ts tests/conversion-events.spec.ts` — **11 passing**

## Related, not fixed here

Cross-domain measurement is **confirmed broken**: a real donate click produced `https://www.zeffy.com/en-US/donation-form/da2dd4cf-…` with no `_gl` parameter. The `linker_domains` entry on the GTM Google tag is not honoured — the Tag Manager API accepted a key it doesn't validate. The fix is in the GA4 Admin UI (Data Streams → Configure tag settings → Configure your domains) and is not exposed by any API version, verified against both `analyticsadmin` discovery documents. Tracked in #510.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NY27Zb9yfEkKFLeN5WRrPF)_