### PR TITLE
docs: correct the staging-filter runbook after 1,019 localhost sessions

### DIFF
--- a/docs/ANALYTICS-STAGING-FILTER.md
+++ b/docs/ANALYTICS-STAGING-FILTER.md
@@ -129,16 +129,36 @@ That is no longer true:** GA4 delivery moved into GTM at the issue #510
 cutover (`GA_DELIVERY = 'gtm'`, container version 2 published), so the
 GTM path below is now live and is the strongest available fix.
 
-Add a **trigger exception** so the GA4 tags only fire on production
-hostnames:
+Add **trigger exceptions** so the GA4 tags only fire on production
+hostnames. You need **two** blocking triggers, not one — see the warning
+below.
 
-1. GTM → **Triggers** → New → _Page View_ (or _Custom Event_ matching
-   `.*` with regex, to cover the conversion events too)
-2. Condition: built-in **Page Hostname** → **does not match RegEx** →
-   `^(www\.)?freeforcharity\.org$` — this is the blocking trigger
-3. Add it as an **Exception** on the Google tag and on each of the four
-   conversion event tags
-4. Publish a new container version
+Both use the same condition: built-in **Page Hostname** → **does not
+match RegEx** → `^(www\.)?freeforcharity\.org$`.
+
+1. GTM → **Triggers** → New → _Initialization_ → add the condition.
+   Name it something like `Block — non-production hostname (init)`.
+2. GTM → **Triggers** → New → _Custom Event_ → **Event name** `.*` with
+   **use regex matching** checked → add the same condition. Name it
+   `Block — non-production hostname (custom event)`.
+3. On the **Google tag**, add the _Initialization_ blocker as an
+   **Exception**. That tag fires on the built-in **Initialization – All
+   Pages** trigger (`2147479553`), so the exception has to be an
+   Initialization trigger to match.
+4. On each of the **four conversion event tags** (`donate_open`,
+   `donate_form_view`, `volunteer_apply`, `service_application_start`),
+   add the _Custom Event_ blocker as an Exception.
+5. Publish a new container version.
+
+> **One blocking trigger will not cover both.** GTM evaluates an
+> exception only on the event type its own trigger listens for. A Page
+> View or Initialization blocker is never evaluated when a tag fires on a
+> Custom Event, and vice versa — so a single exception silently protects
+> only half the tags while appearing to be applied everywhere. This step
+> originally described picking _Page View_ **or** _Custom Event_ as
+> though they were interchangeable; they are not, and the Page View
+> option was doubly wrong because the Google tag fires on Initialization,
+> which a Page View blocker also misses.
 
 **Match both apex and `www.`, and anchor the pattern.** The hostname
 table above is the reason: real traffic is split ~70/30 between `www.`
@@ -148,11 +168,19 @@ silent, since a tag that never fires looks identical to a site with no
 visitors. The `^…$` anchors matter too: an unanchored
 `freeforcharity.org` would also allow `freeforcharity.org.example.com`.
 
-Verify before publishing: GTM **Preview** on both `https://freeforcharity.org/`
-and `https://www.freeforcharity.org/` should show the GA4 tags _fired_,
-and on `http://localhost:3000/` show them _blocked by exception_. All
-three checks are needed — the www case is the one this step originally
-got wrong.
+Verify before publishing, in GTM **Preview**. Both failure modes this
+step has already been written wrong for are invisible without it, so
+check all four cells:
+
+| Preview on                        | Google tag | Conversion event tags               |
+| --------------------------------- | ---------- | ----------------------------------- |
+| `https://freeforcharity.org/`     | fired      | fired (click a donate / apply link) |
+| `https://www.freeforcharity.org/` | fired      | fired                               |
+| `http://localhost:3000/`          | not fired  | not fired                           |
+
+On localhost both rows must show the tags under **Blocked** with the
+exception named. Checking only the Google tag is how you ship a container
+that still records every synthetic conversion event.
 
 This supersedes GA4 Option B, which is now obsolete as written: under
 GTM delivery the GA4 config call is GTM's, not this site's, so

