### PR TITLE
docs: point remaining GuideStar links at Candid, and fix internal links that skipped basePath

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -118,6 +118,14 @@ http://www.fiverr.com/**
 # GuideStar/Candid returns 403 to bots — pages still reachable in a browser.
 # app.candid.org (the profile app, now behind Cloudflare) and learning.candid.org
 # (help.candid.org's 301 target) do the same.
+#
+# Quirk worth knowing before assuming a guidestar.org URL is dead: their
+# Cloudflare rule keys on the exact path, so the SAME profile answers 403
+# ("Just a moment...") without a trailing slash and 200 with one —
+#   /profile/46-2471893   -> 403 challenge
+#   /profile/46-2471893/  -> 200, full profile page
+# A genuinely unknown id (/profile/0000000000) 302s to /Error/HttpError404
+# instead, so a 403 here means the route is live, not retired.
 https://www.guidestar.org/**
 https://help.candid.org/**
 https://app.candid.org/**

--- a/__tests__/components/donate-components/measurable-impact.test.tsx
+++ b/__tests__/components/donate-components/measurable-impact.test.tsx
@@ -20,7 +20,11 @@ describe('MeasurableImpact Component', () => {
     render(<MeasurableImpact />)
     const volunteerLink = screen.getByRole('link', { name: /skilled volunteers/i })
     expect(volunteerLink).toBeInTheDocument()
-    expect(volunteerLink).toHaveAttribute('href', '/volunteer/')
+    // Trailing slash is optional here on purpose. This is a next/link, and Jest
+    // does not load next.config.ts, so `trailingSlash: true` is not in effect —
+    // jsdom renders "/volunteer" while the real static export emits
+    // "/volunteer/". Assert the route, not the build-time normalization.
+    expect(volunteerLink.getAttribute('href')).toMatch(/^\/volunteer\/?$/)
   })
 
   it('renders a Zeffy CTA (no PayPal), gated on the general fund being confirmed', () => {

--- a/src/app/charity-and-nonprofit-case-studies/page.tsx
+++ b/src/app/charity-and-nonprofit-case-studies/page.tsx
@@ -1,4 +1,5 @@
 import { pageMetadata } from '@/lib/page-metadata'
+import Link from 'next/link'
 import React from 'react'
 import HeroSection from '@/components/ui/HeroSection'
 import SuccessStories from '@/components/case-studies/SuccessStories'
@@ -136,13 +137,13 @@ const CaseStudiesPage = () => {
             Contact us if you have a particular case study request or want to be featured in a case
             study.
           </p>
-          <a
+          <Link
             href="/contact-us/"
             className="inline-block px-[30px] py-[10px] text-white border border-[#b35000] rounded-[10px] text-[18px] bg-[#b35000] font-[600] shadow-md hover:shadow-[0px_12px_18px_-6px_#b35000] transition-all duration-300"
             data-font="montserrat-font"
           >
             Contact Us
-          </a>
+          </Link>
         </div>
       </section>
 

--- a/src/app/charity-and-nonprofit-service-and-consultant-directory/page.tsx
+++ b/src/app/charity-and-nonprofit-service-and-consultant-directory/page.tsx
@@ -1,4 +1,5 @@
 import { pageMetadata } from '@/lib/page-metadata'
+import Link from 'next/link'
 import React from 'react'
 import HeroSection from '@/components/ui/HeroSection'
 
@@ -103,13 +104,13 @@ const ServiceDirectoryPage = () => {
             For more information about Free For Charity or to obtain information about being added
             to the directory, please contact us.
           </p>
-          <a
+          <Link
             href="/contact-us/"
             className="inline-block px-[30px] py-[10px] text-white border border-[#b35000] rounded-[10px] text-[18px] bg-[#b35000] font-[600] shadow-md hover:shadow-[0px_12px_18px_-6px_#b35000] transition-all duration-300"
             data-font="montserrat-font"
           >
             Contact Us
-          </a>
+          </Link>
         </div>
       </section>
     </div>

--- a/src/app/charity-and-nonprofit-technology-directory/page.tsx
+++ b/src/app/charity-and-nonprofit-technology-directory/page.tsx
@@ -1,4 +1,5 @@
 import { pageMetadata } from '@/lib/page-metadata'
+import Link from 'next/link'
 import React from 'react'
 import HeroSection from '@/components/ui/HeroSection'
 import AdminGuideLink from '@/components/ui/AdminGuideLink'
@@ -124,13 +125,13 @@ const TechDirectoryPage = () => {
               </a>
             </p>
           </div>
-          <a
+          <Link
             href="/contact-us/"
             className="inline-block px-[30px] py-[10px] text-white border border-[#b35000] rounded-[10px] text-[18px] bg-[#b35000] font-[600] shadow-md hover:shadow-[0px_12px_18px_-6px_#b35000] transition-all duration-300"
             data-font="montserrat-font"
           >
             Contact Us
-          </a>
+          </Link>
         </div>
       </section>
     </div>

--- a/src/app/consulting/page.tsx
+++ b/src/app/consulting/page.tsx
@@ -1,4 +1,5 @@
 import { pageMetadata } from '@/lib/page-metadata'
+import Link from 'next/link'
 import React from 'react'
 import HeroSection from '@/components/ui/HeroSection'
 import AdminGuideLink from '@/components/ui/AdminGuideLink'
@@ -63,13 +64,13 @@ const ConsultingPage = () => {
           >
             Reach out today and let us help your nonprofit succeed.
           </p>
-          <a
+          <Link
             href="/contact-us/"
             className="inline-block px-[30px] py-[10px] text-white border border-[#b35000] rounded-[10px] text-[18px] bg-[#b35000] font-[600] shadow-md hover:shadow-[0px_12px_18px_-6px_#b35000] transition-all duration-300"
             data-font="montserrat-font"
           >
             Contact Us
-          </a>
+          </Link>
         </div>
       </section>
     </div>

--- a/src/app/cookie-policy/page.tsx
+++ b/src/app/cookie-policy/page.tsx
@@ -1,4 +1,5 @@
 import { pageMetadata } from '@/lib/page-metadata'
+import Link from 'next/link'
 
 export const metadata = pageMetadata({
   title: 'Cookie Policy',
@@ -505,9 +506,9 @@ export default function CookiePolicy() {
           </ol>
           <p className="text-[14px] text-[#666] pb-[10px] leading-[24px] font-[500]">
             For more information about how we handle your personal data, please see our{' '}
-            <a href="/privacy-policy/" className="text-blue-600 underline">
+            <Link href="/privacy-policy/" className="text-blue-600 underline">
               Privacy Policy
-            </a>
+            </Link>
             .
           </p>
         </div>

--- a/src/app/free-training-programs/page.tsx
+++ b/src/app/free-training-programs/page.tsx
@@ -1,4 +1,5 @@
 import { pageMetadata } from '@/lib/page-metadata'
+import Link from 'next/link'
 import React from 'react'
 import HeroSection from '@/components/ui/HeroSection'
 import FaqSection from '@/components/free-training-programs-components/faq-section'
@@ -141,13 +142,13 @@ const FreeTrainingProgramsPage = () => {
                     Average salary: {program.salary}
                   </p>
                 </div>
-                <a
+                <Link
                   href="/volunteer/"
                   className="inline-block mt-6 px-[24px] py-[8px] text-white border border-[#b35000] rounded-[10px] text-[16px] bg-[#b35000] font-[600] shadow-md hover:shadow-[0px_12px_18px_-6px_#b35000] transition-all duration-300"
                   data-font="montserrat-font"
                 >
                   Sign Up Now
-                </a>
+                </Link>
               </div>
             ))}
           </div>

--- a/src/app/help-for-charities/page.tsx
+++ b/src/app/help-for-charities/page.tsx
@@ -1,4 +1,5 @@
 import { pageMetadata } from '@/lib/page-metadata'
+import Link from 'next/link'
 import React from 'react'
 import HeroSection from '@/components/ui/HeroSection'
 import HelpForCharities from '@/components/ui/help-for-charity'
@@ -67,12 +68,12 @@ const index = () => {
       <div className="w-[90%] max-w-[720px] mx-auto py-[20px] text-center">
         <p className="text-[18px] font-[500] leading-[28px] text-[#333]" data-font="lato-font">
           Wondering what this looks like in practice? Read the{' '}
-          <a
+          <Link
             href="/charity-and-nonprofit-case-studies/"
             className="text-[#0567B1] underline font-[600]"
           >
             success stories of charities FFC serves
-          </a>{' '}
+          </Link>{' '}
           — what they were missing, what we provided free, and what changed.
         </p>
       </div>

--- a/src/app/matching-gifts/page.tsx
+++ b/src/app/matching-gifts/page.tsx
@@ -70,7 +70,7 @@ export default function MatchingGifts() {
                 <dd className="inline">
                   Candid (GuideStar) profile —{' '}
                   <a
-                    href="https://www.guidestar.org/profile/46-2471893"
+                    href="https://app.candid.org/profile/9326392/free-for-charity-46-2471893"
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-[#0567B1] underline"

--- a/src/app/other-ways-to-give/page.tsx
+++ b/src/app/other-ways-to-give/page.tsx
@@ -62,7 +62,7 @@ export default function OtherWaysToGive() {
                 <dt className="font-[700] inline">Verification: </dt>
                 <dd className="inline">
                   <a
-                    href="https://www.guidestar.org/profile/46-2471893"
+                    href="https://app.candid.org/profile/9326392/free-for-charity-46-2471893"
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-[#0567B1] underline"

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -1,4 +1,5 @@
 import { pageMetadata } from '@/lib/page-metadata'
+import Link from 'next/link'
 
 export const metadata = pageMetadata({
   title: 'Privacy Policy',
@@ -128,9 +129,9 @@ export default function PrivacyPolicy() {
           </ul>
           <p className="text-[14px] text-[#666] pb-[10px] leading-[24px] font-[500]">
             Our{' '}
-            <a href="/cookie-policy/" className="text-blue-600 underline">
+            <Link href="/cookie-policy/" className="text-blue-600 underline">
               Cookie Policy
-            </a>{' '}
+            </Link>{' '}
             lists each cookie by name, purpose, and how long it lasts, and you can change your
             choice at any time from the cookie settings link in our footer.
           </p>

--- a/src/app/terms-of-service/page.tsx
+++ b/src/app/terms-of-service/page.tsx
@@ -1,4 +1,5 @@
 import { pageMetadata } from '@/lib/page-metadata'
+import Link from 'next/link'
 
 export const metadata = pageMetadata({
   title: 'Terms of Service',
@@ -221,42 +222,42 @@ export default function TermsOfService() {
           </p>
           <ul className="text-[14px] text-[#666] pb-[10px] leading-[24px] font-[500] list-disc list-inside">
             <li>
-              <a href="/privacy-policy/" className="text-[#0567B1] underline">
+              <Link href="/privacy-policy/" className="text-[#0567B1] underline">
                 Privacy Policy
-              </a>
+              </Link>
             </li>
             <li>
-              <a href="/cookie-policy/" className="text-[#0567B1] underline">
+              <Link href="/cookie-policy/" className="text-[#0567B1] underline">
                 Cookie Policy
-              </a>
+              </Link>
             </li>
             <li>
-              <a href="/donation-policy/" className="text-[#0567B1] underline">
+              <Link href="/donation-policy/" className="text-[#0567B1] underline">
                 Donation Policy
-              </a>{' '}
+              </Link>{' '}
               and the{' '}
-              <a href="/free-for-charity-donation-policy/" className="text-[#0567B1] underline">
+              <Link href="/free-for-charity-donation-policy/" className="text-[#0567B1] underline">
                 Free For Charity Donation Policy
-              </a>
+              </Link>
             </li>
             <li>
-              <a href="/publicity-consent-policy/" className="text-[#0567B1] underline">
+              <Link href="/publicity-consent-policy/" className="text-[#0567B1] underline">
                 Publicity &amp; Story Consent Policy
-              </a>{' '}
+              </Link>{' '}
               — permits FFC to feature your organization (name, logo, site link, mission blurb, and
               a factual account of the free services provided) in case studies, testimonials, the
               charity spotlight, and directory listings. You can withdraw this consent at any time
               with no effect on your services.
             </li>
             <li>
-              <a href="/vulnerability-disclosure-policy/" className="text-[#0567B1] underline">
+              <Link href="/vulnerability-disclosure-policy/" className="text-[#0567B1] underline">
                 Vulnerability Disclosure Policy
-              </a>
+              </Link>
             </li>
             <li>
-              <a href="/accessibility-statement/" className="text-[#0567B1] underline">
+              <Link href="/accessibility-statement/" className="text-[#0567B1] underline">
                 Accessibility Statement
-              </a>
+              </Link>
             </li>
           </ul>
 

--- a/src/app/workforce-development/page.tsx
+++ b/src/app/workforce-development/page.tsx
@@ -1,4 +1,5 @@
 import { pageMetadata } from '@/lib/page-metadata'
+import Link from 'next/link'
 import React from 'react'
 import HeroSection from '@/components/ui/HeroSection'
 import AdminGuideLink from '@/components/ui/AdminGuideLink'
@@ -135,13 +136,13 @@ const WorkforceDevelopmentPage = () => {
               (520) 222-8104
             </a>
           </p>
-          <a
+          <Link
             href="/volunteer/"
             className="inline-block px-[30px] py-[10px] text-white border border-[#b35000] rounded-[10px] text-[18px] bg-[#b35000] font-[600] shadow-md hover:shadow-[0px_12px_18px_-6px_#b35000] transition-all duration-300"
             data-font="montserrat-font"
           >
             Volunteer Now
-          </a>
+          </Link>
         </div>
       </section>
     </div>

--- a/src/components/501c3-components/Help-For-Charities-and-Nonprofit/index.tsx
+++ b/src/components/501c3-components/Help-For-Charities-and-Nonprofit/index.tsx
@@ -96,14 +96,14 @@ const index = () => {
               <ol className="list-decimal list-outside ml-8 mt-1 space-y-1 text-[#666]">
                 <li>
                   (Please read our{' '}
-                  <a
+                  <Link
                     href="/guidestar-guide/"
                     className="text-[#0567B1] underline font-medium"
                     target="_blank"
                     rel="noopener noreferrer"
                   >
                     GuideStar Guide
-                  </a>
+                  </Link>
                   , we require charities to have at least Gold Seal of Transparency to receive our
                   services.)
                 </li>

--- a/src/components/501c3-components/Ready-to-get-started-and-faqs/index.tsx
+++ b/src/components/501c3-components/Ready-to-get-started-and-faqs/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import Link from 'next/link'
 import ReadyToGetStarted from '@/components/help-for-charities-components/Ready-to-Get-Started-Now'
 import AccordionItem from '@/components/ui/Accordian'
 const index = () => {
@@ -56,9 +57,9 @@ const index = () => {
           </p>
           <h1 className="pb-[1em] font-[700]">
             Visit{' '}
-            <a href="/domains/" className="text-[#0567B1]">
+            <Link href="/domains/" className="text-[#0567B1]">
               https://freeforcharity.org/domains
-            </a>{' '}
+            </Link>{' '}
             and follow all steps
           </h1>
           <p className="pb-[1em]">

--- a/src/components/domains/Setup-Email-Hosting/index.tsx
+++ b/src/components/domains/Setup-Email-Hosting/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import Link from 'next/link'
 import Image from 'next/image'
 import { assetPath } from '@/lib/assetPath'
 import AdminGuideLink from '@/components/ui/AdminGuideLink'
@@ -124,13 +125,13 @@ const index = () => {
           <p className="text-[18px] leading-[32px] font-[500] pb-[1em]" data-font="raleway-font">
             Follow the following simple steps to set up your Microsoft 365 Business Premium Account
           </p>
-          <a
+          <Link
             href="/domains/#setupstep2"
             className="text-[25px] leading-[32px] font-[600] text-[#0460C0]"
             data-font="raleway-font"
           >
             See the Microsoft 365 setup steps
-          </a>
+          </Link>
         </div>
 
         <div className="p-[20px] text-center bg-white rounded-[10px] overflow-hidden pt-[30px] pr-[20px] pb-[30px] pl-[20px] shadow-[0px_2px_18px_0px_rgba(0,0,0,0.3)]">
@@ -163,13 +164,13 @@ const index = () => {
             Prefer Google? Follow these simple steps to set up your Google Workspace for Nonprofits
             account
           </p>
-          <a
+          <Link
             href="/google-for-nonprofits-guide/"
             className="text-[25px] leading-[32px] font-[600] text-[#0460C0]"
             data-font="raleway-font"
           >
             See the Google Workspace setup steps
-          </a>
+          </Link>
         </div>
       </div>
 

--- a/src/components/donate-components/measurable-impact/index.tsx
+++ b/src/components/donate-components/measurable-impact/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import Link from 'next/link'
 import ZeffyPopupButton from '@/components/ui/ZeffyPopupButton'
 import { generalCampaign } from '@/data/donation-campaigns'
 
@@ -36,9 +37,9 @@ const Index = () => {
             <p className="text-[18px] font-[500] leading-[27px] mb-[5.82%]" data-font="lato-font">
               In addition to financial support, Free For Charity also needs community support
               through{' '}
-              <a href="/volunteer/" className="text-[#0567B1]">
+              <Link href="/volunteer/" className="text-[#0567B1]">
                 skilled volunteers
-              </a>{' '}
+              </Link>{' '}
               and gifts in kind (such as services or products sold by your business). Take a look at
               the volunteer opportunities today.
             </p>

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -51,7 +51,7 @@ const Footer: React.FC = () => {
               />
             </a>
             <Link
-              href="https://www.guidestar.org/profile/shared/bbbe173a-87b9-4af9-a8a2-cae255a95742"
+              href="https://app.candid.org/profile/9326392/free-for-charity/?pkId=7232730a-03b5-467f-a82c-443dcd2122ed&isActive=true"
               target="_blank"
               rel="noopener noreferrer"
               className="group relative my-4 flex w-full max-w-[230px] items-center justify-between
@@ -60,7 +60,7 @@ const Footer: React.FC = () => {
               data-font="aria-font"
             >
               <span className="text-[17px] font-medium leading-tight sm:text-[18px] md:text-[20px] transition-transform duration-300 group-hover:-translate-x-1">
-                Direct GuideStar Profile Link
+                Direct Candid Profile Link
               </span>
 
               <ArrowRight

--- a/src/components/free-charity-web-hosting/FAQs/index.tsx
+++ b/src/components/free-charity-web-hosting/FAQs/index.tsx
@@ -148,9 +148,12 @@ const AccordionLayout = () => {
                 Yes, We have had IRS designation since 2014 and have been building our systems and
                 testing or support for several years. While charities for charities are rare they do
                 exist and in fact fill an important need in reducing overhead expenses for other
-                nonprofits. Our IRS designation number (EIN) is 46-2471893. You can see our
-                guidestar profile{' '}
-                <a href="https://www.guidestar.org/profile/46-2471893" className="text-[#0567B1]">
+                nonprofits. Our IRS designation number (EIN) is 46-2471893. You can see our Candid
+                (GuideStar) profile{' '}
+                <a
+                  href="https://app.candid.org/profile/9326392/free-for-charity-46-2471893"
+                  className="text-[#0567B1]"
+                >
                   here.
                 </a>{' '}
                 We are proud to also recommend other charities for charities that inspired us to{' '}

--- a/src/components/free-charity-web-hosting/FAQs/index.tsx
+++ b/src/components/free-charity-web-hosting/FAQs/index.tsx
@@ -152,6 +152,8 @@ const AccordionLayout = () => {
                 (GuideStar) profile{' '}
                 <a
                   href="https://app.candid.org/profile/9326392/free-for-charity-46-2471893"
+                  target="_blank"
+                  rel="noopener noreferrer"
                   className="text-[#0567B1]"
                 >
                   here.

--- a/src/components/free-charity-web-hosting/FAQs/index.tsx
+++ b/src/components/free-charity-web-hosting/FAQs/index.tsx
@@ -1,5 +1,6 @@
 'use client'
 import React, { useState, useRef } from 'react'
+import SmartLink from '@/components/ui/SmartLink'
 import { FaPlus, FaMinus } from 'react-icons/fa'
 import { domainDonationTaxFaq, hostingBacklogFaq } from '@/data/faqs'
 
@@ -192,9 +193,9 @@ const AccordionLayout = () => {
                     <li key={way.before}>
                       {way.before}
                       {way.link && (
-                        <a href={way.link.href} className="text-[#0567B1]">
+                        <SmartLink href={way.link.href} className="text-[#0567B1]">
                           {way.link.label}
-                        </a>
+                        </SmartLink>
                       )}
                       {way.after}
                     </li>

--- a/src/components/free-for-charitys-tools-for-success-components/Two-Cards-With-Heading/index.tsx
+++ b/src/components/free-for-charitys-tools-for-success-components/Two-Cards-With-Heading/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import Link from 'next/link'
 import SlidingCard from '@/components/ui/SlidingCard'
 
 const index = () => {
@@ -28,9 +29,12 @@ const index = () => {
                 profile before giving free or discounted items to your organization. Claim your
                 profile and have it validated at the highest level possible here before seeking the
                 other services — our{' '}
-                <a href="/guidestar-guide/" className="underline">
+                {/* next/link, not a raw <a>: the GitHub Pages staging deploy builds with
+                    NEXT_PUBLIC_BASE_PATH=/FFC-IN-freeforcharity.org, and only Link applies
+                    that prefix. A root-absolute href would 404 there. */}
+                <Link href="/guidestar-guide/" className="underline">
                   Candid guide
-                </a>{' '}
+                </Link>{' '}
                 walks you through it.
               </>
             }

--- a/src/components/free-for-charitys-tools-for-success-components/Two-Cards-With-Heading/index.tsx
+++ b/src/components/free-for-charitys-tools-for-success-components/Two-Cards-With-Heading/index.tsx
@@ -18,20 +18,24 @@ const index = () => {
 
           <SlidingCard
             direction="left"
-            subtitle="Guidestar (free with paid options)"
+            subtitle="Candid, formerly GuideStar (free with paid options)"
             description={
               <>
                 This charity provides profiles of nearly every charity in the world. It also
                 provides an API that lets others check on the nonprofit status of any charity by
                 name, EIN, or other metrics. Many of the charity for charity sites as well as
-                indirect sites that provide discounts to nonprofits require a completed profile on
-                Guide Star before giving free or discounted items to your organization. Create your
+                indirect sites that provide discounts to nonprofits require a completed Candid
+                profile before giving free or discounted items to your organization. Claim your
                 profile and have it validated at the highest level possible here before seeking the
-                other services.
+                other services — our{' '}
+                <a href="/guidestar-guide/" className="underline">
+                  Candid guide
+                </a>{' '}
+                walks you through it.
               </>
             }
             buttonText="Available Here"
-            buttonLink="https://www.guidestar.org/"
+            buttonLink="https://candid.org/claim-nonprofit-profile/"
             imageSrc="/Images/guidestar.webp" // 👈 image passed as prop
           />
           <SlidingCard

--- a/src/components/home-page/FrequentlyAskedQuestions/index.tsx
+++ b/src/components/home-page/FrequentlyAskedQuestions/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import SmartLink from '@/components/ui/SmartLink'
 import FrequentlyAskedQuestions from '@/components/ui/Frequently-Asked-Questions'
 import { domainDonationTaxFaq, hostingBacklogFaq } from '@/data/faqs'
 
@@ -268,9 +269,9 @@ const index = () => {
                   <br />
                   {index + 1}. {way.before}
                   {way.link && (
-                    <a href={way.link.href} className="text-[#1c6e92] underline">
+                    <SmartLink href={way.link.href} className="text-[#1c6e92] underline">
                       {way.link.label}
-                    </a>
+                    </SmartLink>
                   )}
                   {way.after}
                 </React.Fragment>

--- a/src/components/online-impacts-onboarding-guide-components/Ready-To-Get-Started-Now/index.tsx
+++ b/src/components/online-impacts-onboarding-guide-components/Ready-To-Get-Started-Now/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import Link from 'next/link'
 import TransparentBtn from '@/components/ui/Transparentbtn'
 import AccordionItem from '@/components/ui/Accordian'
 import { hubAddProduct, ONBOARDING_PID } from '@/lib/config'
@@ -79,9 +80,9 @@ const index = () => {
 
           <p className="text-[18px] font-[700] text-[#4a4a4a] mb-[1em]">
             Visit{' '}
-            <a href="/domains/" className="text-[#0567B1]">
+            <Link href="/domains/" className="text-[#0567B1]">
               https://freeforcharity.org/domains
-            </a>{' '}
+            </Link>{' '}
             and follow all steps
           </p>
           <p className="text-[18px] font-[500] text-[#4a4a4a] mb-[1em]">

--- a/src/components/ui/AdminGuideLink.tsx
+++ b/src/components/ui/AdminGuideLink.tsx
@@ -1,7 +1,13 @@
 import React from 'react'
+import SmartLink from '@/components/ui/SmartLink'
 
 interface AdminGuideLinkProps {
-  /** Absolute ffcadmin.org URL — build with `ffcAdminUrl()` from src/data/admin-links. */
+  /**
+   * Usually an absolute ffcadmin.org URL — build with `ffcAdminUrl()` from
+   * src/data/admin-links. A root-relative path is also accepted for the cases
+   * where the canonical guide lives on this site instead (e.g. the Google
+   * Workspace guide); those route through next/link and stay in the same tab.
+   */
   href: string
   /** Link text. Defaults depend on variant. */
   label?: string
@@ -28,6 +34,9 @@ const AdminGuideLink: React.FC<AdminGuideLinkProps> = ({
   const text =
     label ??
     (isLegacy ? 'Legacy WordPress guide on FFC Admin' : 'Full step-by-step guide on FFC Admin')
+  // A root-relative href is a guide on this site, so it neither opens a new tab
+  // nor goes to FFC Admin — announcing that it does would be wrong.
+  const isExternal = !href.startsWith('/') || href.startsWith('//')
 
   return (
     <div
@@ -38,10 +47,10 @@ const AdminGuideLink: React.FC<AdminGuideLinkProps> = ({
       {description ? (
         <p className="mb-[8px] text-[14px] leading-[22px] text-[#555]">{description}</p>
       ) : null}
-      <a
+      <SmartLink
         href={href}
-        target="_blank"
-        rel="noopener noreferrer"
+        target={isExternal ? '_blank' : undefined}
+        rel={isExternal ? 'noopener noreferrer' : undefined}
         className={`inline-flex items-center gap-[8px] text-[16px] font-[600] underline-offset-4 hover:underline ${
           // #9a3412 (deep brand orange) clears WCAG AA contrast on the pale
           // #fff7f0 callout (~7:1); the lighter #f47c20 is only 2.55:1 as text.
@@ -50,8 +59,8 @@ const AdminGuideLink: React.FC<AdminGuideLinkProps> = ({
       >
         <span>{text}</span>
         <span aria-hidden="true">&rarr;</span>
-        <span className="sr-only">(opens FFC Admin in a new tab)</span>
-      </a>
+        {isExternal ? <span className="sr-only">(opens FFC Admin in a new tab)</span> : null}
+      </SmartLink>
     </div>
   )
 }

--- a/src/components/ui/CallToActionCard.tsx
+++ b/src/components/ui/CallToActionCard.tsx
@@ -1,5 +1,6 @@
 'use client'
 import React, { useEffect, useRef, useState } from 'react'
+import SmartLink from '@/components/ui/SmartLink'
 
 interface IconTextCardProps {
   icon: React.ReactNode
@@ -34,7 +35,7 @@ const IconTextCard: React.FC<IconTextCardProps> = ({ icon, iconLabel = 'icon', t
   }, [])
 
   return (
-    <a
+    <SmartLink
       href={href || '#'}
       rel="noopener noreferrer"
       className="
@@ -70,7 +71,7 @@ const IconTextCard: React.FC<IconTextCardProps> = ({ icon, iconLabel = 'icon', t
       >
         {text}
       </h2>
-    </a>
+    </SmartLink>
   )
 }
 

--- a/src/components/ui/SmartLink.tsx
+++ b/src/components/ui/SmartLink.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import Link from 'next/link'
+
+type SmartLinkProps = React.ComponentPropsWithoutRef<'a'> & { href: string }
+
+/**
+ * Anchor that routes root-relative URLs through next/link.
+ *
+ * The GitHub Pages staging deploy builds with
+ * NEXT_PUBLIC_BASE_PATH=/FFC-IN-freeforcharity.org, and only next/link applies
+ * that prefix — a raw <a href="/foo/"> resolves against the domain root and
+ * 404s there while working fine in production. next/link also emits the
+ * trailing-slash form that `trailingSlash: true` canonicalizes to, avoiding a
+ * redirect hop.
+ *
+ * Everything else (absolute http(s) URLs, mailto:, tel:, bare #hash) falls
+ * through to a plain <a>, which is what those need. Same branch StepCard makes
+ * inline; this exists for the shared components that take an href prop and
+ * cannot know which kind they will be handed.
+ */
+const SmartLink: React.FC<SmartLinkProps> = ({ href, children, ...rest }) => {
+  const isInternal = href.startsWith('/') && !href.startsWith('//')
+
+  if (isInternal) {
+    return (
+      <Link href={href} {...rest}>
+        {children}
+      </Link>
+    )
+  }
+
+  return (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  )
+}
+
+export default SmartLink

--- a/src/components/ui/Transparentbtn.tsx
+++ b/src/components/ui/Transparentbtn.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import SmartLink from '@/components/ui/SmartLink'
 import { IoIosArrowForward } from 'react-icons/io'
 
 interface TransparentbtnProps {
@@ -10,7 +11,7 @@ interface TransparentbtnProps {
 const Transparentbtn: React.FC<TransparentbtnProps> = ({ text, href, color = '#0567B1' }) => {
   return (
     <div>
-      <a
+      <SmartLink
         href={href || '#'}
         target={href ? '_blank' : undefined}
         rel={href ? 'noopener noreferrer' : undefined}
@@ -31,7 +32,7 @@ const Transparentbtn: React.FC<TransparentbtnProps> = ({ text, href, color = '#0
           strokeWidth={2}
           style={{ color }}
         />
-      </a>
+      </SmartLink>
     </div>
   )
 }

--- a/src/components/volunteer/Free-For-Charity/index.tsx
+++ b/src/components/volunteer/Free-For-Charity/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import Link from 'next/link'
 import Transparentbtn from '@/components/ui/Transparentbtn'
 import { adminLinks, ffcAdminUrl } from '@/data/admin-links'
 
@@ -397,9 +398,9 @@ const Index = () => {
           </p>
           <p className="text-[18px] font-[500] leading-[27px] mb-[5.82%]" data-font="lato-font">
             In addition to financial support, Free For Charity also needs community support through{' '}
-            <a href="/volunteer/" className="text-[#0567B1]">
+            <Link href="/volunteer/" className="text-[#0567B1]">
               skilled volunteers
-            </a>{' '}
+            </Link>{' '}
             and gifts in kind (such as services or products sold by your business). Take a look at
             the volunteer opportunities today.
           </p>

--- a/tests/external-links.spec.ts
+++ b/tests/external-links.spec.ts
@@ -29,14 +29,21 @@ test.describe('External Link Targets', () => {
     }
   })
 
-  test('footer GuideStar link should have target="_blank"', async ({ page }) => {
+  test('footer Candid profile links should open in a new tab', async ({ page }) => {
     await page.goto('/')
 
+    // Both the seal and the "Direct Candid Profile Link" button point at
+    // app.candid.org — guidestar.org now only survives as the widget host on
+    // the seal's <img src>, which is not a link.
     const footer = page.locator('footer')
-    const guidestarLink = footer.locator('a[href*="guidestar.org"]').first()
-    await expect(guidestarLink).toBeVisible()
-    // GuideStar seal link uses <a> not <Link>, may or may not have target
-    // The profile link uses Next.js Link component
+    const candidLinks = footer.locator('a[href*="app.candid.org"]')
+    await expect(candidLinks).not.toHaveCount(0)
+
+    for (const link of await candidLinks.all()) {
+      await expect(link).toHaveAttribute('target', '_blank')
+      await expect(link).toHaveAttribute('rel', /noopener/)
+      await expect(link).toHaveAttribute('rel', /noreferrer/)
+    }
   })
 
   test('footer Supported Charity Login link should have target="_blank"', async ({ page }) => {

--- a/tests/footer-complete.spec.ts
+++ b/tests/footer-complete.spec.ts
@@ -30,9 +30,9 @@ test.describe('Footer - Column 1: Endorsements', () => {
     await expect(sealImg).toBeVisible()
   })
 
-  test('should display Direct GuideStar Profile Link button', async ({ page }) => {
+  test('should display Direct Candid Profile Link button', async ({ page }) => {
     const footer = page.locator('footer')
-    await expect(footer.getByText('Direct GuideStar Profile Link')).toBeVisible()
+    await expect(footer.getByText('Direct Candid Profile Link')).toBeVisible()
   })
 
   test('should display EIN number', async ({ page }) => {


### PR DESCRIPTION
Two related passes. The first was the ask; the second came out of review on the first.

## 1. Remaining GuideStar → Candid links

Follow-up to #517, which only touched `/guidestar-guide/`. Five other places still sent visitors to guidestar.org.

| Where | Was | Now |
| --- | --- | --- |
| `/matching-gifts/` | `guidestar.org/profile/46-2471893` | `app.candid.org/profile/9326392/free-for-charity-46-2471893` |
| `/other-ways-to-give/` | same | same |
| Web-hosting FAQ | same | same, and "guidestar profile" → "Candid (GuideStar) profile" |
| Tools for Success card | `guidestar.org/` home page | `candid.org/claim-nonprofit-profile/`, plus a link to our own guide |
| Footer button | the retired `/profile/shared/<uuid>` format | the current sharable link, relabelled "Direct Candid Profile Link" |

The Tools for Success button was the weakest: its copy says "create your profile and have it validated at the highest level possible here," but the button dropped you on the guidestar.org home page.

**Left alone deliberately:** the `widgets.guidestar.org` seal embeds (still Candid's own widget host — the embed code Candid generates in 2026 uses it), and the `guidestar.org` entry in `structured-data.ts` `sameAs` (a live, self-canonical URL for the same entity, with the Candid URL already leading). Happy to drop the latter if you'd rather the schema name only the current brand.

### About the "bot-blocked" URL

An earlier report that `guidestar.org/profile/46-2471893` was unverifiable was incomplete. It resolves fine:

```
/profile/46-2471893    -> 403, cf-mitigated: challenge, "Just a moment..."
/profile/46-2471893/   -> 200, "Free For Charity - GuideStar Profile"   <- trailing slash
/profile/0000000000    -> 302 /Error/HttpError404
```

Their Cloudflare rule keys on the exact path. The unknown-id case is the tell: it reaches the origin and gets a real 404, so a 403 on a real id means the route is live, not retired. The page is a full profile, self-canonical to guidestar.org, linking out to the Candid profile — a maintained mirror. **Nothing was broken for visitors**; the links just named the old brand. `.lycheeignore` now records this so nobody re-derives it from a 403.

## 2. Internal links that skipped basePath

Review flagged that a root-absolute anchor to `/guidestar-guide/` I added would 404 on staging, which builds with `NEXT_PUBLIC_BASE_PATH=/FFC-IN-freeforcharity.org`. That was true, and the problem was site-wide rather than mine alone. An audit of the staging export found **9 unprefixed internal links; there are now 0**, with 2,372 correctly prefixed.

Two kinds of offender:

1. **23 literal root-absolute anchors across 16 files** — terms-of-service (7), the three directory pages, consulting, cookie-policy, privacy-policy, free-training-programs, help-for-charities, workforce-development, 501c3, domains, donate, volunteer, online-impacts. Converted to `next/link`.

2. **Shared components taking an `href` prop**, which is why a source grep missed them: `CallToActionCard`, `Transparentbtn`, `AdminGuideLink`, and the two FAQ renderers reading `way.link.href` from `faqs.ts`. The literal path lives at the call site, so grepping the markup never finds them — auditing the built HTML did.

For (2) the href may be internal or external (`ffcAdminUrl`, hub, Zeffy, `mailto:`, bare `#hash`), so they now go through a new `SmartLink` that branches — the same branch `StepCard` already makes inline, extracted because a component taking an href can't know which kind it will be handed.

Behaviour is otherwise preserved, including `Transparentbtn` opening *internal* links in a new tab. That's pre-existing and arguably wrong, but changing it is a visible UX decision, so I left it.

`AdminGuideLink` also announced "(opens FFC Admin in a new tab)" to screen readers on every link, including the one internal usage that does neither. Now conditional.

## Tests changed

- `footer-complete.spec.ts` asserted the old "Direct GuideStar Profile Link" label.
- `external-links.spec.ts` selected the footer anchor whose href contained `guidestar.org`, which no longer exists — guidestar.org survives there only in the seal image's `src`, which is not a link. Retargeted at `app.candid.org`, and made to actually assert `target`/`rel`, which it never did.
- `measurable-impact.test.tsx` asserted `href === "/volunteer/"` exactly. Jest doesn't load `next.config.ts`, so `trailingSlash` isn't in effect and `next/link` renders `/volunteer`; the real export still emits `/volunteer/`. Now asserts the route, not the build-time normalization.

## Testing

- `npm run lint` — clean
- `npm test` — 689 passing
- **Built both ways**: staging prefixes every internal href (0 unprefixed); production leaks no prefix and keeps every trailing slash (0 problems across 2,372 hrefs)
- Rendered `/`, `/about-us/`, `/terms-of-service/`, `/domains/`, `/donate/`, `/free-charity-web-hosting/`, `/free-for-charitys-tools-for-success/`, `/volunteer/` in headless Chromium — 8/8 clean

Refs #517