### PR TITLE
fix(security): clear both high advisories in one lockfile bump (#524)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2347,9 +2347,9 @@
       }
     },
     "node_modules/@jest/core/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2668,9 +2668,9 @@
       }
     },
     "node_modules/@jest/reporters/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5609,9 +5609,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6876,9 +6876,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9180,9 +9180,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -9707,9 +9707,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -11351,9 +11351,9 @@
       }
     },
     "node_modules/jest-cli/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12061,9 +12061,9 @@
       }
     },
     "node_modules/jest-runtime/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Closes #524. Supersedes #522 and #523 (both should close when this lands).

## The deadlock

`Security Audit` on `main` has failed **8 consecutive runs** since 2026-08-04 (last: [`31156001009`](https://github.com/FreeForCharity/FFC-IN-freeforcharity.org/actions/runs/31156001009), 2026-08-07T07:00Z). Failing step is **5. Audit high-severity production deps** — `npm audit --omit=dev --audit-level=high`.

| advisory | package | severity |
| --- | --- | --- |
| GHSA-rgw5-rvv9-x895 | `brace-expansion` 4.0.0 – 5.0.8 — DoS, bypasses the CVE-2026-14257 mitigation | **high** |
| GHSA-7p8r-x3mc-p8w7 | `fast-uri` 3.0.0 – 3.1.4 — host confusion via backslash authority introducer | **high** |

Dependabot opened one PR per advisory. **Neither can ever go green alone**, because `npm audit` evaluates the whole dependency tree rather than the PR's own change:

| PR | bumps | its own audit still reports |
| --- | --- | --- |
| #522 | `brace-expansion` | `fast-uri 3.0.0 - 3.1.4` — high |
| #523 | `fast-uri` | `brace-expansion 4.0.0 - 5.0.8` — high |

Both sit `UNSTABLE`. The correct-sounding reviewer heuristic — *don't merge a PR with a failing required check* — keeps both out permanently. This is a deadlock, not neglect, and it does not resolve itself.

## Why this PR rather than `npm audit fix`

`npm audit fix --omit=dev` clears the advisories, but it does **not** stop there — it also upgrades:

```
next     16.2.11 -> 16.3.0     (framework minor)
postcss   8.5.20 -> 8.5.26
nanoid     3.3.16 -> 3.3.17
```

A Next.js minor upgrade on the org's **main public website** is not a security patch, and folding one into a security PR is how it ships unreviewed. Rejected as the mechanism.

This PR is `npm update brace-expansion fast-uri --package-lock-only` — **exactly the union of #522 and #523**, nothing else:

```
brace-expansion  1.1.16 -> 1.1.18   (x1)
brace-expansion   2.1.2 -> 2.1.4    (x4)
brace-expansion   5.0.8 -> 5.0.9    (x2)   <- the gating instance (node_modules/glob/…)
fast-uri          3.1.4 -> 3.1.5    (x1)
```

`package-lock.json` only. 24 insertions, 24 deletions. No `package.json` change, no framework change.

## Verification (run locally, not inferred)

| check | result |
| --- | --- |
| `npm run audit:high` — the exact gating command | **exit 0**, 2 moderate remain (below the `high` gate) |
| `npm ci` | exit 0, lockfile consistent |
| `npm run build` | exit 0, all routes prerendered |
| `npm test` | **52 suites / 689 tests passed** |
| `prettier --check package-lock.json` | clean |
| CR count (`tr -cd '\r' \| wc -c`) | 0 |

Baseline was reproduced first: the same two highs, same wording as CI, from the lockfile alone.

## Note — the two remaining moderates are out of scope

`postcss <=8.5.22` (via `next`) stays. It is **moderate**, the gate is `--audit-level=high`, and clearing it requires the Next.js minor this PR deliberately avoids. It should be its own reviewed upgrade PR, not a rider here.

Dev-tree highs (`js-yaml`, `undici`) are likewise untouched — `--omit=dev` does not gate them, and #521 already covers `undici`.

---
_Opened by the FFC Agentic OS Conductor (run 113). Left as a draft for @clarkemoyer: this is the org's main public website._