--- a/docs/ANALYTICS-STAGING-FILTER.md
+++ b/docs/ANALYTICS-STAGING-FILTER.md
@@ -60,11 +60,13 @@ Collection still happens, but every report shows production only. Zero
 risk of accidentally dropping real production data.
 
 1. GA4 → **Reports** → any report → **Add comparison / Edit comparisons**
-2. Build a comparison: **Dimension = `Hostname`**, **Match type = exactly matches**, **Value = `freeforcharity.org`**
+2. Build a comparison: **Dimension = `Hostname`**, **Match type = matches regex**, **Value = `^(www\.)?freeforcharity\.org$`**
 3. Apply. For ad-hoc analysis, do the same in **Explore** → add a filter on the `Hostname` dimension.
 
-You can also add `www.freeforcharity.org` with an "OR" condition if the
-www host ever serves pages directly.
+**Include `www.`** — it is not hypothetical. The hostname table above
+shows `www.freeforcharity.org` carrying most real sessions and the bare
+apex carrying a handful, so an apex-only comparison hides nearly all of
+your genuine traffic while looking like it worked.
 
 ### Option B — Stop collection entirely (superseded — see [GTM](#gtm))
 
@@ -124,11 +126,26 @@ hostnames:
 
 1. GTM → **Triggers** → New → _Page View_ (or _Custom Event_ matching
    `.*` with regex, to cover the conversion events too)
-2. Condition: built-in **Page Hostname** → **does not equal**
-   `freeforcharity.org` — this is the blocking trigger
+2. Condition: built-in **Page Hostname** → **does not match RegEx** →
+   `^(www\.)?freeforcharity\.org$` — this is the blocking trigger
 3. Add it as an **Exception** on the Google tag and on each of the four
    conversion event tags
 4. Publish a new container version
+
+**Match both apex and `www.`, and anchor the pattern.** The hostname
+table above is the reason: most real sessions arrive on
+`www.freeforcharity.org`, so a condition that allows only the bare apex
+would block the majority of legitimate production traffic — the exact
+opposite of the intent, and silent, since a tag that never fires looks
+identical to a site with no visitors. The `^…$` anchors matter too: an
+unanchored `freeforcharity.org` would also allow
+`freeforcharity.org.example.com`.
+
+Verify before publishing: GTM **Preview** on both `https://freeforcharity.org/`
+and `https://www.freeforcharity.org/` should show the GA4 tags _fired_,
+and on `http://localhost:3000/` show them _blocked by exception_. All
+three checks are needed — the www case is the one this step originally
+got wrong.
 
 This supersedes GA4 Option B, which is now obsolete as written: under
 GTM delivery the GA4 config call is GTM's, not this site's, so

--- a/docs/ANALYTICS-STAGING-FILTER.md
+++ b/docs/ANALYTICS-STAGING-FILTER.md
@@ -45,10 +45,13 @@ not a rounding error, and on 20260726 it actually outran `www.`. Any
 filter or trigger condition that names only one host is wrong.
 
 Two things follow. First, the code-level guard is the actual fix and it
-has landed: `isAutomatedBrowser()` in `src/lib/analytics-config.ts`
-(PR #512) skips all tag loading when `navigator.webdriver` is set, which
-covers Playwright, Puppeteer, and Lighthouse — i.e. every automated
-source this repo runs. Second, the filters below are still needed, both
+has landed (PR #512): `isAutomatedBrowser()` in
+`src/lib/analytics-config.ts` is the predicate — it reports whether
+`navigator.webdriver` is set — and the early return that acts on it lives
+in `loadDefaultTags()` in `src/components/cookie-consent/index.tsx`,
+which returns before injecting anything. Between them that covers
+Playwright, Puppeteer, and Lighthouse — i.e. every automated source this
+repo runs. Second, the filters below are still needed, both
 to exclude the ~1,000 sessions already collected (nothing here is
 retroactive at the collection layer — only report filters can hide
 history) and to catch hits from a hand-driven `npm run dev` browser,
@@ -83,12 +86,21 @@ The original plan here was for **this site** to send
 `location.hostname !== 'freeforcharity.org'`, paired with the built-in
 _Internal Traffic_ data filter set to **Exclude**.
 
-That is no longer the right place for it. Since the issue #510 cutover
-this site emits no GA4 config of its own (`GA_DELIVERY = 'gtm'`) — the
-config belongs to GTM's Google tag, so the equivalent change is a GTM
+That is no longer the right place for it **while `GA_DELIVERY = 'gtm'`**,
+which is the default and what production runs since the issue #510
+cutover. Under that mode the site emits no GA4 config of its own — the
+config belongs to GTM's Google tag — so the equivalent change is a GTM
 field or, better, the hostname **trigger exception** in the GTM section
-below. Don't add `traffic_type` to this codebase; it would have nothing
-to attach to.
+below. Adding `traffic_type` to this codebase would have nothing to
+attach to.
+
+The qualifier is deliberate: `NEXT_PUBLIC_GA_DELIVERY=direct` restores
+the self-contained gtag path (the documented rollback, and what a local
+`direct` build exercises), and in _that_ mode this site does emit its own
+config and a `traffic_type` field there would work. So if you are reading
+this during a rollback, Option B is live again and the GTM section below
+is the part that does not apply. Check which mode the build under
+investigation actually used before trusting either.
 
 The data-filter half still applies if you go the GTM-field route: GA4 →
 Admin → Data Settings → **Data Filters** → _Internal Traffic_ →

--- a/docs/ANALYTICS-STAGING-FILTER.md
+++ b/docs/ANALYTICS-STAGING-FILTER.md
@@ -154,29 +154,40 @@ below.
 Both use the same condition: built-in **Page Hostname** → **does not
 match RegEx** → `^(www\.)?freeforcharity\.org$`.
 
-1. GTM → **Triggers** → New → _Initialization_ → add the condition.
-   Name it something like `Block — non-production hostname (init)`.
-2. GTM → **Triggers** → New → _Custom Event_ → **Event name** `.*` with
+1. **Read the Google tag's own trigger first.** GTM → **Tags** → the
+   Google tag → note what is listed under _Triggering_. It is one of the
+   built-ins — _All Pages_, _Initialization – All Pages_, or _Consent
+   Initialization – All Pages_ — and **you must match it**, because an
+   exception of a different type is never evaluated (see the warning).
+   Don't assume: the two FFC containers genuinely differ here.
+   `GTM-NJ4DXH9` (freeforcharity.org) fires its Google tag on built-in
+   trigger `2147479553`, while `GTM-WMZH965Q` (ffcadmin.org) uses
+   `2147479573`. The Tag Manager API returns only these numeric ids and
+   does not expose their names, so the UI is the authority — go look.
+2. GTM → **Triggers** → New → the **same type** you just read → add the
+   condition. Name it `Block — non-production hostname (page)`.
+3. GTM → **Triggers** → New → _Custom Event_ → **Event name** `.*` with
    **use regex matching** checked → add the same condition. Name it
    `Block — non-production hostname (custom event)`.
-3. On the **Google tag**, add the _Initialization_ blocker as an
-   **Exception**. That tag fires on the built-in **Initialization – All
-   Pages** trigger (`2147479553`), so the exception has to be an
-   Initialization trigger to match.
-4. On each of the **four conversion event tags** (`donate_open`,
+4. On the **Google tag**, add the blocker from step 2 as an **Exception**.
+5. On each of the **four conversion event tags** (`donate_open`,
    `donate_form_view`, `volunteer_apply`, `service_application_start`),
    add the _Custom Event_ blocker as an Exception.
-5. Publish a new container version.
+6. Publish a new container version.
 
 > **One blocking trigger will not cover both.** GTM evaluates an
-> exception only on the event type its own trigger listens for. A Page
-> View or Initialization blocker is never evaluated when a tag fires on a
-> Custom Event, and vice versa — so a single exception silently protects
-> only half the tags while appearing to be applied everywhere. This step
-> originally described picking _Page View_ **or** _Custom Event_ as
-> though they were interchangeable; they are not, and the Page View
-> option was doubly wrong because the Google tag fires on Initialization,
-> which a Page View blocker also misses.
+> exception only on the event type its own trigger listens for. A page-
+> level blocker (_All Pages_ / _Initialization_) is never evaluated when a
+> tag fires on a Custom Event, and vice versa — so a single exception
+> silently protects only half the tags while appearing to be applied
+> everywhere. This step originally described picking _Page View_ **or**
+> _Custom Event_ as though they were interchangeable; they are not.
+>
+> It then went too far the other way and asserted the Google tag fires on
+> _Initialization – All Pages_, naming trigger `2147479553` as that
+> trigger. That mapping is unverified — the API exposes the id but not its
+> name — so the instruction is now "read the tag's actual trigger and
+> match it" rather than a guess dressed as a fact. Step 1 is the check.
 
 **Match both apex and `www.`, and anchor the pattern.** The hostname
 table above is the reason: real traffic is split ~70/30 between `www.`

--- a/docs/ANALYTICS-STAGING-FILTER.md
+++ b/docs/ANALYTICS-STAGING-FILTER.md
@@ -10,9 +10,41 @@ That's intentional (it lets you validate analytics on staging before the
 flip), but it means production reporting will include staging + dev hits
 unless you filter them out. This doc is the operator runbook for that.
 
-The volume is usually tiny (staging validation is a short window, dev
-hits require a developer to accept the cookie banner on localhost), so
-this is data-hygiene, not an emergency.
+**This was originally filed as data-hygiene rather than an emergency, on
+the reasoning that "the volume is usually tiny — dev hits require a
+developer to accept the cookie banner on localhost." That reasoning was
+wrong on both halves, and measured production data now contradicts it.**
+
+Consent Mode removed the banner gate (tags load on the first pageview,
+storage is what consent governs), so nothing has to be clicked for a
+localhost hit to be recorded. And automated runs are not one-at-a-time:
+each Playwright pass over the ~58-page sitemap produces a session per
+page with a fresh client id. Hostname breakdown from the GA4 Data API:
+
+| Date     | Hostname                 | Sessions  | Pageviews |
+| -------- | ------------------------ | --------- | --------- |
+| 20260723 | `www.freeforcharity.org` | 19        | 21        |
+| 20260724 | `www.freeforcharity.org` | 9         | 8         |
+| 20260724 | `localhost`              | 4         | 4         |
+| 20260725 | `localhost`              | **1,019** | **1,318** |
+| 20260725 | `www.freeforcharity.org` | 13        | 17        |
+| 20260726 | `freeforcharity.org`     | 2         | 2         |
+
+Real traffic runs ~10–20 sessions a day. A single day of local test runs
+produced **1,019** — roughly half the property's entire 28-day session
+count, and about 50× that day's real traffic. Nothing in GA4 marks it as
+synthetic: the pages are real and the events are well-formed, so it
+reads as a traffic surge.
+
+Two things follow. First, the code-level guard is the actual fix and it
+has landed: `isAutomatedBrowser()` in `src/lib/analytics-config.ts`
+(PR #512) skips all tag loading when `navigator.webdriver` is set, which
+covers Playwright, Puppeteer, and Lighthouse — i.e. every automated
+source this repo runs. Second, the filters below are still needed, both
+to exclude the ~1,000 sessions already collected (nothing here is
+retroactive at the collection layer — only report filters can hide
+history) and to catch hits from a hand-driven `npm run dev` browser,
+which sets no `webdriver` flag and is therefore invisible to the guard.
 
 ---
 
@@ -34,19 +66,23 @@ risk of accidentally dropping real production data.
 You can also add `www.freeforcharity.org` with an "OR" condition if the
 www host ever serves pages directly.
 
-### Option B — Stop collection entirely (stronger, more setup)
+### Option B — Stop collection entirely (superseded — see [GTM](#gtm))
 
-If you'd rather staging hits never reach GA4 at all, use the
-`traffic_type` parameter + Internal Traffic data filter:
+The original plan here was for **this site** to send
+`traffic_type: 'internal'` on its GA4 config call whenever
+`location.hostname !== 'freeforcharity.org'`, paired with the built-in
+_Internal Traffic_ data filter set to **Exclude**.
 
-1. The site would need to send `traffic_type: 'internal'` on the GA4
-   config call when `location.hostname !== 'freeforcharity.org'`. That's
-   a small code change — **ask and we'll add it**; it's deliberately not
-   in the build today because you chose the report-filter approach.
-2. GA4 → Admin → Data Settings → **Data Filters** → the built-in
-   _Internal Traffic_ filter is set to **Exclude** `traffic_type = internal`.
+That is no longer the right place for it. Since the issue #510 cutover
+this site emits no GA4 config of its own (`GA_DELIVERY = 'gtm'`) — the
+config belongs to GTM's Google tag, so the equivalent change is a GTM
+field or, better, the hostname **trigger exception** in the GTM section
+below. Don't add `traffic_type` to this codebase; it would have nothing
+to attach to.
 
-Until that code change lands, Option A is the working path.
+The data-filter half still applies if you go the GTM-field route: GA4 →
+Admin → Data Settings → **Data Filters** → _Internal Traffic_ →
+**Exclude** `traffic_type = internal`.
 
 ### Option C — IP-based Internal Traffic filter
 
@@ -77,12 +113,34 @@ Clarity has no hostname data-filter either. Options, in order of effort:
 
 ## GTM
 
-GTM itself doesn't "collect" — it just fires tags. If you later move GA4
-_into_ GTM (instead of the current direct gtag), add a **trigger
-exception** so the GA4 tag only fires when the built-in `Page Hostname`
-variable equals `freeforcharity.org`. That's the cleanest "never collect
-from staging" option and supersedes GA4 Option B. (Today GA4 fires
-directly, not via GTM, so this doesn't apply yet.)
+GTM itself doesn't "collect" — it just fires tags. **This section used to
+say "today GA4 fires directly, not via GTM, so this doesn't apply yet."
+That is no longer true:** GA4 delivery moved into GTM at the issue #510
+cutover (`GA_DELIVERY = 'gtm'`, container version 2 published), so the
+GTM path below is now live and is the strongest available fix.
+
+Add a **trigger exception** so the GA4 tags only fire on production
+hostnames:
+
+1. GTM → **Triggers** → New → _Page View_ (or _Custom Event_ matching
+   `.*` with regex, to cover the conversion events too)
+2. Condition: built-in **Page Hostname** → **does not equal**
+   `freeforcharity.org` — this is the blocking trigger
+3. Add it as an **Exception** on the Google tag and on each of the four
+   conversion event tags
+4. Publish a new container version
+
+This supersedes GA4 Option B, which is now obsolete as written: under
+GTM delivery the GA4 config call is GTM's, not this site's, so
+`traffic_type` would be a field on the GTM Google tag rather than a code
+change here.
+
+Unlike the code-level `navigator.webdriver` guard, a hostname exception
+catches _every_ non-production hit — including a developer clicking
+around a hand-run `npm run dev` server, which the guard cannot see. The
+two are complementary, not redundant: the guard stops the hits before
+they leave the browser (so they never cost anything), and the exception
+is the catch-all for whatever the guard misses.
 
 ---
 
@@ -90,5 +148,12 @@ directly, not via GTM, so this doesn't apply yet.)
 
 Once WordPress is retired and only `freeforcharity.org` serves the
 Next.js export, staging stops existing and the only non-prod hits are
-occasional localhost dev sessions. The Option A report filter keeps
-those out indefinitely with no maintenance.
+localhost dev sessions.
+
+Do not read that as "so this stops mattering" — the 2026-07-25 figures
+above are localhost dev/test hits **after** staging had already stopped
+being the concern, and they were the largest single source of traffic in
+the property. The `navigator.webdriver` guard plus the Option A report
+comparison keep them out with no ongoing maintenance; the GTM hostname
+exception closes the remaining hand-driven-`npm run dev` gap if you want
+collection stopped rather than filtered.

--- a/docs/ANALYTICS-STAGING-FILTER.md
+++ b/docs/ANALYTICS-STAGING-FILTER.md
@@ -19,7 +19,13 @@ Consent Mode removed the banner gate (tags load on the first pageview,
 storage is what consent governs), so nothing has to be clicked for a
 localhost hit to be recorded. And automated runs are not one-at-a-time:
 each Playwright pass over the ~58-page sitemap produces a session per
-page with a fresh client id. Hostname breakdown from the GA4 Data API:
+page with a fresh client id.
+
+**Sessions** by hostname, from the GA4 Data API (`sessions` metric,
+`hostName` dimension). Every figure below is a session count, not
+pageviews or events — the same unit the "sessions a day" comparisons
+after the table use. `—` means the host reported no sessions that day at
+all, i.e. the row is absent from the API response rather than zero-valued.
 
 | Date     | `www.freeforcharity.org` | `freeforcharity.org` | `localhost` |
 | -------- | ------------------------ | -------------------- | ----------- |
@@ -87,7 +93,7 @@ The original plan here was for **this site** to send
 _Internal Traffic_ data filter set to **Exclude**.
 
 That is no longer the right place for it **while `GA_DELIVERY = 'gtm'`**,
-which is the default and what production runs since the issue #510
+which is the default and what production has run since the issue #510
 cutover. Under that mode the site emits no GA4 config of its own — the
 config belongs to GTM's Google tag — so the equivalent change is a GTM
 field or, better, the hostname **trigger exception** in the GTM section

--- a/docs/ANALYTICS-STAGING-FILTER.md
+++ b/docs/ANALYTICS-STAGING-FILTER.md
@@ -21,20 +21,28 @@ localhost hit to be recorded. And automated runs are not one-at-a-time:
 each Playwright pass over the ~58-page sitemap produces a session per
 page with a fresh client id. Hostname breakdown from the GA4 Data API:
 
-| Date     | Hostname                 | Sessions  | Pageviews |
-| -------- | ------------------------ | --------- | --------- |
-| 20260723 | `www.freeforcharity.org` | 19        | 21        |
-| 20260724 | `www.freeforcharity.org` | 9         | 8         |
-| 20260724 | `localhost`              | 4         | 4         |
-| 20260725 | `localhost`              | **1,019** | **1,318** |
-| 20260725 | `www.freeforcharity.org` | 13        | 17        |
-| 20260726 | `freeforcharity.org`     | 2         | 2         |
+| Date     | `www.freeforcharity.org` | `freeforcharity.org` | `localhost` |
+| -------- | ------------------------ | -------------------- | ----------- |
+| 20260720 | 17                       | 7                    | 2           |
+| 20260721 | 12                       | 5                    | —           |
+| 20260722 | 22                       | 5                    | —           |
+| 20260723 | 19                       | 5                    | —           |
+| 20260724 | 9                        | 5                    | 4           |
+| 20260725 | 13                       | 9                    | **1,019**   |
+| 20260726 | 1                        | 2                    | —           |
+| **Sum**  | **93**                   | **38**               | **1,025**   |
 
-Real traffic runs ~10–20 sessions a day. A single day of local test runs
-produced **1,019** — roughly half the property's entire 28-day session
-count, and about 50× that day's real traffic. Nothing in GA4 marks it as
-synthetic: the pages are real and the events are well-formed, so it
-reads as a traffic surge.
+Real traffic runs ~15–25 sessions a day across both production hosts. A
+single day of local test runs produced **1,019** — roughly half the
+property's entire 28-day session count, and about 45× that day's real
+traffic. Nothing in GA4 marks it as synthetic: the pages are real and
+the events are well-formed, so it reads as a traffic surge.
+
+Note the split between the two production hosts, because the filters
+below depend on it: `www.` carries about 70% of real sessions and the
+apex about 30%. **Both are ordinary production traffic** — the apex is
+not a rounding error, and on 20260726 it actually outran `www.`. Any
+filter or trigger condition that names only one host is wrong.
 
 Two things follow. First, the code-level guard is the actual fix and it
 has landed: `isAutomatedBrowser()` in `src/lib/analytics-config.ts`
@@ -63,10 +71,10 @@ risk of accidentally dropping real production data.
 2. Build a comparison: **Dimension = `Hostname`**, **Match type = matches regex**, **Value = `^(www\.)?freeforcharity\.org$`**
 3. Apply. For ad-hoc analysis, do the same in **Explore** → add a filter on the `Hostname` dimension.
 
-**Include `www.`** — it is not hypothetical. The hostname table above
-shows `www.freeforcharity.org` carrying most real sessions and the bare
-apex carrying a handful, so an apex-only comparison hides nearly all of
-your genuine traffic while looking like it worked.
+**Match both hosts.** The hostname table above shows `www.` at ~70% of
+real sessions and the apex at ~30%, so a comparison naming either one
+alone silently discards a large slice of genuine traffic while looking
+like it worked.
 
 ### Option B — Stop collection entirely (superseded — see [GTM](#gtm))
 
@@ -133,13 +141,12 @@ hostnames:
 4. Publish a new container version
 
 **Match both apex and `www.`, and anchor the pattern.** The hostname
-table above is the reason: most real sessions arrive on
-`www.freeforcharity.org`, so a condition that allows only the bare apex
-would block the majority of legitimate production traffic — the exact
-opposite of the intent, and silent, since a tag that never fires looks
-identical to a site with no visitors. The `^…$` anchors matter too: an
-unanchored `freeforcharity.org` would also allow
-`freeforcharity.org.example.com`.
+table above is the reason: real traffic is split ~70/30 between `www.`
+and the apex, so a condition allowing only one host blocks a large share
+of legitimate production traffic — the exact opposite of the intent, and
+silent, since a tag that never fires looks identical to a site with no
+visitors. The `^…$` anchors matter too: an unanchored
+`freeforcharity.org` would also allow `freeforcharity.org.example.com`.
 
 Verify before publishing: GTM **Preview** on both `https://freeforcharity.org/`
 and `https://www.freeforcharity.org/` should show the GA4 tags _fired_,


### PR DESCRIPTION
## What

Docs-only. Corrects three claims in `docs/ANALYTICS-STAGING-FILTER.md` that measured production data or the #510 GTM cutover has since invalidated.

## Why

**1. "The volume is usually tiny."** The runbook filed dev/staging pollution as data-hygiene on the reasoning that *"dev hits require a developer to accept the cookie banner on localhost."* Both halves are wrong:

- Consent Mode removed the banner gate — tags load on the first pageview and consent governs *storage*, so nothing needs clicking for a localhost hit to be recorded.
- Automated runs aren't one-at-a-time. Each Playwright pass over the ~58-page sitemap opens a session per page with a fresh client id.

Hostname breakdown from the GA4 Data API:

| Date | Hostname | Sessions | Pageviews |
| --- | --- | --- | --- |
| 20260723 | `www.freeforcharity.org` | 19 | 21 |
| 20260724 | `www.freeforcharity.org` | 9 | 8 |
| 20260724 | `localhost` | 4 | 4 |
| 20260725 | `localhost` | **1,019** | **1,318** |
| 20260725 | `www.freeforcharity.org` | 13 | 17 |
| 20260726 | `freeforcharity.org` | 2 | 2 |

Real traffic runs 10–20 sessions/day. One day of local test runs produced 1,019 — roughly half the property's entire 28-day session count. Nothing in GA4 marks it as synthetic, so it reads as a traffic surge rather than noise.

**2. The GTM section said "GA4 fires directly, not via GTM, so this doesn't apply yet."** GA4 delivery moved into GTM at the #510 cutover (`GA_DELIVERY = 'gtm'`, container version 2 published). The hostname **trigger exception** that section described as hypothetical is now live and is the strongest available fix.

**3. Option B told a reader to add `traffic_type` to this codebase.** Under `GA_DELIVERY = 'gtm'` this site emits no GA4 config call, so there is nothing for that parameter to attach to. Marked superseded and pointed at the GTM route.

## Changes

- Replaced the "volume is usually tiny" paragraph with the measured breakdown and an explicit correction of the earlier reasoning.
- Pointed at the landed `isAutomatedBrowser()` guard (#512) as the actual fix, and kept the filters as the *retroactive* path — nothing is retroactive at the collection layer, so only report filters can hide the ~1,000 sessions already collected.
- Noted the gap the guard cannot close: a hand-driven `npm run dev` browser sets no `webdriver` flag.
- Rewrote Option B as superseded; rewrote the GTM section as the live, recommended fix with concrete steps.
- Rewrote "After the flip" so it no longer implies the problem disappears once staging does — the 1,019 sessions happened after staging had stopped being the concern.

## Testing

Docs-only; no code paths touched. `format:check` and `lint` pass via the pre-commit hook, formatted with the CI-pinned `prettier@3.8.1`.

Refs #510

---
_Generated by [Claude Code](https://claude.ai/code/session_01NY27Zb9yfEkKFLeN5WRrPF)_